### PR TITLE
Refactor server build dependencies and linker configuration

### DIFF
--- a/server/core/meson.build
+++ b/server/core/meson.build
@@ -8,12 +8,12 @@ yuzu_server_core_lib = static_library(
 yuzu_server_core_dep = declare_dependency(
   link_with: yuzu_server_core_lib,
   include_directories: include_directories('include'),
+  dependencies: [yuzu_sdk_dep, yuzu_proto_dep, grpc_dep, spdlog_dep],
 )
 
 executable(
   'yuzu-server',
   files('src/main.cpp'),
-  dependencies: [yuzu_server_core_dep, yuzu_sdk_dep, cli11_dep],
-  link_args: ['/FORCE:MULTIPLE'],
+  dependencies: [yuzu_server_core_dep, cli11_dep],
   install: true,
 )


### PR DESCRIPTION
## Summary
This change reorganizes the dependency declarations in the server build configuration to improve modularity and remove unnecessary linker flags.

## Key Changes
- Moved SDK, protobuf, gRPC, and spdlog dependencies from the executable target to the `yuzu_server_core_dep` dependency declaration, making them available to all consumers of the core library
- Removed `yuzu_sdk_dep` from the executable's direct dependencies since it's now transitively provided through `yuzu_server_core_dep`
- Removed the `/FORCE:MULTIPLE` linker flag from the executable build configuration

## Implementation Details
By declaring dependencies at the library level rather than the executable level, the build system now properly exposes transitive dependencies. This ensures that any code linking against `yuzu_server_core_lib` automatically gets access to the required SDK, protobuf, gRPC, and logging dependencies without needing to explicitly list them again. The removal of the `/FORCE:MULTIPLE` linker flag suggests that the underlying linking issues it was working around have been resolved through proper dependency management.

https://claude.ai/code/session_01RNcRAryGxiH8TCfG7CuHgd