### PR TITLE
Fix abseil version constraint and remove redundant builtin-baseline

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -13,7 +13,7 @@
     "protobuf",
     {
       "name": "abseil",
-      "version>=": "20240116"
+      "version>=": "20240116.1"
     },
     "spdlog",
     "nlohmann-json",
@@ -31,6 +31,5 @@
       "platform": "!(arm & !x64)"
     }
   ],
-  "builtin-baseline": "c1f21baeaf7127c13ee141fe1bdaa49eed371c0c",
   "overrides": []
 }


### PR DESCRIPTION
vcpkg uses a date.patch versioning scheme for abseil; the version string "20240116" does not exist in the database (entries are "20240116.1", "20240116.2", etc.), which caused vcpkg install to fail with "no version database entry for abseil at 20240116".

Also remove builtin-baseline from vcpkg.json: vcpkg-configuration.json already provides the default-registry baseline, so the field was redundant and produced a warning on every install.

https://claude.ai/code/session_01RNcRAryGxiH8TCfG7CuHgd