### PR TITLE
Fix MSVC build: use plain extern for HTML string across TUs

### DIFF
--- a/server/core/src/chargen_ui.cpp
+++ b/server/core/src/chargen_ui.cpp
@@ -1,11 +1,8 @@
-// Chargen web UI HTML — compiled in its own translation unit to work around
-// an MSVC bug where long raw string literals containing braces confuse the
-// preprocessor's brace-matching in surrounding code.
-
-namespace yuzu::server::detail {
+// Chargen web UI HTML — compiled in its own translation unit to isolate
+// the long raw string literal from MSVC's brace-matching in server.cpp.
 
 // NOLINTBEGIN(cert-err58-cpp)
-const char* const kIndexHtml = R"HTM(<!DOCTYPE html>
+const char* const kChargenIndexHtml = R"HTM(<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -167,5 +164,3 @@ const char* const kIndexHtml = R"HTM(<!DOCTYPE html>
 </html>
 )HTM";
 // NOLINTEND(cert-err58-cpp)
-
-}  // namespace yuzu::server::detail

--- a/server/core/src/chargen_ui.hpp
+++ b/server/core/src/chargen_ui.hpp
@@ -1,9 +1,0 @@
-// Chargen web UI HTML string.
-// The definition lives in chargen_ui.cpp — a separate TU to work around
-// an MSVC bug where long raw string literals with braces confuse brace
-// matching in the surrounding translation unit.
-#pragma once
-
-namespace yuzu::server::detail {
-extern const char* const kIndexHtml;
-}  // namespace yuzu::server::detail

--- a/server/core/src/server.cpp
+++ b/server/core/src/server.cpp
@@ -22,6 +22,9 @@
 #include <unordered_map>
 #include <vector>
 
+// Defined in chargen_ui.cpp (separate TU to isolate MSVC raw-string issues).
+extern const char* const kChargenIndexHtml;
+
 namespace yuzu::server {
 
 namespace {
@@ -117,11 +120,6 @@ public:
 };
 
 }  // anonymous namespace
-
-// Extern HTML declaration — definition lives in chargen_ui.cpp (separate TU
-// to work around MSVC raw-string brace-matching bug).
-#include "chargen_ui.hpp"
-using detail::kIndexHtml;
 
 // ── ServerImpl ───────────────────────────────────────────────────────────────
 
@@ -251,7 +249,7 @@ private:
 
         // Serve the HTMX page
         web_server_->Get("/", [](const httplib::Request&, httplib::Response& res) {
-            res.set_content(kIndexHtml, "text/html; charset=utf-8");
+            res.set_content(kChargenIndexHtml, "text/html; charset=utf-8");
         });
 
         // SSE endpoint — clients connect here for live chargen output


### PR DESCRIPTION
The previous approach using a namespaced header + using-declaration caused C2653 on MSVC ("detail is not a class or namespace name"), which cascaded into C3240/C1075 brace-mismatch errors.

Simplify: declare `extern const char* const kChargenIndexHtml` at file scope in server.cpp (before any namespace), define it at global scope in chargen_ui.cpp. No header needed, no namespace resolution issues, and the raw string stays fully isolated from server.cpp.

https://claude.ai/code/session_01PG8JYrUDVhPDm7sK2XiHru