### PR TITLE
Move ServerImpl out of anonymous namespace for MSVC compatibility

### DIFF
--- a/server/core/src/server.cpp
+++ b/server/core/src/server.cpp
@@ -173,6 +173,8 @@ public:
     // Placeholder. SendCommand RPC would forward to the agent's ExecuteCommand stream.
 };
 
+}  // anonymous namespace
+
 // -- ServerImpl ---------------------------------------------------------------
 
 class ServerImpl final : public Server {
@@ -453,8 +455,6 @@ void ServerImpl::stop_chargen() {
     }
     spdlog::info("Chargen stopped");
 }
-
-}  // anonymous namespace
 
 // -- Factory ------------------------------------------------------------------
 


### PR DESCRIPTION
MSVC does not support out-of-line member definitions (ClassName::method) for classes defined in anonymous namespaces -- it produces C4596 "illegal qualified name in member declaration".

Move ServerImpl and its method definitions outside the anonymous namespace while keeping helper types/functions (EventBus, ChargenState, SseSinkState, sse_content_provider, etc.) inside it.

https://claude.ai/code/session_01PG8JYrUDVhPDm7sK2XiHru