### PR TITLE
Fix MSVC C4596 by using named `detail` namespace for server helpers

### DIFF
--- a/server/core/src/server.cpp
+++ b/server/core/src/server.cpp
@@ -27,7 +27,7 @@ extern const char* const kChargenIndexHtml;
 
 namespace yuzu::server {
 
-namespace {
+namespace detail {
 
 // -- Platform-specific log path -----------------------------------------------
 
@@ -173,7 +173,7 @@ public:
     // Placeholder. SendCommand RPC would forward to the agent's ExecuteCommand stream.
 };
 
-}  // anonymous namespace
+}  // namespace detail
 
 // -- ServerImpl ---------------------------------------------------------------
 
@@ -181,7 +181,7 @@ class ServerImpl final : public Server {
 public:
     explicit ServerImpl(Config cfg)
         : cfg_(std::move(cfg)),
-          chargen_state_(std::make_shared<ChargenState>())
+          chargen_state_(std::make_shared<detail::ChargenState>())
     {
         setup_chargen_logger();
     }
@@ -201,9 +201,9 @@ private:
     void stop_chargen();
 
     Config                            cfg_;
-    std::shared_ptr<ChargenState>     chargen_state_;
-    AgentServiceImpl                  agent_service_{chargen_state_};
-    ManagementServiceImpl             mgmt_service_;
+    std::shared_ptr<detail::ChargenState> chargen_state_;
+    detail::AgentServiceImpl             agent_service_{chargen_state_};
+    detail::ManagementServiceImpl        mgmt_service_;
     std::unique_ptr<grpc::Server>     agent_server_;
     std::unique_ptr<grpc::Server>     mgmt_server_;
     std::unique_ptr<httplib::Server>  web_server_;
@@ -299,7 +299,7 @@ ServerImpl::build_server_credentials() const {
 }
 
 void ServerImpl::setup_chargen_logger() {
-    auto log_path = chargen_log_path();
+    auto log_path = detail::chargen_log_path();
     auto parent = log_path.parent_path();
     if (!parent.empty()) {
         std::error_code ec;
@@ -346,7 +346,7 @@ void ServerImpl::setup_sse_endpoint() {
         res.set_header("Cache-Control", "no-cache");
         res.set_header("X-Accel-Buffering", "no");
 
-        auto sink_state = std::make_shared<SseSinkState>();
+        auto sink_state = std::make_shared<detail::SseSinkState>();
 
         sink_state->sub_id = cs->event_bus.subscribe(
             [sink_state](const std::string& line) {
@@ -357,15 +357,15 @@ void ServerImpl::setup_sse_endpoint() {
                 sink_state->cv.notify_one();
             });
 
-        EventBus* bus = &cs->event_bus;
+        detail::EventBus* bus = &cs->event_bus;
 
         res.set_content_provider(
             "text/event-stream",
             [sink_state](size_t offset, httplib::DataSink& sink) -> bool {
-                return sse_content_provider(sink_state, offset, sink);
+                return detail::sse_content_provider(sink_state, offset, sink);
             },
             [sink_state, bus](bool success) {
-                sse_resource_release(sink_state, *bus, success);
+                detail::sse_resource_release(sink_state, *bus, success);
             }
         );
     });


### PR DESCRIPTION
### Motivation
- MSVC rejects out-of-line member definitions for classes declared inside anonymous namespaces, producing C4596 errors when `ServerImpl` referenced helper types/functions in the TU.
- The change keeps helper types/functions internal to the translation unit while making their names usable in qualified member declarations and definitions.

### Description
- Replace the anonymous namespace in `server/core/src/server.cpp` with a named `detail` namespace and keep internal helpers (e.g. `ChargenState`, `EventBus`, `SseSinkState`, `sse_content_provider`, `sse_resource_release`, `AgentServiceImpl`, `ManagementServiceImpl`) inside it.
- Update `ServerImpl` to refer to the helpers with `detail::` qualification for member types, initializers, and helper calls (e.g. `detail::chargen_log_path()`, `detail::SseSinkState`, `detail::sse_content_provider`).
- The change is localized to `server/core/src/server.cpp` and preserves the original internal/translation-unit-only intent while avoiding MSVC parsing limitations.

### Testing
- Attempted a local CMake configure+build using `cmake --preset linux-debug && cmake --build --preset linux-debug`, which failed in this environment due to missing vcpkg toolchain and missing Ninja/compiler (environment limitation); build did not complete.
- Ran automated text/code checks to verify the edits: a brace-balance script confirmed no unmatched braces and `rg`/`nl` searches verified all helper references were updated to `detail::...`, and these checks succeeded.
- Git operations (`git add`/`git commit`) completed successfully to record the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8ac451118832c8f5fedb94f3b78c7)