### PR TITLE
Fix protobuf debug/release CRT mismatch on Windows

### DIFF
--- a/agents/core/CMakeLists.txt
+++ b/agents/core/CMakeLists.txt
@@ -16,7 +16,6 @@ target_link_libraries(yuzu_agent_core
   PUBLIC
     yuzu::sdk
     yuzu_proto
-    gRPC::grpc++
     spdlog::spdlog
 )
 

--- a/agents/core/meson.build
+++ b/agents/core/meson.build
@@ -5,7 +5,7 @@ yuzu_agent_core_lib = shared_library(
     include_directories('include'),
     include_directories('../../sdk/include'),
   ],
-  dependencies: [yuzu_sdk_dep, yuzu_proto_dep, grpcpp_dep, spdlog_dep],
+  dependencies: [yuzu_sdk_dep, yuzu_proto_dep, spdlog_dep],
   cpp_args: ['-DYUZU_AGENT_CORE_BUILDING'],
   install: true,
 )
@@ -25,6 +25,6 @@ executable(
     include_directories('include'),
     include_directories('../../sdk/include'),
   ],
-  dependencies: [yuzu_agent_core_dep, yuzu_proto_dep, grpcpp_dep, spdlog_dep, cli11_dep],
+  dependencies: [yuzu_agent_core_dep, yuzu_proto_dep, spdlog_dep, cli11_dep],
   install: true,
 )

--- a/cmake/modules/YuzuProto.cmake
+++ b/cmake/modules/YuzuProto.cmake
@@ -71,5 +71,5 @@ function(yuzu_proto_library)
 
   add_library(${ARG_NAME} STATIC ${GENERATED_SRCS} ${GENERATED_HDRS})
   target_include_directories(${ARG_NAME} PUBLIC "${PROTO_OUT}")
-  target_link_libraries(${ARG_NAME} PUBLIC gRPC::grpc++ protobuf::libprotobuf)
+  target_link_libraries(${ARG_NAME} PUBLIC gRPC::grpc++)
 endfunction()

--- a/meson.build
+++ b/meson.build
@@ -29,7 +29,6 @@ build_tests    = get_option('build_tests')
 
 # ── Dependencies ──────────────────────────────────────────────────────────────
 grpcpp_dep = dependency('gRPC', method: 'cmake', modules: ['gRPC::grpc++'], required: true)
-protobuf_dep = dependency('Protobuf', method: 'cmake', modules: ['protobuf::libprotobuf'], required: true)
 add_project_arguments('-DSPDLOG_COMPILED_LIB', language: 'cpp')
 spdlog_dep      = dependency('spdlog',        required: true)
 nlohmann_dep    = dependency('nlohmann_json', required: true)

--- a/proto/meson.build
+++ b/proto/meson.build
@@ -1,6 +1,3 @@
-grpc_dep = dependency('gRPC', method: 'cmake', modules: ['gRPC::grpc++'])
-protobuf_dep = dependency('Protobuf', method: 'cmake', modules: ['protobuf::libprotobuf'])
-
 protoc = find_program('protoc', required: true)
 grpc_cpp_plugin = find_program('grpc_cpp_plugin', required: true)
 
@@ -39,12 +36,12 @@ yuzu_proto_lib = static_library(
     gen_srcs,
     cpp_args: ['/wd4100','/wd4267','/wd4244','/wd4458','/wd4018','/wd4996'],
     include_directories: include_directories('.'),
-    dependencies: [grpc_dep, protobuf_dep],
+    dependencies: [grpcpp_dep],
 )
 
 yuzu_proto_dep = declare_dependency(
     link_with: yuzu_proto_lib,
     sources: gen_hdrs,
     include_directories: include_directories('.'),
-    dependencies: [grpc_dep, protobuf_dep],
+    dependencies: [grpcpp_dep],
 )

--- a/server/core/CMakeLists.txt
+++ b/server/core/CMakeLists.txt
@@ -12,7 +12,6 @@ target_link_libraries(yuzu_server_core
   PUBLIC
     yuzu::sdk
     yuzu_proto
-    gRPC::grpc++
     spdlog::spdlog
     httplib::httplib
 )

--- a/server/core/meson.build
+++ b/server/core/meson.build
@@ -2,13 +2,13 @@ yuzu_server_core_lib = static_library(
   'yuzu_server_core',
   files('src/server.cpp', 'src/chargen_ui.cpp'),
   include_directories: ['include'],
-  dependencies: [yuzu_sdk_dep, yuzu_proto_dep, grpcpp_dep, spdlog_dep, httplib_dep],
+  dependencies: [yuzu_sdk_dep, yuzu_proto_dep, spdlog_dep, httplib_dep],
 )
 
 yuzu_server_core_dep = declare_dependency(
   link_with: yuzu_server_core_lib,
   include_directories: include_directories('include'),
-  dependencies: [yuzu_sdk_dep, yuzu_proto_dep, grpcpp_dep, spdlog_dep, httplib_dep],
+  dependencies: [yuzu_sdk_dep, yuzu_proto_dep, spdlog_dep, httplib_dep],
 )
 
 executable(


### PR DESCRIPTION
Remove explicit protobuf::libprotobuf dependency from yuzu_proto — gRPC::grpc++ already provides it transitively. The duplicate resolution caused Meson's CMake tracer to put both libprotobufd.lib (debug) and libprotobuf.lib (release) on the same link line with vcpkg's x64-windows triplet, resulting in a CRT mismatch crash (0xc0000005) during grpc::ServerBuilder::BuildAndStart().

Also remove redundant gRPC dependencies from consumer targets (agents/core, server/core) since yuzu_proto_dep already propagates gRPC transitively.

https://claude.ai/code/session_01XAbe7NZcH2PsikttEu7EFy