### PR TITLE
Fix run() calling BuildAndStart three times on the same builder

### DIFF
--- a/server/core/src/server.cpp
+++ b/server/core/src/server.cpp
@@ -216,10 +216,9 @@ public:
         }
     }
 
-   void run() override {
+    void run() override {
         spdlog::info("run(): entering");
         grpc::EnableDefaultHealthCheckService(true);
-        spdlog::info("run(): health check enabled");
 
         auto agent_creds = grpc::InsecureServerCredentials();
         if (cfg_.tls_enabled) {
@@ -229,34 +228,12 @@ public:
                 spdlog::warn("TLS enabled but cert/key not provided -- falling back to insecure");
             }
         }
-        spdlog::info("run(): credentials ready");
 
         grpc::ServerBuilder agent_builder;
         agent_builder.AddListeningPort(cfg_.listen_address, agent_creds);
-        spdlog::info("run(): agent port added");
 
         grpc::ServerBuilder mgmt_builder;
         mgmt_builder.AddListeningPort(cfg_.management_address, grpc::InsecureServerCredentials());
-        spdlog::info("run(): management port added");
-
-        agent_server_ = agent_builder.BuildAndStart();
-        spdlog::info("run(): agent server built: {}", agent_server_ ? "OK" : "FAILED");
-
-        try {
-            agent_server_ = agent_builder.BuildAndStart();
-            spdlog::info("run(): agent server built: {}", agent_server_ ? "OK" : "FAILED");
-        } catch (const std::exception& ex) {
-            spdlog::error("run(): agent server threw: {}", ex.what());
-            return;
-        } catch (...) {
-            spdlog::error("run(): agent server threw unknown exception");
-            return;
-        }
-
-        mgmt_builder.AddListeningPort(
-            cfg_.management_address,
-            grpc::InsecureServerCredentials()
-        );
 
         agent_server_ = agent_builder.BuildAndStart();
         mgmt_server_  = mgmt_builder.BuildAndStart();


### PR DESCRIPTION
ServerBuilder cannot be reused after BuildAndStart(). The method was calling agent_builder.BuildAndStart() three times (lines 242, 246, 261) and adding the management listening port twice (lines 239, 256-259). This caused crashes or silent failures that prevented the server from ever reaching start_web_server().

Simplify to: configure each builder once, build once, check for null, log, start the web UI, and wait.

https://claude.ai/code/session_01XAbe7NZcH2PsikttEu7EFy