### PR TITLE
Fix cpp_std=c++latest to c++23 in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project(
   license: 'Apache-2.0',
   meson_version: '>=1.3.0',
   default_options: [
-    'cpp_std=c++latest',
+    'cpp_std=c++23',
     'warning_level=3',
     'werror=false',
     'default_library=shared',


### PR DESCRIPTION
c++latest is an MSVC-specific flag, not a valid Meson cpp_std value. Meson requires a concrete standard identifier. Use c++23 to match the CMake build (CMAKE_CXX_STANDARD 23).

https://claude.ai/code/session_01XAbe7NZcH2PsikttEu7EFy