### PR TITLE
Revert cpp_std to c++latest; fix gRPC server startup with single builder

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project(
   license: 'Apache-2.0',
   meson_version: '>=1.3.0',
   default_options: [
-    'cpp_std=c++23',
+    'cpp_std=c++latest',
     'warning_level=3',
     'werror=false',
     'default_library=shared',

--- a/server/core/src/server.cpp
+++ b/server/core/src/server.cpp
@@ -229,17 +229,14 @@ public:
             }
         }
 
-        grpc::ServerBuilder agent_builder;
-        agent_builder.AddListeningPort(cfg_.listen_address, agent_creds);
+        grpc::ServerBuilder builder;
+        builder.AddListeningPort(cfg_.listen_address, agent_creds);
+        builder.AddListeningPort(cfg_.management_address, grpc::InsecureServerCredentials());
 
-        grpc::ServerBuilder mgmt_builder;
-        mgmt_builder.AddListeningPort(cfg_.management_address, grpc::InsecureServerCredentials());
+        agent_server_ = builder.BuildAndStart();
 
-        agent_server_ = agent_builder.BuildAndStart();
-        mgmt_server_  = mgmt_builder.BuildAndStart();
-
-        if (!agent_server_ || !mgmt_server_) {
-            spdlog::error("Failed to start gRPC server(s) -- check that ports {} and {} are available",
+        if (!agent_server_) {
+            spdlog::error("Failed to start gRPC server -- check that ports {} and {} are available",
                 cfg_.listen_address, cfg_.management_address);
             return;
         }


### PR DESCRIPTION
- Revert cpp_std=c++23 back to c++latest — the original value is valid for both MSVC and GCC/Clang in Meson. MSVC doesn't list c++23 in its allowed values.

- Fix "completion queues must be frequently polled" error by collapsing two ServerBuilders into one. The service classes are placeholders that can't be registered yet, so a single builder with both listening ports uses the default health check service to satisfy gRPC's requirement.

https://claude.ai/code/session_01XAbe7NZcH2PsikttEu7EFy