### PR TITLE
Remove 1e reference and replace Tachyon mention in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yuzu
 
-A multi-platform agent and server framework for real-time endpoint management. Yuzu is the successor to 1e Tachyon, built from the ground up in C++23 with a focus on extensibility, performance, and cross-platform portability.
+A multi-platform agent and server framework for real-time endpoint management. Yuzu is the successor to a popular automation and orchestration suite, built from the ground up in C++23 with a focus on extensibility, performance, and cross-platform portability.
 
 ## Architecture
 


### PR DESCRIPTION
### Motivation
- Remove the explicit `1e` vendor reference and replace the product name `Tachyon` with a neutral phrase to avoid naming a specific third-party product.

### Description
- Updated the `README.md` introduction line to replace "successor to 1e Tachyon" with "successor to a popular automation and orchestration suite".

### Testing
- Ran a repository search with `rg -n "1e|Tachyon"` and confirmed there are no remaining matches in `README.md` after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac4240cb28832ca418d3b4cc603cd3)