### PR TITLE
Fix Qodana config by adding bootstrap script for compile_commands.json

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -8,3 +8,24 @@ profile:
   name: qodana.recommended
 include:
   - name: CheckDependencyLicenses
+bootstrap: |
+  # Install system dependencies needed by vcpkg ports
+  sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+    build-essential pkg-config autoconf autoconf-archive libtool \
+    cmake ninja-build curl zip unzip tar git \
+    linux-libc-dev
+  # Bootstrap vcpkg
+  if [ -z "$VCPKG_ROOT" ]; then
+    export VCPKG_ROOT="$HOME/vcpkg"
+    git clone https://github.com/microsoft/vcpkg.git "$VCPKG_ROOT"
+    "$VCPKG_ROOT/bootstrap-vcpkg.sh" -disableMetrics
+  fi
+  # Configure with compile_commands.json
+  cmake -B build -G Ninja \
+    -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
+    -DVCPKG_TARGET_TRIPLET=x64-linux \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+    -DYUZU_BUILD_TESTS=OFF
+  # Symlink compile_commands.json to project root for Qodana auto-detection
+  ln -sf build/compile_commands.json compile_commands.json


### PR DESCRIPTION
The qodana-clang linter requires a compilation database to analyse C++ code,
but the config had no build setup. Add a bootstrap script that installs system
dependencies, sets up vcpkg, and runs CMake with -DCMAKE_EXPORT_COMPILE_COMMANDS=ON.

https://claude.ai/code/session_01H4DMc746KALLsxJU9whwoS