### PR TITLE
Fix Qodana setup by aligning linter image with action CLI

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
       checks: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
           fetch-depth: 0  # a full history is required for pull request analysis
@@ -23,6 +23,7 @@ jobs:
         uses: JetBrains/qodana-action@v2025.2
         with:
           pr-mode: false
+          use-nightly: false
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN_1234984992 }}
           QODANA_ENDPOINT: 'https://qodana.cloud'

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -3,7 +3,7 @@
 ####################################################################################################################
 
 version: "1.0"
-linter: jetbrains/qodana-clang:2025.3
+linter: jetbrains/qodana-clang:2025.2
 profile:
   name: qodana.recommended
 include:


### PR DESCRIPTION
### Motivation
- Fix the Qodana startup failure in CI caused by a mismatch between the Qodana action/CLI (`2025.2`) and the linter image (`jetbrains/qodana-clang:2025.3`) which prevented the image from being pulled and the scan from starting.

### Description
- Update `qodana.yaml` to use `linter: jetbrains/qodana-clang:2025.2`, change `actions/checkout@v3` to `actions/checkout@v4` in `.github/workflows/qodana_code_quality.yml`, and add `use-nightly: false` to the Qodana action step for deterministic/stable behavior.

### Testing
- An initial attempt to parse YAML with `python` failed due to a missing `yaml` module, then both files were successfully parsed with `ruby` (`require 'yaml'`), the changes were inspected via `git diff`, and the commit (`git commit`) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b51c8d6048832caf9dd06bc6a070e1)