### PR TITLE
Add host vulnerability scanning plugin with CVE matching and config c…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ if(YUZU_BUILD_AGENT)
     add_subdirectory(agents/plugins/firewall)
     add_subdirectory(agents/plugins/antivirus)
     add_subdirectory(agents/plugins/bitlocker)
+    add_subdirectory(agents/plugins/vuln_scan)
   endif()
 endif()
 

--- a/agents/plugins/vuln_scan/CMakeLists.txt
+++ b/agents/plugins/vuln_scan/CMakeLists.txt
@@ -1,0 +1,17 @@
+include(${CMAKE_SOURCE_DIR}/cmake/modules/CompilerFlags.cmake)
+
+add_library(plugin_vuln_scan SHARED
+  src/vuln_scan_plugin.cpp
+)
+add_library(yuzu::plugin_vuln_scan ALIAS plugin_vuln_scan)
+
+target_link_libraries(plugin_vuln_scan PRIVATE yuzu::sdk)
+
+set_target_properties(plugin_vuln_scan PROPERTIES
+  PREFIX ""
+  OUTPUT_NAME "vuln_scan"
+)
+
+yuzu_set_compiler_flags(plugin_vuln_scan)
+
+install(TARGETS plugin_vuln_scan LIBRARY DESTINATION lib/yuzu/plugins)

--- a/agents/plugins/vuln_scan/meson.build
+++ b/agents/plugins/vuln_scan/meson.build
@@ -1,0 +1,8 @@
+shared_library(
+  'vuln_scan',
+  files('src/vuln_scan_plugin.cpp'),
+  name_prefix: '',
+  dependencies: [yuzu_sdk_dep, yuzu_agent_core_dep],
+  install: true,
+  install_dir: get_option('libdir') / 'yuzu' / 'plugins',
+)

--- a/agents/plugins/vuln_scan/src/config_checks.hpp
+++ b/agents/plugins/vuln_scan/src/config_checks.hpp
@@ -1,0 +1,526 @@
+#pragma once
+
+#include <array>
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#if defined(__linux__) || defined(__APPLE__)
+#include <sstream>
+#endif
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
+namespace yuzu::vuln {
+
+struct ConfigCheckResult {
+    std::string_view severity;
+    std::string_view title;
+    std::string detail;
+    bool passed;
+};
+
+// ── Subprocess helper (Linux / macOS) ──────────────────────────────────────
+
+#if defined(__linux__) || defined(__APPLE__)
+namespace detail {
+
+inline std::string run_cmd(const char* cmd) {
+    std::string result;
+    std::array<char, 256> buf{};
+    FILE* pipe = popen(cmd, "r");
+    if (!pipe) return result;
+    while (fgets(buf.data(), static_cast<int>(buf.size()), pipe)) {
+        result += buf.data();
+    }
+    pclose(pipe);
+    while (!result.empty() && (result.back() == '\n' || result.back() == '\r')) {
+        result.pop_back();
+    }
+    return result;
+}
+
+inline bool file_contains(const char* path, std::string_view needle) {
+    std::ifstream f(path);
+    if (!f.is_open()) return false;
+    std::string line;
+    while (std::getline(f, line)) {
+        // Skip comment lines
+        auto pos = line.find_first_not_of(" \t");
+        if (pos != std::string::npos && line[pos] == '#') continue;
+        if (line.find(needle) != std::string::npos) return true;
+    }
+    return false;
+}
+
+inline std::string read_proc_value(const char* path) {
+    std::ifstream f(path);
+    if (!f.is_open()) return {};
+    std::string val;
+    std::getline(f, val);
+    return val;
+}
+
+}  // namespace detail
+#endif
+
+// ── Windows config checks ──────────────────────────────────────────────────
+
+#ifdef _WIN32
+namespace detail {
+
+inline std::string read_registry_string(HKEY root, const char* subkey,
+                                         const char* value_name) {
+    HKEY hkey{};
+    if (RegOpenKeyExA(root, subkey, 0, KEY_READ, &hkey) != ERROR_SUCCESS)
+        return {};
+    char buf[512]{};
+    DWORD size = sizeof(buf);
+    DWORD type = 0;
+    std::string result;
+    if (RegQueryValueExA(hkey, value_name, nullptr, &type,
+                         reinterpret_cast<LPBYTE>(buf), &size) == ERROR_SUCCESS) {
+        if ((type == REG_SZ || type == REG_EXPAND_SZ) && size > 0) {
+            result.assign(buf, size - 1);
+        }
+    }
+    RegCloseKey(hkey);
+    return result;
+}
+
+inline DWORD read_registry_dword(HKEY root, const char* subkey,
+                                  const char* value_name, DWORD default_val) {
+    HKEY hkey{};
+    if (RegOpenKeyExA(root, subkey, 0, KEY_READ, &hkey) != ERROR_SUCCESS)
+        return default_val;
+    DWORD val = 0;
+    DWORD size = sizeof(val);
+    DWORD type = 0;
+    DWORD result = default_val;
+    if (RegQueryValueExA(hkey, value_name, nullptr, &type,
+                         reinterpret_cast<LPBYTE>(&val), &size) == ERROR_SUCCESS) {
+        if (type == REG_DWORD) result = val;
+    }
+    RegCloseKey(hkey);
+    return result;
+}
+
+}  // namespace detail
+
+inline std::vector<ConfigCheckResult> run_windows_checks() {
+    std::vector<ConfigCheckResult> results;
+
+    // UAC enabled
+    {
+        auto val = detail::read_registry_dword(
+            HKEY_LOCAL_MACHINE,
+            "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
+            "EnableLUA", 0);
+        results.push_back({
+            val == 1 ? "INFO" : "HIGH",
+            "UAC (User Account Control)",
+            val == 1 ? "Enabled" : "Disabled - system is vulnerable to privilege escalation",
+            val == 1
+        });
+    }
+
+    // SMBv1 disabled
+    {
+        auto val = detail::read_registry_dword(
+            HKEY_LOCAL_MACHINE,
+            "SYSTEM\\CurrentControlSet\\Services\\LanmanServer\\Parameters",
+            "SMB1", 1);  // default is enabled if key missing
+        results.push_back({
+            val == 0 ? "INFO" : "CRITICAL",
+            "SMBv1 Protocol",
+            val == 0 ? "Disabled" : "Enabled - vulnerable to EternalBlue/WannaCry (MS17-010)",
+            val == 0
+        });
+    }
+
+    // Auto-logon disabled
+    {
+        auto val = detail::read_registry_string(
+            HKEY_LOCAL_MACHINE,
+            "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon",
+            "AutoAdminLogon");
+        bool disabled = val.empty() || val == "0";
+        results.push_back({
+            disabled ? "INFO" : "HIGH",
+            "Auto-Logon",
+            disabled ? "Disabled" : "Enabled - credentials stored in plaintext in registry",
+            disabled
+        });
+    }
+
+    // RDP Network Level Authentication
+    {
+        auto val = detail::read_registry_dword(
+            HKEY_LOCAL_MACHINE,
+            "SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp",
+            "UserAuthentication", 0);
+        auto rdp_enabled = detail::read_registry_dword(
+            HKEY_LOCAL_MACHINE,
+            "SYSTEM\\CurrentControlSet\\Control\\Terminal Server",
+            "fDenyTSConnections", 1);
+        if (rdp_enabled == 0) {  // RDP is enabled
+            results.push_back({
+                val == 1 ? "INFO" : "HIGH",
+                "RDP Network Level Authentication",
+                val == 1 ? "Enabled" : "Disabled - RDP is exposed without pre-authentication",
+                val == 1
+            });
+        }
+    }
+
+    // Windows Defender real-time protection
+    {
+        auto val = detail::read_registry_dword(
+            HKEY_LOCAL_MACHINE,
+            "SOFTWARE\\Microsoft\\Windows Defender\\Real-Time Protection",
+            "DisableRealtimeMonitoring", 0);
+        results.push_back({
+            val == 0 ? "INFO" : "HIGH",
+            "Windows Defender Real-Time Protection",
+            val == 0 ? "Enabled" : "Disabled - no real-time malware protection",
+            val == 0
+        });
+    }
+
+    // Firewall profiles
+    {
+        static const char* kProfiles[] = {"DomainProfile", "StandardProfile", "PublicProfile"};
+        static const char* kNames[]    = {"Domain", "Private", "Public"};
+        for (int i = 0; i < 3; ++i) {
+            auto subkey = std::string("SYSTEM\\CurrentControlSet\\Services\\"
+                                       "SharedAccess\\Parameters\\FirewallPolicy\\") + kProfiles[i];
+            auto val = detail::read_registry_dword(
+                HKEY_LOCAL_MACHINE, subkey.c_str(), "EnableFirewall", 0);
+            results.push_back({
+                val == 1 ? "INFO" : "HIGH",
+                "Windows Firewall",
+                std::string(kNames[i]) + " profile: " + (val == 1 ? "Enabled" : "Disabled"),
+                val == 1
+            });
+        }
+    }
+
+    return results;
+}
+#endif
+
+// ── Linux config checks ───────────────────────────────────────────────────
+
+#ifdef __linux__
+inline std::vector<ConfigCheckResult> run_linux_checks() {
+    std::vector<ConfigCheckResult> results;
+
+    // SSH: PermitRootLogin
+    {
+        bool root_login = detail::file_contains("/etc/ssh/sshd_config", "PermitRootLogin yes");
+        bool no_root = detail::file_contains("/etc/ssh/sshd_config", "PermitRootLogin no");
+        // If explicit "no" found, it's secure. If "yes" found, it's insecure.
+        // If neither, default depends on distro but flag as warning.
+        if (no_root) {
+            results.push_back({"INFO", "SSH Root Login", "PermitRootLogin is set to no", true});
+        } else if (root_login) {
+            results.push_back({"HIGH", "SSH Root Login",
+                "PermitRootLogin is set to yes - direct root access via SSH is enabled", false});
+        } else {
+            results.push_back({"MEDIUM", "SSH Root Login",
+                "PermitRootLogin not explicitly set - may default to prohibit-password", false});
+        }
+    }
+
+    // SSH: PasswordAuthentication
+    {
+        bool pw_yes = detail::file_contains("/etc/ssh/sshd_config", "PasswordAuthentication yes");
+        bool pw_no = detail::file_contains("/etc/ssh/sshd_config", "PasswordAuthentication no");
+        if (pw_no) {
+            results.push_back({"INFO", "SSH Password Authentication",
+                "Disabled - key-based auth only", true});
+        } else if (pw_yes) {
+            results.push_back({"MEDIUM", "SSH Password Authentication",
+                "Enabled - consider using key-based authentication only", false});
+        }
+    }
+
+    // ASLR
+    {
+        auto val = detail::read_proc_value("/proc/sys/kernel/randomize_va_space");
+        bool ok = !val.empty() && val[0] == '2';
+        results.push_back({
+            ok ? "INFO" : "HIGH",
+            "ASLR (Address Space Layout Randomization)",
+            ok ? "Full randomization enabled (value=2)"
+               : "Not fully enabled (value=" + val + ") - should be 2",
+            ok
+        });
+    }
+
+    // Core dumps restricted
+    {
+        auto val = detail::read_proc_value("/proc/sys/fs/suid_dumpable");
+        bool ok = !val.empty() && val[0] == '0';
+        results.push_back({
+            ok ? "INFO" : "MEDIUM",
+            "SUID Core Dumps",
+            ok ? "Restricted (suid_dumpable=0)"
+               : "Not restricted (suid_dumpable=" + val + ") - SUID programs may dump core",
+            ok
+        });
+    }
+
+    // /tmp mounted noexec
+    {
+        std::ifstream mounts("/proc/mounts");
+        bool found_tmp = false;
+        bool has_noexec = false;
+        if (mounts.is_open()) {
+            std::string line;
+            while (std::getline(mounts, line)) {
+                if (line.find(" /tmp ") != std::string::npos) {
+                    found_tmp = true;
+                    has_noexec = line.find("noexec") != std::string::npos;
+                    break;
+                }
+            }
+        }
+        if (found_tmp) {
+            results.push_back({
+                has_noexec ? "INFO" : "MEDIUM",
+                "/tmp noexec",
+                has_noexec ? "/tmp is mounted with noexec"
+                           : "/tmp is not mounted with noexec - executables can run from /tmp",
+                has_noexec
+            });
+        }
+    }
+
+    // Firewall (iptables/nftables)
+    {
+        auto ipt = detail::run_cmd("iptables -L -n 2>/dev/null | wc -l");
+        auto nft = detail::run_cmd("nft list ruleset 2>/dev/null | wc -l");
+        auto ufw = detail::run_cmd("ufw status 2>/dev/null | head -1");
+
+        bool has_rules = false;
+        std::string detail_str;
+
+        if (ufw.find("active") != std::string::npos) {
+            has_rules = true;
+            detail_str = "UFW firewall is active";
+        } else {
+            int ipt_lines = 0, nft_lines = 0;
+            try { ipt_lines = std::stoi(ipt); } catch (...) {}
+            try { nft_lines = std::stoi(nft); } catch (...) {}
+            // iptables -L with no rules still shows ~8 lines (headers)
+            has_rules = ipt_lines > 10 || nft_lines > 0;
+            if (has_rules) {
+                detail_str = "Firewall rules detected";
+            } else {
+                detail_str = "No firewall rules detected - host may be unprotected";
+            }
+        }
+
+        results.push_back({
+            has_rules ? "INFO" : "HIGH",
+            "Firewall",
+            detail_str,
+            has_rules
+        });
+    }
+
+    // World-writable directories in PATH
+    {
+        auto path_env = detail::run_cmd("echo $PATH");
+        std::istringstream ss(path_env);
+        std::string dir;
+        std::vector<std::string> writable;
+        while (std::getline(ss, dir, ':')) {
+            if (dir.empty()) continue;
+            auto check = "test -d '" + dir + "' && test -w '" + dir +
+                         "' && stat -c '%a' '" + dir + "' 2>/dev/null";
+            auto perms = detail::run_cmd(check.c_str());
+            if (!perms.empty() && perms.size() >= 3 && perms.back() >= '2') {
+                writable.push_back(dir);
+            }
+        }
+        if (!writable.empty()) {
+            std::string dirs;
+            for (const auto& d : writable) {
+                if (!dirs.empty()) dirs += ", ";
+                dirs += d;
+            }
+            results.push_back({"HIGH", "World-Writable PATH Directories",
+                "World-writable directories found in PATH: " + dirs, false});
+        }
+    }
+
+    return results;
+}
+#endif
+
+// ── macOS config checks ───────────────────────────────────────────────────
+
+#ifdef __APPLE__
+inline std::vector<ConfigCheckResult> run_macos_checks() {
+    std::vector<ConfigCheckResult> results;
+
+    // Gatekeeper
+    {
+        auto out = detail::run_cmd("spctl --status 2>&1");
+        bool enabled = out.find("enabled") != std::string::npos;
+        results.push_back({
+            enabled ? "INFO" : "HIGH",
+            "Gatekeeper",
+            enabled ? "Enabled - only verified apps can run"
+                    : "Disabled - unsigned apps can run without restriction",
+            enabled
+        });
+    }
+
+    // FileVault
+    {
+        auto out = detail::run_cmd("fdesetup status 2>&1");
+        bool on = out.find("On") != std::string::npos;
+        results.push_back({
+            on ? "INFO" : "HIGH",
+            "FileVault Disk Encryption",
+            on ? "Enabled" : "Disabled - disk is not encrypted",
+            on
+        });
+    }
+
+    // SIP (System Integrity Protection)
+    {
+        auto out = detail::run_cmd("csrutil status 2>&1");
+        bool enabled = out.find("enabled") != std::string::npos;
+        results.push_back({
+            enabled ? "INFO" : "CRITICAL",
+            "System Integrity Protection (SIP)",
+            enabled ? "Enabled" : "Disabled - system files are unprotected",
+            enabled
+        });
+    }
+
+    // Firewall
+    {
+        auto out = detail::run_cmd(
+            "/usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate 2>&1");
+        bool enabled = out.find("enabled") != std::string::npos;
+        results.push_back({
+            enabled ? "INFO" : "MEDIUM",
+            "Application Firewall",
+            enabled ? "Enabled" : "Disabled",
+            enabled
+        });
+    }
+
+    // Remote Login (SSH)
+    {
+        auto out = detail::run_cmd("systemsetup -getremotelogin 2>&1");
+        bool off = out.find("Off") != std::string::npos;
+        results.push_back({
+            off ? "INFO" : "MEDIUM",
+            "Remote Login (SSH)",
+            off ? "Disabled" : "Enabled - SSH access is open",
+            off
+        });
+    }
+
+    // Automatic updates
+    {
+        auto out = detail::run_cmd(
+            "defaults read /Library/Preferences/com.apple.SoftwareUpdate "
+            "AutomaticCheckEnabled 2>&1");
+        bool enabled = out.find("1") != std::string::npos;
+        results.push_back({
+            enabled ? "INFO" : "MEDIUM",
+            "Automatic Software Updates",
+            enabled ? "Enabled" : "Disabled - system may miss security patches",
+            enabled
+        });
+    }
+
+    return results;
+}
+#endif
+
+// ── Cross-platform checks ─────────────────────────────────────────────────
+
+inline std::vector<ConfigCheckResult> run_cross_platform_checks() {
+    std::vector<ConfigCheckResult> results;
+
+#if defined(__linux__) || defined(__APPLE__)
+    // Check for common risky ports listening on all interfaces
+    auto listeners = detail::run_cmd(
+        "ss -tlnH 2>/dev/null || netstat -tlnp 2>/dev/null");
+    if (!listeners.empty()) {
+        static constexpr struct { int port; const char* name; const char* risk; } kRiskyPorts[] = {
+            {21,   "FTP",    "Unencrypted file transfer"},
+            {23,   "Telnet", "Unencrypted remote access"},
+            {445,  "SMB",    "File sharing - common attack vector"},
+            {3389, "RDP",    "Remote desktop - frequent brute force target"},
+            {5900, "VNC",    "Remote desktop - often unencrypted"},
+        };
+
+        for (const auto& rp : kRiskyPorts) {
+            auto port_str = ":" + std::to_string(rp.port) + " ";
+            auto any_bind = "0.0.0.0:" + std::to_string(rp.port);
+            auto any6_bind = ":::" + std::to_string(rp.port);
+            if (listeners.find(any_bind) != std::string::npos ||
+                listeners.find(any6_bind) != std::string::npos) {
+                results.push_back({
+                    "HIGH",
+                    "Open Port",
+                    std::string(rp.name) + " (port " + std::to_string(rp.port) +
+                        ") listening on all interfaces - " + rp.risk,
+                    false
+                });
+            }
+        }
+    }
+#endif
+
+#ifdef _WIN32
+    // On Windows, check common risky ports via netstat
+    // (simplified — real implementation would parse netstat output)
+    // For now, skipped since Windows firewall check covers this area
+#endif
+
+    return results;
+}
+
+// ── Run all platform checks ───────────────────────────────────────────────
+
+inline std::vector<ConfigCheckResult> run_all_config_checks() {
+    std::vector<ConfigCheckResult> results;
+
+#ifdef _WIN32
+    auto win = run_windows_checks();
+    results.insert(results.end(), win.begin(), win.end());
+#elif defined(__linux__)
+    auto lin = run_linux_checks();
+    results.insert(results.end(), lin.begin(), lin.end());
+#elif defined(__APPLE__)
+    auto mac = run_macos_checks();
+    results.insert(results.end(), mac.begin(), mac.end());
+#endif
+
+    auto cross = run_cross_platform_checks();
+    results.insert(results.end(), cross.begin(), cross.end());
+
+    return results;
+}
+
+}  // namespace yuzu::vuln

--- a/agents/plugins/vuln_scan/src/cve_rules.hpp
+++ b/agents/plugins/vuln_scan/src/cve_rules.hpp
@@ -1,0 +1,193 @@
+#pragma once
+
+#include <array>
+#include <string_view>
+
+namespace yuzu::vuln {
+
+struct CveRule {
+    std::string_view cve_id;
+    std::string_view product;         // case-insensitive substring match on app name
+    std::string_view affected_below;  // versions below this are vulnerable
+    std::string_view fixed_in;        // informational: version that fixed it
+    std::string_view severity;        // CRITICAL, HIGH, MEDIUM, LOW
+    std::string_view description;
+};
+
+// ── Version comparison ─────────────────────────────────────────────────────
+// Returns <0 if a<b, 0 if a==b, >0 if a>b.
+// Splits on '.' and '-', compares each segment numerically where possible.
+
+inline int compare_versions(std::string_view a, std::string_view b) {
+    auto next_segment = [](std::string_view& s) -> std::string_view {
+        if (s.empty()) return {};
+        auto pos = s.find_first_of(".-");
+        std::string_view seg;
+        if (pos == std::string_view::npos) {
+            seg = s;
+            s = {};
+        } else {
+            seg = s.substr(0, pos);
+            s = s.substr(pos + 1);
+        }
+        return seg;
+    };
+
+    auto to_num = [](std::string_view seg) -> std::pair<bool, long long> {
+        if (seg.empty()) return {true, 0};
+        long long val = 0;
+        for (char c : seg) {
+            if (c < '0' || c > '9') return {false, 0};
+            val = val * 10 + (c - '0');
+        }
+        return {true, val};
+    };
+
+    std::string_view ra = a, rb = b;
+    while (!ra.empty() || !rb.empty()) {
+        auto sa = next_segment(ra);
+        auto sb = next_segment(rb);
+
+        auto [a_num, a_val] = to_num(sa);
+        auto [b_num, b_val] = to_num(sb);
+
+        if (a_num && b_num) {
+            if (a_val != b_val) return (a_val < b_val) ? -1 : 1;
+        } else {
+            int cmp = sa.compare(sb);
+            if (cmp != 0) return cmp;
+        }
+    }
+    return 0;
+}
+
+// ── Bundled CVE rules ──────────────────────────────────────────────────────
+// High-profile CVEs across common software. Updated with plugin releases.
+
+inline constexpr std::array kCveRules = std::to_array<CveRule>({
+    // OpenSSL
+    {"CVE-2014-0160", "openssl", "1.0.1g", "1.0.1g", "CRITICAL",
+     "Heartbleed: TLS heartbeat read overrun allows memory disclosure"},
+    {"CVE-2022-3602", "openssl", "3.0.7", "3.0.7", "HIGH",
+     "X.509 certificate verification buffer overrun"},
+    {"CVE-2023-0286", "openssl", "3.0.8", "3.0.8", "HIGH",
+     "X.400 address type confusion in X.509 GeneralName"},
+    {"CVE-2024-5535", "openssl", "3.3.2", "3.3.2", "MEDIUM",
+     "SSL_select_next_proto buffer overread"},
+
+    // curl
+    {"CVE-2023-38545", "curl", "8.4.0", "8.4.0", "CRITICAL",
+     "SOCKS5 heap buffer overflow"},
+    {"CVE-2023-38546", "curl", "8.4.0", "8.4.0", "LOW",
+     "Cookie injection with none file"},
+    {"CVE-2024-2398", "curl", "8.7.1", "8.7.1", "MEDIUM",
+     "HTTP/2 push headers memory leak"},
+
+    // sudo
+    {"CVE-2021-3156", "sudo", "1.9.5p2", "1.9.5p2", "CRITICAL",
+     "Baron Samedit: heap buffer overflow in sudoedit"},
+    {"CVE-2023-22809", "sudo", "1.9.12p2", "1.9.12p2", "HIGH",
+     "sudoedit arbitrary file write via user-provided path"},
+
+    // polkit
+    {"CVE-2021-4034", "polkit", "0.120", "0.120", "CRITICAL",
+     "PwnKit: local privilege escalation via pkexec"},
+
+    // Log4j (Java)
+    {"CVE-2021-44228", "log4j", "2.17.0", "2.17.0", "CRITICAL",
+     "Log4Shell: remote code execution via JNDI lookup"},
+    {"CVE-2021-45046", "log4j", "2.17.0", "2.17.0", "CRITICAL",
+     "Log4Shell bypass: incomplete fix in 2.15.0"},
+
+    // Apache HTTP Server
+    {"CVE-2021-41773", "apache", "2.4.50", "2.4.50", "CRITICAL",
+     "Path traversal and file disclosure"},
+    {"CVE-2023-25690", "apache", "2.4.56", "2.4.56", "CRITICAL",
+     "HTTP request smuggling via mod_proxy"},
+
+    // OpenSSH
+    {"CVE-2024-6387", "openssh", "9.8", "9.8p1", "CRITICAL",
+     "regreSSHion: unauthenticated remote code execution"},
+    {"CVE-2023-38408", "openssh", "9.3p2", "9.3p2", "HIGH",
+     "PKCS#11 provider remote code execution via ssh-agent"},
+
+    // Python
+    {"CVE-2023-24329", "python", "3.11.4", "3.11.4", "HIGH",
+     "urllib.parse URL parsing bypass via leading whitespace"},
+    {"CVE-2024-0450", "python", "3.12.2", "3.12.2", "MEDIUM",
+     "zipfile quoted-overlap zipbomb protection bypass"},
+
+    // Node.js
+    {"CVE-2023-44487", "node", "20.8.1", "20.8.1", "HIGH",
+     "HTTP/2 Rapid Reset denial of service"},
+    {"CVE-2024-22019", "node", "20.11.1", "20.11.1", "HIGH",
+     "Reading unprocessed HTTP request with unbounded chunk extension"},
+
+    // Google Chrome
+    {"CVE-2024-0519", "chrome", "120.0.6099.225", "120.0.6099.225", "HIGH",
+     "V8 out-of-bounds memory access"},
+    {"CVE-2024-4671", "chrome", "124.0.6367.202", "124.0.6367.202", "HIGH",
+     "Visuals use-after-free"},
+
+    // Mozilla Firefox
+    {"CVE-2024-29944", "firefox", "124.0.1", "124.0.1", "CRITICAL",
+     "Privileged JavaScript execution via event handler"},
+    {"CVE-2024-9680", "firefox", "131.0.2", "131.0.2", "CRITICAL",
+     "Animation timeline use-after-free"},
+
+    // .NET Runtime
+    {"CVE-2024-21319", "dotnet", "8.0.1", "8.0.1", "HIGH",
+     "Denial of service via SignedCms degenerate certificates"},
+    {"CVE-2024-38168", "dotnet", "8.0.8", "8.0.8", "HIGH",
+     "ASP.NET Core denial of service"},
+
+    // Java / OpenJDK
+    {"CVE-2024-20918", "openjdk", "21.0.2", "21.0.2", "HIGH",
+     "Hotspot array access bounds check bypass"},
+    {"CVE-2024-20952", "openjdk", "21.0.2", "21.0.2", "HIGH",
+     "Security manager bypass via Object serialization"},
+
+    // Windows Print Spooler
+    {"CVE-2021-34527", "windows", "10.0.19041.1083", "KB5004945", "CRITICAL",
+     "PrintNightmare: RCE via Windows Print Spooler"},
+    {"CVE-2021-1675", "windows", "10.0.19041.1052", "KB5003637", "CRITICAL",
+     "Print Spooler privilege escalation"},
+
+    // nginx
+    {"CVE-2022-41741", "nginx", "1.23.2", "1.23.2", "HIGH",
+     "mp4 module memory corruption"},
+    {"CVE-2024-7347", "nginx", "1.27.1", "1.27.1", "MEDIUM",
+     "Worker process crash in mp4 module"},
+
+    // PostgreSQL
+    {"CVE-2023-5868", "postgresql", "16.1", "16.1", "MEDIUM",
+     "Memory disclosure in aggregate function calls"},
+    {"CVE-2024-0985", "postgresql", "16.2", "16.2", "HIGH",
+     "Non-owner REFRESH MATERIALIZED VIEW CONCURRENTLY executes as owner"},
+
+    // Git
+    {"CVE-2024-32002", "git", "2.45.1", "2.45.1", "CRITICAL",
+     "RCE via crafted repositories with submodules"},
+    {"CVE-2023-25652", "git", "2.40.1", "2.40.1", "HIGH",
+     "git apply --reject writes outside worktree"},
+
+    // 7-Zip
+    {"CVE-2024-11477", "7-zip", "24.07", "24.07", "HIGH",
+     "Zstandard decompression integer underflow RCE"},
+
+    // WinRAR
+    {"CVE-2023-38831", "winrar", "6.23", "6.23", "HIGH",
+     "Code execution when opening crafted archive"},
+
+    // PuTTY
+    {"CVE-2024-31497", "putty", "0.81", "0.81", "CRITICAL",
+     "NIST P-521 private key recovery from ECDSA signatures"},
+
+    // PHP
+    {"CVE-2024-4577", "php", "8.3.8", "8.3.8", "CRITICAL",
+     "CGI argument injection on Windows"},
+    {"CVE-2024-2756", "php", "8.3.4", "8.3.4", "MEDIUM",
+     "Cookie __Host-/__Secure- prefix bypass"},
+});
+
+}  // namespace yuzu::vuln

--- a/agents/plugins/vuln_scan/src/vuln_scan_plugin.cpp
+++ b/agents/plugins/vuln_scan/src/vuln_scan_plugin.cpp
@@ -1,0 +1,467 @@
+/**
+ * vuln_scan_plugin.cpp — Host vulnerability scanning plugin for Yuzu
+ *
+ * Actions:
+ *   "scan"        — Full scan (CVE + configuration checks).
+ *   "cve_scan"    — CVE-only: match installed software against known CVEs.
+ *   "config_scan" — Configuration/compliance checks only.
+ *   "summary"     — Quick severity counts from a full scan.
+ *
+ * Output is pipe-delimited via write_output():
+ *   <severity>|cve|<CVE-ID>: <description>|<product> <installed_ver> (fixed in <fixed_ver>)
+ *   <severity>|config|<title>|<detail>
+ *   summary|<severity>|<count>
+ */
+
+#include <yuzu/plugin.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdio>
+#include <format>
+#include <map>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#if defined(__linux__) || defined(__APPLE__)
+#include <sstream>
+#endif
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
+#include "cve_rules.hpp"
+#include "config_checks.hpp"
+
+namespace {
+
+// ── Subprocess helper (Linux / macOS) ──────────────────────────────────────
+
+#if defined(__linux__) || defined(__APPLE__)
+std::string run_command(const char* cmd) {
+    std::string result;
+    std::array<char, 256> buf{};
+    FILE* pipe = popen(cmd, "r");
+    if (!pipe) return result;
+    while (fgets(buf.data(), static_cast<int>(buf.size()), pipe)) {
+        result += buf.data();
+    }
+    pclose(pipe);
+    while (!result.empty() && (result.back() == '\n' || result.back() == '\r')) {
+        result.pop_back();
+    }
+    return result;
+}
+
+bool command_exists(const char* cmd) {
+    auto check = std::string("command -v ") + cmd + " >/dev/null 2>&1";
+    return system(check.c_str()) == 0;
+}
+#endif
+
+// ── App record ────────────────────────────────────────────────────────────
+
+struct AppInfo {
+    std::string name;
+    std::string version;
+};
+
+// Case-insensitive substring match
+bool icontains(std::string_view haystack, std::string_view needle) {
+    if (needle.empty()) return true;
+    if (haystack.size() < needle.size()) return false;
+    auto it = std::search(haystack.begin(), haystack.end(),
+        needle.begin(), needle.end(),
+        [](char a, char b) {
+            return std::tolower(static_cast<unsigned char>(a)) ==
+                   std::tolower(static_cast<unsigned char>(b));
+        });
+    return it != haystack.end();
+}
+
+// Replace invalid UTF-8 bytes with '?'
+std::string sanitize_utf8(const std::string& s) {
+    std::string out;
+    out.reserve(s.size());
+    size_t i = 0;
+    while (i < s.size()) {
+        auto c = static_cast<unsigned char>(s[i]);
+        if (c < 0x80) {
+            out += s[i]; ++i;
+        } else if ((c >> 5) == 0x06 && i + 1 < s.size() &&
+                   (static_cast<unsigned char>(s[i+1]) >> 6) == 0x02) {
+            out += s[i]; out += s[i+1]; i += 2;
+        } else if ((c >> 4) == 0x0E && i + 2 < s.size() &&
+                   (static_cast<unsigned char>(s[i+1]) >> 6) == 0x02 &&
+                   (static_cast<unsigned char>(s[i+2]) >> 6) == 0x02) {
+            out += s[i]; out += s[i+1]; out += s[i+2]; i += 3;
+        } else if ((c >> 3) == 0x1E && i + 3 < s.size() &&
+                   (static_cast<unsigned char>(s[i+1]) >> 6) == 0x02 &&
+                   (static_cast<unsigned char>(s[i+2]) >> 6) == 0x02 &&
+                   (static_cast<unsigned char>(s[i+3]) >> 6) == 0x02) {
+            out += s[i]; out += s[i+1]; out += s[i+2]; out += s[i+3]; i += 4;
+        } else {
+            out += '?'; ++i;
+        }
+    }
+    return out;
+}
+
+// Escape pipe characters in output values
+std::string escape_pipes(std::string_view s) {
+    std::string out;
+    out.reserve(s.size());
+    for (char c : s) {
+        if (c == '|') out += "\\|";
+        else out += c;
+    }
+    return out;
+}
+
+// ── Get installed apps (same approach as installed_apps plugin) ────────────
+
+#ifdef _WIN32
+void enumerate_uninstall_key(HKEY root, const char* subkey, REGSAM extra_sam,
+                             std::vector<AppInfo>& apps) {
+    HKEY hkey{};
+    if (RegOpenKeyExA(root, subkey, 0, KEY_READ | KEY_ENUMERATE_SUB_KEYS | extra_sam,
+                      &hkey) != ERROR_SUCCESS) {
+        return;
+    }
+
+    char name_buf[256]{};
+    DWORD idx = 0;
+    DWORD name_len = sizeof(name_buf);
+
+    while (RegEnumKeyExA(hkey, idx++, name_buf, &name_len,
+                         nullptr, nullptr, nullptr, nullptr) == ERROR_SUCCESS) {
+        HKEY app_key{};
+        if (RegOpenKeyExA(hkey, name_buf, 0, KEY_READ | extra_sam, &app_key) == ERROR_SUCCESS) {
+            auto read_str = [&](const char* value_name) -> std::string {
+                char buf[512]{};
+                DWORD size = sizeof(buf);
+                DWORD type = 0;
+                if (RegQueryValueExA(app_key, value_name, nullptr, &type,
+                                     reinterpret_cast<LPBYTE>(buf), &size) == ERROR_SUCCESS) {
+                    if (type == REG_SZ && size > 0) {
+                        return std::string(buf, size - 1);
+                    }
+                }
+                return {};
+            };
+
+            auto display_name = read_str("DisplayName");
+            if (!display_name.empty()) {
+                auto sys_component = read_str("SystemComponent");
+                if (sys_component != "1") {
+                    auto version = read_str("DisplayVersion");
+                    apps.push_back({std::move(display_name), std::move(version)});
+                }
+            }
+            RegCloseKey(app_key);
+        }
+        name_len = sizeof(name_buf);
+    }
+    RegCloseKey(hkey);
+}
+
+std::vector<AppInfo> get_installed_apps() {
+    std::vector<AppInfo> apps;
+    static const char* kUninstallKey =
+        "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall";
+    enumerate_uninstall_key(HKEY_LOCAL_MACHINE, kUninstallKey, KEY_WOW64_64KEY, apps);
+    enumerate_uninstall_key(HKEY_LOCAL_MACHINE, kUninstallKey, KEY_WOW64_32KEY, apps);
+    enumerate_uninstall_key(HKEY_CURRENT_USER, kUninstallKey, 0, apps);
+
+    std::sort(apps.begin(), apps.end(), [](const AppInfo& a, const AppInfo& b) {
+        return a.name < b.name || (a.name == b.name && a.version < b.version);
+    });
+    apps.erase(std::unique(apps.begin(), apps.end(),
+        [](const AppInfo& a, const AppInfo& b) {
+            return a.name == b.name && a.version == b.version;
+        }), apps.end());
+
+    return apps;
+}
+#elif defined(__linux__)
+std::vector<AppInfo> get_installed_apps() {
+    std::vector<AppInfo> apps;
+
+    if (command_exists("dpkg-query")) {
+        auto out = run_command(
+            "dpkg-query -W -f='${Package}|${Version}|${Status}\\n' 2>/dev/null");
+        std::istringstream ss(out);
+        std::string line;
+        while (std::getline(ss, line)) {
+            if (line.find("install ok installed") == std::string::npos) continue;
+            std::istringstream ls(line);
+            std::string name, version;
+            std::getline(ls, name, '|');
+            std::getline(ls, version, '|');
+            apps.push_back({name, version});
+        }
+    } else if (command_exists("rpm")) {
+        auto out = run_command(
+            "rpm -qa --queryformat '%{NAME}|%{VERSION}-%{RELEASE}\\n' 2>/dev/null");
+        std::istringstream ss(out);
+        std::string line;
+        while (std::getline(ss, line)) {
+            auto sep = line.find('|');
+            if (sep != std::string::npos) {
+                apps.push_back({line.substr(0, sep), line.substr(sep + 1)});
+            }
+        }
+    } else if (command_exists("pacman")) {
+        auto out = run_command("pacman -Q 2>/dev/null");
+        std::istringstream ss(out);
+        std::string line;
+        while (std::getline(ss, line)) {
+            auto sp = line.find(' ');
+            if (sp != std::string::npos) {
+                apps.push_back({line.substr(0, sp), line.substr(sp + 1)});
+            }
+        }
+    }
+
+    return apps;
+}
+#elif defined(__APPLE__)
+std::vector<AppInfo> get_installed_apps() {
+    std::vector<AppInfo> apps;
+
+    auto out = run_command(
+        "system_profiler SPApplicationsDataType -detailLevel mini 2>/dev/null"
+        " | grep -E '^ {4}\\w|Version:'");
+    if (!out.empty()) {
+        std::istringstream ss(out);
+        std::string line;
+        std::string current_name;
+        std::string current_version;
+        while (std::getline(ss, line)) {
+            auto start = line.find_first_not_of(" \t");
+            if (start == std::string::npos) continue;
+            line = line.substr(start);
+
+            if (line.find("Version:") == 0) {
+                current_version = line.substr(line.find(':') + 2);
+            } else if (!line.empty() && line.back() == ':') {
+                if (!current_name.empty()) {
+                    apps.push_back({current_name, current_version});
+                }
+                current_name = line.substr(0, line.size() - 1);
+                current_version.clear();
+            }
+        }
+        if (!current_name.empty()) {
+            apps.push_back({current_name, current_version});
+        }
+    }
+
+    // Also check Homebrew packages
+    if (command_exists("brew")) {
+        auto brew_out = run_command("brew list --versions 2>/dev/null");
+        std::istringstream ss(brew_out);
+        std::string line;
+        while (std::getline(ss, line)) {
+            auto sp = line.find(' ');
+            if (sp != std::string::npos) {
+                apps.push_back({line.substr(0, sp), line.substr(sp + 1)});
+            }
+        }
+    }
+
+    return apps;
+}
+#else
+std::vector<AppInfo> get_installed_apps() {
+    return {};
+}
+#endif
+
+// ── Scan results ──────────────────────────────────────────────────────────
+
+struct Finding {
+    std::string severity;
+    std::string category;  // "cve" or "config"
+    std::string title;
+    std::string detail;
+};
+
+// ── CVE scan ──────────────────────────────────────────────────────────────
+
+std::vector<Finding> do_cve_scan_impl() {
+    std::vector<Finding> findings;
+    auto apps = get_installed_apps();
+
+    for (const auto& rule : yuzu::vuln::kCveRules) {
+        for (const auto& app : apps) {
+            if (!icontains(app.name, rule.product)) continue;
+            if (app.version.empty()) continue;
+
+            // Check if installed version is below the fixed version
+            if (yuzu::vuln::compare_versions(app.version, rule.affected_below) < 0) {
+                findings.push_back({
+                    std::string(rule.severity),
+                    "cve",
+                    std::format("{}: {}", rule.cve_id, rule.description),
+                    std::format("{} {} (fixed in {})",
+                        app.name, app.version, rule.fixed_in)
+                });
+            }
+        }
+    }
+
+    return findings;
+}
+
+// ── Config scan ───────────────────────────────────────────────────────────
+
+std::vector<Finding> do_config_scan_impl() {
+    std::vector<Finding> findings;
+    auto checks = yuzu::vuln::run_all_config_checks();
+
+    for (const auto& check : checks) {
+        // Report all checks (passed ones as INFO)
+        findings.push_back({
+            std::string(check.severity),
+            "config",
+            std::string(check.title),
+            check.detail
+        });
+    }
+
+    return findings;
+}
+
+// ── Output helpers ────────────────────────────────────────────────────────
+
+void output_findings(yuzu::CommandContext& ctx, const std::vector<Finding>& findings) {
+    if (findings.empty()) {
+        ctx.write_output("INFO|scan|No vulnerabilities|No issues detected");
+        return;
+    }
+
+    for (const auto& f : findings) {
+        ctx.write_output(sanitize_utf8(std::format("{}|{}|{}|{}",
+            f.severity,
+            escape_pipes(f.category),
+            escape_pipes(f.title),
+            escape_pipes(f.detail))));
+    }
+}
+
+void output_summary(yuzu::CommandContext& ctx, const std::vector<Finding>& findings) {
+    std::map<std::string, int> counts;
+    counts["CRITICAL"] = 0;
+    counts["HIGH"] = 0;
+    counts["MEDIUM"] = 0;
+    counts["LOW"] = 0;
+    counts["INFO"] = 0;
+
+    for (const auto& f : findings) {
+        counts[f.severity]++;
+    }
+
+    // Output total first
+    int total = 0;
+    int issues = 0;
+    for (const auto& [sev, count] : counts) {
+        total += count;
+        if (sev != "INFO") issues += count;
+    }
+
+    ctx.write_output(std::format("summary|TOTAL|{} findings ({} issues)", total, issues));
+
+    for (const auto& sev : {"CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"}) {
+        ctx.write_output(std::format("summary|{}|{}", sev, counts[sev]));
+    }
+}
+
+}  // namespace
+
+class VulnScanPlugin final : public yuzu::Plugin {
+public:
+    std::string_view name()        const noexcept override { return "vuln_scan"; }
+    std::string_view version()     const noexcept override { return "1.0.0"; }
+    std::string_view description() const noexcept override {
+        return "Host vulnerability scanning — CVE matching and configuration compliance checks";
+    }
+
+    const char* const* actions() const noexcept override {
+        static const char* acts[] = {
+            "scan", "cve_scan", "config_scan", "summary", nullptr
+        };
+        return acts;
+    }
+
+    yuzu::Result<void> init(yuzu::PluginContext& /*ctx*/) override {
+        return {};
+    }
+
+    void shutdown(yuzu::PluginContext& /*ctx*/) noexcept override {}
+
+    int execute(yuzu::CommandContext& ctx,
+                std::string_view action,
+                [[maybe_unused]] yuzu::Params params) override {
+
+        if (action == "scan") {
+            ctx.report_progress(0);
+            auto cve_findings = do_cve_scan_impl();
+            ctx.report_progress(50);
+            auto config_findings = do_config_scan_impl();
+            ctx.report_progress(90);
+
+            std::vector<Finding> all;
+            all.reserve(cve_findings.size() + config_findings.size());
+            all.insert(all.end(), cve_findings.begin(), cve_findings.end());
+            all.insert(all.end(), config_findings.begin(), config_findings.end());
+
+            output_findings(ctx, all);
+            ctx.report_progress(100);
+            return 0;
+        }
+
+        if (action == "cve_scan") {
+            ctx.report_progress(0);
+            auto findings = do_cve_scan_impl();
+            output_findings(ctx, findings);
+            ctx.report_progress(100);
+            return 0;
+        }
+
+        if (action == "config_scan") {
+            ctx.report_progress(0);
+            auto findings = do_config_scan_impl();
+            output_findings(ctx, findings);
+            ctx.report_progress(100);
+            return 0;
+        }
+
+        if (action == "summary") {
+            auto cve_findings = do_cve_scan_impl();
+            auto config_findings = do_config_scan_impl();
+
+            std::vector<Finding> all;
+            all.reserve(cve_findings.size() + config_findings.size());
+            all.insert(all.end(), cve_findings.begin(), cve_findings.end());
+            all.insert(all.end(), config_findings.begin(), config_findings.end());
+
+            output_summary(ctx, all);
+            return 0;
+        }
+
+        ctx.write_output(std::format("unknown action: {}", action));
+        return 1;
+    }
+};
+
+YUZU_PLUGIN_EXPORT(VulnScanPlugin)

--- a/meson.build
+++ b/meson.build
@@ -95,6 +95,7 @@ if build_agent
     subdir('agents/plugins/firewall')
     subdir('agents/plugins/antivirus')
     subdir('agents/plugins/bitlocker')
+    subdir('agents/plugins/vuln_scan')
   endif
 endif
 

--- a/server/core/src/dashboard_ui.cpp
+++ b/server/core/src/dashboard_ui.cpp
@@ -416,7 +416,12 @@ R"HTM(
       'script_exec bash':              { plugin: 'script_exec', action: 'bash' },
       'software_actions':              { plugin: 'software_actions', action: 'list_upgradable' },
       'software_actions list_upgradable': { plugin: 'software_actions', action: 'list_upgradable' },
-      'software_actions installed_count': { plugin: 'software_actions', action: 'installed_count' }
+      'software_actions installed_count': { plugin: 'software_actions', action: 'installed_count' },
+      'vuln_scan':              { plugin: 'vuln_scan', action: 'scan' },
+      'vuln_scan scan':         { plugin: 'vuln_scan', action: 'scan' },
+      'vuln_scan cve_scan':     { plugin: 'vuln_scan', action: 'cve_scan' },
+      'vuln_scan config_scan':  { plugin: 'vuln_scan', action: 'config_scan' },
+      'vuln_scan summary':      { plugin: 'vuln_scan', action: 'summary' }
     };
 
     /* ── Column schemas per plugin ────────────────────────── */
@@ -447,7 +452,8 @@ R"HTM(
       'event_logs':       ['Agent', 'Key', 'Value'],
       'sccm':             ['Agent', 'Key', 'Value'],
       'script_exec':      ['Agent', 'Key', 'Value'],
-      'software_actions': ['Agent', 'Key', 'Value']
+      'software_actions': ['Agent', 'Key', 'Value'],
+      'vuln_scan':        ['Agent', 'Severity', 'Category', 'Title', 'Detail']
     };
 )HTM"
 // Part 3: Helpers and table management
@@ -682,6 +688,16 @@ R"HTM(
                     parts[3], parts[4], parts[5], parts[6], parts[7], parts[8]]);
           } else {
             addRow([agentName, payload]);
+          }
+        } else if (plugin === 'vuln_scan') {
+          /* severity|category|title|detail */
+          var parts = payload.split('|');
+          if (parts.length >= 4) {
+            addRow([agentName, parts[0], parts[1].replace(/\\\|/g,'|'), parts[2].replace(/\\\|/g,'|'), parts.slice(3).join('|').replace(/\\\|/g,'|')]);
+          } else if (parts.length >= 2) {
+            addRow([agentName, parts[0], parts.slice(1).join('|'), '', '']);
+          } else {
+            addRow([agentName, payload, '', '', '']);
           }
         } else if (['status','device_identity','os_info','hardware','users','installed_apps','msi_packages','network_config','diagnostics','agent_actions','processes','services','filesystem','network_diag','network_actions','firewall','antivirus','bitlocker','windows_updates','event_logs','sccm','script_exec','software_actions'].indexOf(plugin) >= 0) {
           /* key|value */


### PR DESCRIPTION
…ompliance

New vuln_scan agent plugin that performs both CVE-based software scanning (matching installed apps against 40+ bundled CVE rules) and configuration compliance checks across Windows, Linux, and macOS. Supports four actions: scan (full), cve_scan, config_scan, and summary. Dashboard UI updated with command mappings, column schema, and custom 4-field rendering.

https://claude.ai/code/session_01ByjmyJGoqxYYFhZoWT9qGE

## Summary

<!-- Brief description of what this PR does and why -->

## Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] CI / Build

## Testing

<!-- What testing was done? -->

## Checklist

- [ ] Builds on Linux (GCC and Clang)
- [x] Builds on Windows (MSVC)
- [ ] Tests pass (`ctest --preset linux-debug`)
- [ ] No new clang-tidy warnings
- [ ] No new compiler warnings
