### PR TITLE
chore(release): prep v0.11.0-rc2 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-rc2] - 2026-04-20
+
 ### Added
 
 - **Guardian "Guaranteed State" engine — wire contract + server store


### PR DESCRIPTION
## Summary

Retitle `[Unreleased]` to `[0.11.0-rc2] - 2026-04-20` so the release workflow has a matching section to reference, and open a fresh empty `[Unreleased]` above it.

Purpose: exercise the new SBOM + SLSA + cosign pipeline that landed in #463 against a real tag before using it for a customer-facing release. rc1 predated this wiring and did not exercise any of it.

`meson.build` stays at `0.11.0` (the release workflow strips the `-rc2` suffix before calling `check-compose-versions.sh`, per `6d9cfe1`).

## Test plan

- [x] `tests/test_changelog_order.py` passes locally (11 sections in order)
- [x] `scripts/check-compose-versions.sh 0.11.0` passes
- [x] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)