### PR TITLE
ci(sentinel): re-enable 30-min cron on runner inventory check

### DIFF
--- a/.github/workflows/runner-inventory-sentinel.yml
+++ b/.github/workflows/runner-inventory-sentinel.yml
@@ -31,15 +31,13 @@ name: Runner inventory sentinel
 # RUNNER_INVENTORY_TOKEN < pat.txt`. See docs/ci-troubleshooting.md.
 
 on:
-  # Scheduled trigger DISABLED until RUNNER_INVENTORY_TOKEN PAT is created.
-  # See docs/ci-troubleshooting.md (TODO Saturday) for PAT setup. Until
-  # the PAT exists, scheduled runs would fail every 30 min on the 403
-  # from /actions/runners, training operators to ignore the workflow —
-  # an anti-pattern for a sentinel whose whole job is loud signaling.
-  # Re-enable the cron line below in the same PR that adds the PAT.
-  #
-  # schedule:
-  #   - cron: "*/30 * * * *"
+  # Runs every 30 minutes against the RUNNER_INVENTORY_TOKEN PAT so
+  # drift between GitHub's actions/runners listing and
+  # .github/runner-inventory.json surfaces quickly. Cron was parked
+  # until the PAT was in place (scheduled failures would have trained
+  # operators to ignore the workflow — anti-pattern for a sentinel).
+  schedule:
+    - cron: "*/30 * * * *"
   workflow_dispatch:
   push:
     branches: [dev, main]


### PR DESCRIPTION
## Summary

`RUNNER_INVENTORY_TOKEN` PAT is in place, so the scheduled trigger on `runner-inventory-sentinel.yml` can come off parking. Two-line uncomment (plus cleanup of the surrounding "parked until PAT" explainer comment, which no longer applies).

- Re-enables `schedule: */30 * * * *`
- Replaces the parked-state comment with one describing current behaviour
- Keeps `workflow_dispatch` + `push` path trigger unchanged

## Verification

- YAML parses; `on:` keys now include `schedule`, `workflow_dispatch`, `push`.
- Merging this PR itself triggers the sentinel's own `push` path (the file is in its own `paths:` filter), which will be the first live exercise of the PAT-authenticated invariant against `.github/runner-inventory.json`.
- If the PAT is mis-scoped or the inventory drifts, this PR's CI will fail the same way the earlier manual run did — diagnosable, not silent.

## Rollback

Comment out the `schedule:` block again if scheduled failures become noisy. Not expected — the sentinel is designed to stay silent unless state drifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)