### PR TITLE
fix(ci): close CodeQL code-injection in pre-release.yml + scope CodeQL scan

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,20 @@
+name: "Yuzu CodeQL config"
+
+# Exclude third-party and generated code from CodeQL scanning.
+#
+# vcpkg_installed/  — vendored dependency headers (protobuf, abseil,
+#   grpc, httplib, etc.). Any finding here is an upstream bug we cannot
+#   fix in-tree and would be erased by the next vcpkg cache rebuild.
+# build-*/          — per-OS Meson build trees (build-linux,
+#   build-windows, build-macos, build-linux-codeql, etc.). Contains
+#   generated .pb.cc files and moc output; findings are derivative of
+#   the source headers CodeQL already scans directly.
+# builddir*/        — legacy build tree names from before the per-OS
+#   convention landed (kept for belt-and-braces; currently .gitignored).
+# _build/           — rebar3 Erlang build dir (Erlang isn't in the
+#   scanned languages but this avoids stray .beam / source scans).
+paths-ignore:
+  - "vcpkg_installed/**"
+  - "build-*/**"
+  - "builddir*/**"
+  - "_build/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -291,6 +291,9 @@ jobs:
         with:
           languages: ${{ matrix.languages }}
           queries: +security-and-quality
+          # Scope the scan to first-party code; see the config file for
+          # the list of vendored/generated paths that are excluded.
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Configure (Meson debug) — linux
         if: matrix.os == 'linux'

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -42,11 +42,18 @@ jobs:
         id: ver
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Bind externally-influenced values to env vars rather than
+          # interpolating them into bash source — a branch name or
+          # workflow_dispatch input can carry shell metacharacters, and
+          # direct `${{ ... }}` expansion into a `run:` block is a code-
+          # injection sink (CodeQL actions/code-injection/critical).
+          EVENT_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            TAG="${{ inputs.tag }}"
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            TAG="$INPUT_TAG"
           else
-            TAG="${{ github.event.workflow_run.head_branch }}"
+            TAG="$EVENT_BRANCH"
           fi
           VERSION="${TAG#v}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Close CodeQL-flagged Actions code-injection sink in `pre-release.yml`
+  + exclude vendored and generated paths from CodeQL scanning.** Two
+  security-tooling follow-ups surfaced by the first real CodeQL scan
+  after the Scorecard lift landed.
+  - **Code injection fix.** CodeQL critical rule
+    `actions/code-injection/critical` flagged line 49 of
+    `.github/workflows/pre-release.yml`, where
+    `${{ github.event.workflow_run.head_branch }}` was interpolated
+    directly into the bash `run:` block of the "Determine version" step.
+    `workflow_run` is an externally-influenced event trigger, and branch
+    or tag names can carry shell metacharacters. Rebound both
+    `head_branch` and the `workflow_dispatch` `inputs.tag` value to step-
+    level `env:` entries (`EVENT_BRANCH`, `INPUT_TAG`) and reference them
+    as shell variables — the canonical Actions security pattern.
+  - **CodeQL scope.** Added `.github/codeql/codeql-config.yml` with a
+    `paths-ignore` list (`vcpkg_installed/**`, `build-*/**`,
+    `builddir*/**`, `_build/**`) and wired it into the `codeql-action/init`
+    step via `config-file:`. Previously the scan indexed every header
+    under `vcpkg_installed/x64-linux/include/` — protobuf, abseil,
+    httplib — producing one "critical" (protobuf `map.h`) + six "high"
+    (abseil `raw_hash_set.h`, protobuf tctable, httplib `non-https-url`)
+    findings that are upstream-vendor bugs we cannot fix in-tree and
+    would be erased by the next vcpkg cache rebuild. Excluding them
+    collapses the noise and leaves first-party findings visible.
+
 - **Isolate `yuzu_gw_real_upstream_SUITE` from CI's gateway CT discovery.**
   The suite needs a live `yuzu-server` reachable on `127.0.0.1:50055`
   AND `YUZU_GW_TEST_TOKEN` set (or `scripts/linux-start-UAT.sh` to have


### PR DESCRIPTION
## Summary

First real remediations from the CodeQL + Scorecard findings surfaced by last week's security-tooling lift.

- **Closes CodeQL critical alert #8** — `actions/code-injection/critical` on `.github/workflows/pre-release.yml:49`. The "Determine version" step interpolated `${{ github.event.workflow_run.head_branch }}` and `${{ inputs.tag }}` directly into its bash `run:` block. `workflow_run` is externally influenced and branch/tag names can carry shell metacharacters. Rebinds both values to step-level `env:` entries (`EVENT_BRANCH`, `INPUT_TAG`) and references them as `"$EVENT_BRANCH"` / `"$INPUT_TAG"` — the canonical Actions security pattern.
- **Scopes CodeQL to first-party code.** Adds `.github/codeql/codeql-config.yml` with `paths-ignore` for `vcpkg_installed/**`, `build-*/**`, `builddir*/**`, `_build/**`, wired into the `codeql-action/init` step via `config-file`. Clears 1 critical + 6 high alerts that were all in vendored headers (protobuf `map.h`, abseil `raw_hash_set.h`, protobuf tctable, httplib `non-https-url`) — upstream-vendor findings we cannot fix in-tree and would be erased by the next vcpkg cache rebuild.
- **CHANGELOG** entry under Unreleased / Changed.

After this, the remaining CodeQL signal drops to a small number of first-party `actions/unpinned-tag` mediums across workflows — those get swept up in the next Scorecard lift PR, not here.

## Test plan

- [x] CodeQL workflow dispatches cleanly against this branch (re-scan picks up the new `config-file:` and the `paths-ignore`).
- [x] `pre-release.yml` workflow-dispatches on an existing tag and the "Determine version" step reports the expected `tag=` / `version=` in its output (env-var indirection unchanged behaviour).
- [ ] After merge, confirm CodeQL alert #8 auto-closes on next analysis run against dev; confirm the 1 critical + 6 high vendored-dep alerts (protobuf / abseil / httplib) auto-close as dismissed-out-of-scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)