### PR TITLE
ci: dedup push + pull_request events on feature/fix branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,12 @@
 name: CI
 
 on:
+  # push fires only on mainline branches (merges into dev/main) so feature/
+  # fix branches with an open PR run CI exactly once via pull_request rather
+  # than the previous duplicate (push + pull_request). For pre-PR feature
+  # work, open the PR earlier or use workflow_dispatch.
   push:
-    branches: [main, dev, "feature/**", "fix/**"]
+    branches: [main, dev]
     paths-ignore:
       - 'docs/**'
       - '*.md'

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -4,8 +4,10 @@ name: Docs Lint
 # markdown-only changes (which ci.yml deliberately skips via paths-ignore).
 # Keep this workflow fast and dependency-light — no build, no vcpkg, no caches.
 on:
+  # push fires only on mainline branches; feature/fix branches with an open
+  # PR run docs lint exactly once via pull_request. Mirrors ci.yml.
   push:
-    branches: [main, dev, "feature/**", "fix/**"]
+    branches: [main, dev]
     paths:
       - 'CHANGELOG.md'
       - 'docs/**'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CI dedup: drop `feature/**` and `fix/**` from the `push:` triggers in
+  `ci.yml` and `docs-lint.yml`.** Pushes to feature/fix branches with an
+  open PR previously fired both the `push` and `pull_request` events on
+  the same SHA, doubling runner consumption for every commit pushed to a
+  PR branch. Mainline branches (`main`, `dev`) remain on the `push:`
+  list so merge runs still fire exactly once. Pre-PR work (no PR open
+  yet) no longer runs CI automatically — open the PR earlier or use the
+  existing `workflow_dispatch` trigger to fire it manually.
+
 - **Digest-pin Dockerfile `FROM` lines, replace `curl | sh` installers,
   and hash-pin `requirements-ci.txt` (PR #3 of Scorecard lift).**
   Completes Scorecard's `Pinned-Dependencies` check — the remaining


### PR DESCRIPTION
## Summary

- `ci.yml` and `docs-lint.yml` had `push: branches: [main, dev, "feature/**", "fix/**"]` alongside `pull_request: branches: [main, dev]`. A push to a `feature/` or `fix/` branch with an open PR fired BOTH workflows on the same SHA, doubling runner consumption per commit on every PR branch.
- Drop `feature/**` and `fix/**` from the `push:` list in both workflows. Mainline branches (`main`, `dev`) stay on `push:` so merge runs still fire exactly once. PRs fire CI exactly once via `pull_request`.
- Pre-PR feature work no longer runs CI automatically — open the PR earlier, or use the existing `workflow_dispatch` trigger to fire it manually.

## Verified case

PR #471 (sibling branch `fix/codeql-pre-release-injection`) showed the duplicate at SHA `09dc7a1`:
- `event: push` at `05:02:46Z` → CI + Docs Lint
- `event: pull_request` at `05:03:05Z` → CI + Docs Lint + Zizmor

After this change, the same push would fire only the `pull_request` runs.

## Test plan

- [ ] Confirm PR triggers CI + Docs Lint exactly once each on this branch's PR.
- [ ] Push a no-op commit to this branch (after PR is open) and confirm only `pull_request` event fires, not `push`.
- [ ] Verify direct merges into `dev` still fire CI + Docs Lint via `push:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)