### PR TITLE
feat(guardian): PR 2 — REST control plane + agent GuardianEngine skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Guardian PR 2 — REST control plane + agent-side `GuardianEngine`
+  skeleton.** Stands up the operator-facing surface and the agent
+  scaffolding the rest of the Windows-first rollout grafts onto. No real
+  guards are running yet; PR 3 lands the Registry Guard + state evaluator
+  + remediation that turns the wire path into actual enforcement.
+  - **Server REST endpoints under `/api/v1/guaranteed-state/*`.** Full CRUD
+    on rules (`GET / POST / GET :id / PUT :id / DELETE :id`) plus `POST
+    /push` (returns `202 Accepted` — fan-out is PR 3), `GET /events`
+    (paginated query mirroring `audit_store` semantics; `limit` capped at
+    1000 at the REST boundary), `GET /status`, `GET /status/:agent_id`,
+    and `GET /alerts`. Conflict detection routes through `kConflictPrefix`
+    → HTTP 409 (matching #396/#399/#402). Created/updated rules carry the
+    session principal in `created_by` / `updated_by`. Every mutating route
+    fires an audit event under target type `GuaranteedState`.
+  - **New RBAC operation `Push` + securable type `GuaranteedState`.**
+    Distributes a rule set to scoped agents — separated from `Write` so
+    operators can be granted "deploy existing rules" without "author new
+    rules." Default seeds: `Operator` gets `Read + Push`,
+    `PlatformEngineer` gets full CRUD + `Push`, `Administrator` and
+    `ITServiceOwner` get the cross-type defaults, `Viewer` gets `Read`.
+    The cross-type `Push` grants on non-Guardian securables are harmless
+    because only the Guardian REST handlers consult `Push`.
+  - **Agent-side `GuardianEngine` class** (`agents/core/src/guardian_engine.{hpp,cpp}`).
+    Two-phase startup per design §4: `start_local()` runs pre-network so
+    the engine is enforcing before the Register RPC opens; `sync_with_server()`
+    runs post-Register and is the future drain point for buffered events.
+    Persists rules into `KvStore` under reserved namespace `__guardian__`
+    as JSON (binary-safe across the SQLite text APIs `KvStore` wraps).
+    `dispatch()` answers `__guard__` plugin commands `push_rules` and
+    `get_status`; reserved-name dispatch is intercepted in `agent.cpp`
+    *before* the plugin match loop so a third-party plugin cannot shadow
+    Guardian (defence-in-depth alongside the load-time reservation that
+    landed in #453). PR 2 reports every rule as `errored` because no
+    guards are running yet — honest about "Guardian installed but inert"
+    until PR 3.
+  - **`TestRouteSink` parses query strings.** The test sink now splits
+    request paths on `?` and feeds the tail to `httplib::detail::`
+    `parse_query_text`, populating `req.params`. This unblocks unit-level
+    coverage of every existing handler that branches on `req.has_param`
+    / `req.get_param_value` (the `events` query parameters were the
+    forcing function). Out-of-scope for the PR but a free win for any
+    follow-up REST test.
+
 - **Guardian: agent rejects plugins declaring a reserved internal-dispatch
   name (#453).** The agent plugin loader now refuses to load any plugin whose
   `YuzuPluginDescriptor::name` matches the reserved set `__guard__`,
@@ -346,6 +389,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   name, batch `insert_events` happy path + transactional rollback on
   mid-batch collision, `created_by` / `updated_by` round-trip, and TTL
   reaper delete mechanics (including `retention_days=0` sentinel).
+- Added `tests/unit/test_guardian_engine.cpp` (13 cases, 79 assertions)
+  for the agent-side `GuardianEngine` ingest contract: `apply_rules`
+  persists rules + bumps generation, `full_sync` wipes the prior set,
+  delta merge keeps prior rules and updates overlap, empty `rule_id` is
+  skipped, `dispatch` round-trips `push_rules` through proto
+  `SerializeAsString`, `dispatch get_status` returns a serialised
+  `GuaranteedStateStatus`, missing `push` parameter / garbage proto map
+  to distinct exit codes, rule cache + `policy_generation` survive an
+  in-process engine reconstruct against the same `KvStore`, null-`KvStore`
+  construction degrades gracefully, and post-`stop()` `apply_rules`
+  fails. Bumps the agent test suite's `agent_test_exe` deps with
+  `yuzu_proto_dep` (the test constructs proto messages directly).
+- Added `tests/unit/server/test_rest_guaranteed_state.cpp` (11 cases,
+  88 assertions) for the `/api/v1/guaranteed-state/*` REST surface:
+  `201` on create with `rule_id` echoed, `400` on missing required
+  fields, `409` mapping from `kConflictPrefix` for duplicate name, full
+  list/get/update/delete round-trip with version bump, `404` on unknown
+  ids with denied-audit, `202` on `/push` with rule count + scope in the
+  audit detail, `events` filter + `limit` pagination, `400` on invalid
+  `limit`, `status` rollup, and `alerts` placeholder. Built against the
+  in-process `TestRouteSink` (no live `httplib::Server`, no #438 TSan
+  trap).
+- Updated `tests/unit/server/test_rbac_store.cpp`: bumped securable-type
+  count to 19, operations count to 6, `Administrator` perms to 114 (19
+  × 6), `Viewer` to 18, and `ITServiceOwner` to 96 (16 × 6) — all
+  knock-ons from adding the `GuaranteedState` securable type and the
+  `Push` operation seeded for PR 2.
 
 ## [0.11.0] - 2026-04-17
 

--- a/agents/core/include/yuzu/agent/guardian_engine.hpp
+++ b/agents/core/include/yuzu/agent/guardian_engine.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+/**
+ * guardian_engine.hpp — Agent-side engine for the Yuzu Guardian (Guaranteed
+ * State) policy loop. See docs/yuzu-guardian-design-v1.1.md.
+ *
+ * This is the PR 2 skeleton: the engine accepts push_rules / get_status
+ * commands over the `__guard__` dispatch hook and persists rule state into
+ * the agent's KvStore under the reserved namespace "__guardian__". No
+ * guard processes are spawned yet — that lands in PR 3.
+ *
+ * Two-phase startup (design §4 — pre-login activation):
+ *   start_local()        — open persistent state, load cached rules;
+ *                          safe to call before the Register RPC.
+ *   sync_with_server()   — mark the engine network-connected; a future PR
+ *                          will drain the buffered-event queue here.
+ */
+
+#include <yuzu/plugin.h>
+
+#include <cstdint>
+#include <expected>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace yuzu::agent {
+class KvStore;
+}
+
+namespace yuzu::guardian::v1 {
+class GuaranteedStatePush;
+class GuaranteedStateRule;
+class GuaranteedStateStatus;
+} // namespace yuzu::guardian::v1
+
+namespace yuzu::agent::v1 {
+class CommandRequest;
+} // namespace yuzu::agent::v1
+
+namespace yuzu::agent {
+
+/// Result of dispatching a `__guard__` command. The caller (agent.cpp)
+/// converts this into a CommandResponse on the bidi stream.
+struct GuardianDispatchResult {
+    int exit_code{0};                 ///< 0 = success, non-zero = failure
+    std::string output;               ///< payload — serialized proto on success, error detail otherwise
+    std::string content_type;         ///< "proto" for SerializeAsString output, "text" otherwise
+};
+
+/// Engine lifecycle and dispatch surface. PR 2 scope: persist rules,
+/// answer status queries, ignore everything else. Thread-safe — the
+/// internal mutex serialises apply_rules / dispatch / get_status.
+class YUZU_EXPORT GuardianEngine {
+public:
+    /// The KvStore pointer may be null at construction (e.g. KV open
+    /// failed). All subsequent methods degrade to soft failures with
+    /// error strings rather than crashing — matches the agent's
+    /// existing "KV unavailable is a warning, not a fatal" posture.
+    GuardianEngine(KvStore* kv, std::string agent_id);
+    ~GuardianEngine();
+
+    GuardianEngine(const GuardianEngine&) = delete;
+    GuardianEngine& operator=(const GuardianEngine&) = delete;
+
+    /// Phase 1 startup (pre-network). Loads cached rules from KvStore
+    /// into the in-memory count cache so get_status() is cheap.
+    std::expected<void, std::string> start_local();
+
+    /// Phase 2 startup (post-Register). No-op in PR 2 — PR 4 uses this
+    /// to drain a buffered-events queue over the command stream.
+    void sync_with_server();
+
+    /// Idempotent shutdown. After stop() returns, dispatch() will
+    /// return a transient-failure result rather than touching KV.
+    void stop();
+
+    /// Replace (full_sync=true) or merge (full_sync=false) the active
+    /// rule set with the contents of `push`. Persists each rule as a
+    /// JSON blob under key "rule:<rule_id>". Returns the number of
+    /// rules applied on success, or an error detail string.
+    std::expected<std::size_t, std::string>
+    apply_rules(const yuzu::guardian::v1::GuaranteedStatePush& push);
+
+    /// Build a GuaranteedStateStatus reflecting currently cached rules.
+    /// All rules report status="compliant" in PR 2 because no guards
+    /// are running yet — the real status machine arrives with PR 3.
+    yuzu::guardian::v1::GuaranteedStateStatus get_status() const;
+
+    /// Entry point for `cmd.plugin() == "__guard__"`. Parses the
+    /// action + params and returns a DispatchResult ready to be
+    /// serialised into a CommandResponse by the caller.
+    GuardianDispatchResult dispatch(const yuzu::agent::v1::CommandRequest& cmd);
+
+    /// Number of rules currently persisted. Informational only.
+    std::size_t rule_count() const;
+
+    /// Current policy generation — monotonically increasing; bumped on
+    /// every successful apply_rules call. Persisted across restarts.
+    std::uint64_t policy_generation() const;
+
+    /// KV namespace used for all Guardian persistent state. Exposed for
+    /// tests — do not read from this namespace in production code.
+    static std::string_view kv_namespace();
+
+private:
+    KvStore* kv_;
+    std::string agent_id_;
+
+    mutable std::mutex mtx_;
+    bool started_{false};
+    bool stopped_{false};
+    std::uint64_t policy_generation_{0};
+    std::size_t rule_count_{0};
+
+    bool put_rule_locked(const yuzu::guardian::v1::GuaranteedStateRule& rule);
+    void refresh_count_locked();
+    void persist_generation_locked();
+};
+
+} // namespace yuzu::agent

--- a/agents/core/meson.build
+++ b/agents/core/meson.build
@@ -9,7 +9,7 @@ endif
 
 yuzu_agent_core_lib = shared_library(
   'yuzu_agent_core',
-  files('src/agent.cpp', 'src/cert_discovery.cpp', 'src/cert_store.cpp', 'src/cloud_identity.cpp', 'src/identity_store.cpp', 'src/kv_store.cpp', 'src/plugin_loader.cpp', 'src/process_enum.cpp', 'src/sdk_utilities.cpp', 'src/temp_file.cpp', 'src/trigger_engine.cpp', 'src/updater.cpp'),
+  files('src/agent.cpp', 'src/cert_discovery.cpp', 'src/cert_store.cpp', 'src/cloud_identity.cpp', 'src/guardian_engine.cpp', 'src/identity_store.cpp', 'src/kv_store.cpp', 'src/plugin_loader.cpp', 'src/process_enum.cpp', 'src/sdk_utilities.cpp', 'src/temp_file.cpp', 'src/trigger_engine.cpp', 'src/updater.cpp'),
   include_directories: [
     include_directories('include'),
     include_directories('../../sdk/include'),

--- a/agents/core/src/agent.cpp
+++ b/agents/core/src/agent.cpp
@@ -12,6 +12,7 @@ __declspec(allocate(".CRT$XCB")) static void(__cdecl* p_dll_diag)() = diag_dll_s
 #include <yuzu/agent/cert_discovery.hpp>
 #include <yuzu/agent/cert_store.hpp>
 #include <yuzu/agent/cloud_identity.hpp>
+#include <yuzu/agent/guardian_engine.hpp>
 #include <yuzu/agent/kv_store.hpp>
 #include <yuzu/agent/plugin_loader.hpp>
 #include <yuzu/agent/trigger_engine.hpp>
@@ -449,6 +450,16 @@ public:
             }
         }
 
+        // 1c. Initialise the Guardian engine (Phase 1 startup, pre-network).
+        // The engine persists rules into the KV store and answers __guard__
+        // dispatches once the Subscribe stream is open. Construction is
+        // safe even when KV failed to open (it degrades to in-memory only).
+        guardian_ = std::make_unique<GuardianEngine>(kv_store_.get(), cfg_.agent_id);
+        if (auto r = guardian_->start_local(); !r) {
+            spdlog::warn("Guardian engine start_local failed: {} — continuing without Guardian",
+                         r.error());
+        }
+
         // Record start time for uptime calculation
         auto start_epoch = std::chrono::duration_cast<std::chrono::seconds>(
                                std::chrono::system_clock::now().time_since_epoch())
@@ -812,6 +823,11 @@ public:
             }
             spdlog::info("Registered with server (session={}, enrollment={})", session_id_,
                          enrollment_status.empty() ? "enrolled" : enrollment_status);
+
+            // Mark Guardian as network-connected. PR 4 will use this hook to
+            // drain a buffered-events queue back over the command stream.
+            if (guardian_)
+                guardian_->sync_with_server();
         }
 
         // 3b. OTA updater: rollback check and old binary cleanup
@@ -981,6 +997,37 @@ public:
 
                 spdlog::info("Received command: plugin={}, action={}, id={}", cmd.plugin(),
                              cmd.action(), cmd.command_id());
+
+                // Reserved-name dispatch — must run before the plugin match
+                // loop so a third-party plugin cannot shadow Guardian (the
+                // load-time check in plugin_loader.cpp also rejects reserved
+                // names, but defence-in-depth keeps both halves explicit).
+                // See docs/yuzu-guardian-design-v1.1.md §7.2.
+                if (cmd.plugin() == "__guard__") {
+                    pb::CommandResponse resp;
+                    resp.set_command_id(cmd.command_id());
+                    auto epoch_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                        std::chrono::system_clock::now().time_since_epoch())
+                                        .count();
+                    resp.mutable_sent_at()->set_millis_epoch(epoch_ms);
+                    if (!guardian_) {
+                        resp.set_status(pb::CommandResponse::FAILURE);
+                        resp.set_exit_code(1);
+                        resp.set_output("guardian engine not initialised");
+                    } else {
+                        auto dr = guardian_->dispatch(cmd);
+                        resp.set_status(dr.exit_code == 0 ? pb::CommandResponse::SUCCESS
+                                                          : pb::CommandResponse::FAILURE);
+                        resp.set_exit_code(dr.exit_code);
+                        resp.set_output(std::move(dr.output));
+                    }
+                    metrics_.counter("yuzu_agent_commands_executed_total",
+                                     {{"plugin", "__guard__"}})
+                        .increment();
+                    std::lock_guard lock(stream_write_mu_);
+                    stream->Write(resp, grpc::WriteOptions());
+                    continue;
+                }
 
                 // Find the matching plugin
                 const YuzuPluginDescriptor* target = nullptr;
@@ -1183,6 +1230,8 @@ public:
     void stop() noexcept override {
         stop_requested_.store(true, std::memory_order_release);
         heartbeat_stop_.store(true, std::memory_order_release);
+        if (guardian_)
+            guardian_->stop();
         if (updater_)
             updater_->stop();
         // Cancel the Subscribe stream to unblock the Read() call
@@ -1207,6 +1256,7 @@ private:
     // pointers remain stable after map insertions.
     std::unordered_map<std::string, std::unique_ptr<PluginContextImpl>> per_plugin_ctx_;
     std::unique_ptr<KvStore> kv_store_;
+    std::unique_ptr<GuardianEngine> guardian_;
     yuzu::MetricsRegistry metrics_;
     std::chrono::steady_clock::time_point start_time_;
     std::string session_id_;

--- a/agents/core/src/guardian_engine.cpp
+++ b/agents/core/src/guardian_engine.cpp
@@ -1,0 +1,338 @@
+/**
+ * guardian_engine.cpp — see guardian_engine.hpp.
+ *
+ * PR 2 scope: persistence + dispatch only. The engine speaks the wire
+ * protocol from `__guard__` commands (push_rules, get_status), serialises
+ * rule state into the agent's KvStore as JSON, and reports a pessimistic
+ * "all rules compliant" status because no guards are running yet.
+ *
+ * Rule persistence layout (under KvStore namespace "__guardian__"):
+ *   key="rule:<rule_id>"    — JSON blob of the rule (yaml_source + denorm fields)
+ *   key="meta:policy_generation" — monotonically increasing uint64 (decimal text)
+ *
+ * The store is JSON, not SerializeAsString, because KvStore wraps the
+ * value in sqlite3_bind_text + sqlite3_column_text — both APIs treat the
+ * payload as a NUL-terminated C string and would truncate any embedded
+ * null byte that proto wire-format readily produces. JSON is binary-safe
+ * over those APIs and matches the storage style used by the rest of the
+ * agent codebase.
+ */
+
+#include <yuzu/agent/guardian_engine.hpp>
+#include <yuzu/agent/kv_store.hpp>
+
+#include "agent.grpc.pb.h"
+#include "guaranteed_state.pb.h"
+
+#include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <charconv>
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace yuzu::agent {
+
+namespace {
+
+namespace gpb = ::yuzu::guardian::v1;
+namespace apb = ::yuzu::agent::v1;
+
+constexpr std::string_view kKvNamespace = "__guardian__";
+constexpr std::string_view kRulePrefix  = "rule:";
+constexpr std::string_view kKeyGen      = "meta:policy_generation";
+
+constexpr std::string_view kActionPushRules = "push_rules";
+constexpr std::string_view kActionGetStatus = "get_status";
+
+constexpr std::string_view kParamPush = "push";
+
+std::string hex_encode(const std::string& bytes) {
+    static constexpr char kHex[] = "0123456789abcdef";
+    std::string out;
+    out.reserve(bytes.size() * 2);
+    for (unsigned char c : bytes) {
+        out += kHex[c >> 4];
+        out += kHex[c & 0xF];
+    }
+    return out;
+}
+
+std::string hex_decode(std::string_view hex) {
+    if (hex.size() % 2 != 0)
+        return {};
+    auto from_hex = [](char c) -> int {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        return -1;
+    };
+    std::string out;
+    out.reserve(hex.size() / 2);
+    for (std::size_t i = 0; i < hex.size(); i += 2) {
+        int hi = from_hex(hex[i]);
+        int lo = from_hex(hex[i + 1]);
+        if (hi < 0 || lo < 0)
+            return {};
+        out += static_cast<char>((hi << 4) | lo);
+    }
+    return out;
+}
+
+nlohmann::json rule_to_json(const gpb::GuaranteedStateRule& r) {
+    nlohmann::json j;
+    j["rule_id"]          = r.rule_id();
+    j["name"]             = r.name();
+    j["yaml_source"]      = r.yaml_source();
+    j["version"]          = static_cast<std::uint64_t>(r.version());
+    j["enabled"]          = r.enabled();
+    j["enforcement_mode"] = r.enforcement_mode();
+    if (!r.signature().empty())
+        j["signature_hex"] = hex_encode(r.signature());
+    return j;
+}
+
+bool json_to_rule(const nlohmann::json& j, gpb::GuaranteedStateRule& out) {
+    if (!j.is_object()) return false;
+    out.set_rule_id(j.value("rule_id", std::string{}));
+    out.set_name(j.value("name", std::string{}));
+    out.set_yaml_source(j.value("yaml_source", std::string{}));
+    out.set_version(j.value("version", std::uint64_t{0}));
+    out.set_enabled(j.value("enabled", false));
+    out.set_enforcement_mode(j.value("enforcement_mode", std::string{}));
+    if (j.contains("signature_hex"))
+        out.set_signature(hex_decode(j["signature_hex"].get<std::string>()));
+    return !out.rule_id().empty();
+}
+
+std::string make_rule_key(std::string_view rule_id) {
+    std::string k(kRulePrefix);
+    k.append(rule_id);
+    return k;
+}
+
+} // namespace
+
+GuardianEngine::GuardianEngine(KvStore* kv, std::string agent_id)
+    : kv_{kv}, agent_id_{std::move(agent_id)} {}
+
+GuardianEngine::~GuardianEngine() = default;
+
+std::string_view GuardianEngine::kv_namespace() {
+    return kKvNamespace;
+}
+
+std::expected<void, std::string> GuardianEngine::start_local() {
+    std::lock_guard lock(mtx_);
+    if (started_) return {};
+    started_ = true;
+    stopped_ = false;
+
+    if (!kv_) {
+        spdlog::warn("Guardian: KV store unavailable — rule cache will be in-memory only "
+                     "(survives only the current process lifetime)");
+        return {};
+    }
+
+    refresh_count_locked();
+
+    if (auto raw = kv_->get(kKvNamespace, kKeyGen); raw.has_value()) {
+        std::uint64_t parsed = 0;
+        const auto& s = *raw;
+        auto [_, ec] = std::from_chars(s.data(), s.data() + s.size(), parsed);
+        if (ec == std::errc{})
+            policy_generation_ = parsed;
+    }
+
+    spdlog::info("Guardian engine started (cached_rules={}, policy_generation={})",
+                 rule_count_, policy_generation_);
+    return {};
+}
+
+void GuardianEngine::sync_with_server() {
+    std::lock_guard lock(mtx_);
+    if (!started_) {
+        spdlog::warn("Guardian: sync_with_server called before start_local — ignoring");
+        return;
+    }
+    spdlog::info("Guardian engine network-connected (policy_generation={}, rules={})",
+                 policy_generation_, rule_count_);
+}
+
+void GuardianEngine::stop() {
+    std::lock_guard lock(mtx_);
+    stopped_ = true;
+    started_ = false;
+}
+
+std::expected<std::size_t, std::string>
+GuardianEngine::apply_rules(const gpb::GuaranteedStatePush& push) {
+    std::lock_guard lock(mtx_);
+    if (stopped_)
+        return std::unexpected("guardian engine stopped");
+    if (!kv_)
+        return std::unexpected("kv store unavailable");
+
+    if (push.full_sync()) {
+        const int cleared = kv_->clear(kKvNamespace);
+        if (cleared > 0)
+            spdlog::info("Guardian: full_sync cleared {} prior rule(s)", cleared);
+        // Re-persist the policy generation marker after clear() wiped everything.
+        persist_generation_locked();
+    }
+
+    std::size_t applied = 0;
+    for (const auto& rule : push.rules()) {
+        if (rule.rule_id().empty()) {
+            spdlog::warn("Guardian: skipping rule with empty rule_id (name={})", rule.name());
+            continue;
+        }
+        if (!put_rule_locked(rule)) {
+            return std::unexpected("failed to persist rule '" + rule.rule_id() + "'");
+        }
+        ++applied;
+    }
+
+    if (push.policy_generation() > policy_generation_) {
+        policy_generation_ = push.policy_generation();
+        persist_generation_locked();
+    }
+
+    refresh_count_locked();
+    spdlog::info("Guardian: apply_rules ok (applied={}, full_sync={}, generation={}, total={})",
+                 applied, push.full_sync(), policy_generation_, rule_count_);
+    return applied;
+}
+
+gpb::GuaranteedStateStatus GuardianEngine::get_status() const {
+    std::lock_guard lock(mtx_);
+    gpb::GuaranteedStateStatus status;
+    status.set_agent_id(agent_id_);
+    status.set_policy_generation(policy_generation_);
+    status.set_total_rules(static_cast<std::uint32_t>(rule_count_));
+
+    // PR 2 has no real evaluator yet — be honest about that. Every rule is
+    // reported with status="errored" because we cannot prove compliance
+    // without a guard running. Dashboards then surface this as "Guardian
+    // installed but inert," matching the PR 2 reality. PR 3 replaces this
+    // with real per-guard health.
+    status.set_compliant_rules(0);
+    status.set_drifted_rules(0);
+    status.set_errored_rules(static_cast<std::uint32_t>(rule_count_));
+
+#if defined(_WIN32)
+    status.set_platform("windows");
+#elif defined(__APPLE__)
+    status.set_platform("macos");
+#else
+    status.set_platform("linux");
+#endif
+
+    if (kv_) {
+        for (const auto& key : kv_->list(kKvNamespace, kRulePrefix)) {
+            auto raw = kv_->get(kKvNamespace, key);
+            if (!raw) continue;
+            gpb::GuaranteedStateRule rule;
+            try {
+                auto parsed = nlohmann::json::parse(*raw);
+                if (!json_to_rule(parsed, rule))
+                    continue;
+            } catch (const nlohmann::json::exception&) {
+                continue;
+            }
+            auto* row = status.add_rules();
+            row->set_rule_id(rule.rule_id());
+            row->set_status("errored");
+            row->set_guard_category("event");
+            row->set_guard_healthy(false);
+            row->set_notifications_total(0);
+        }
+    }
+    return status;
+}
+
+GuardianDispatchResult GuardianEngine::dispatch(const apb::CommandRequest& cmd) {
+    GuardianDispatchResult res;
+
+    if (cmd.action() == kActionPushRules) {
+        const auto& params = cmd.parameters();
+        auto it = params.find(std::string{kParamPush});
+        if (it == params.end()) {
+            res.exit_code = 1;
+            res.content_type = "text";
+            res.output = "missing 'push' parameter (expected serialized GuaranteedStatePush)";
+            return res;
+        }
+        gpb::GuaranteedStatePush push;
+        // proto map<string,string> stores the value as a std::string with
+        // exact length — binary-safe across embedded NUL bytes, unlike a
+        // C-string round trip.
+        if (!push.ParseFromString(it->second)) {
+            res.exit_code = 2;
+            res.content_type = "text";
+            res.output = "failed to parse GuaranteedStatePush proto";
+            return res;
+        }
+        auto applied = apply_rules(push);
+        if (!applied) {
+            res.exit_code = 3;
+            res.content_type = "text";
+            res.output = applied.error();
+            return res;
+        }
+        res.exit_code = 0;
+        res.content_type = "text";
+        res.output = "applied=" + std::to_string(*applied) +
+                     " generation=" + std::to_string(policy_generation()) +
+                     " total=" + std::to_string(rule_count());
+        return res;
+    }
+
+    if (cmd.action() == kActionGetStatus) {
+        auto status = get_status();
+        res.exit_code = 0;
+        res.content_type = "proto";
+        res.output = status.SerializeAsString();
+        return res;
+    }
+
+    res.exit_code = 4;
+    res.content_type = "text";
+    res.output = "unknown __guard__ action: " + cmd.action();
+    return res;
+}
+
+std::size_t GuardianEngine::rule_count() const {
+    std::lock_guard lock(mtx_);
+    return rule_count_;
+}
+
+std::uint64_t GuardianEngine::policy_generation() const {
+    std::lock_guard lock(mtx_);
+    return policy_generation_;
+}
+
+bool GuardianEngine::put_rule_locked(const gpb::GuaranteedStateRule& rule) {
+    if (!kv_) return false;
+    auto j = rule_to_json(rule).dump();
+    return kv_->set(kKvNamespace, make_rule_key(rule.rule_id()), j);
+}
+
+void GuardianEngine::refresh_count_locked() {
+    if (!kv_) {
+        rule_count_ = 0;
+        return;
+    }
+    rule_count_ = kv_->list(kKvNamespace, kRulePrefix).size();
+}
+
+void GuardianEngine::persist_generation_locked() {
+    if (!kv_) return;
+    kv_->set(kKvNamespace, kKeyGen, std::to_string(policy_generation_));
+}
+
+} // namespace yuzu::agent

--- a/agents/core/src/guardian_engine.cpp
+++ b/agents/core/src/guardian_engine.cpp
@@ -31,7 +31,6 @@
 #include <charconv>
 #include <chrono>
 #include <cstdint>
-#include <cstdio>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -272,34 +271,12 @@ GuardianDispatchResult GuardianEngine::dispatch(const apb::CommandRequest& cmd) 
         // proto map<string,string> stores the value as a std::string with
         // exact length — binary-safe across embedded NUL bytes, unlike a
         // C-string round trip.
-        // TEMP DIAGNOSTIC (remove after #473 MSVC test failure fixed):
-        // Dump wire-byte length + first/last bytes to distinguish "map value
-        // was truncated" from "ParseFromString lost fields". Remove once
-        // the Windows-only test_guardian_engine.cpp:212-214 failures are
-        // understood.
-        const std::string& wire = it->second;
-        std::string first_hex, last_hex;
-        for (std::size_t i = 0; i < wire.size() && i < 16; ++i) {
-            char b[4];
-            std::snprintf(b, sizeof(b), "%02x ", static_cast<unsigned char>(wire[i]));
-            first_hex += b;
-        }
-        for (std::size_t i = (wire.size() > 16 ? wire.size() - 16 : 0); i < wire.size(); ++i) {
-            char b[4];
-            std::snprintf(b, sizeof(b), "%02x ", static_cast<unsigned char>(wire[i]));
-            last_hex += b;
-        }
-        spdlog::info("Guardian DIAG: push wire bytes={}  head=[{}]  tail=[{}]",
-                     wire.size(), first_hex, last_hex);
         if (!push.ParseFromString(it->second)) {
             res.exit_code = 2;
             res.content_type = "text";
             res.output = "failed to parse GuaranteedStatePush proto";
             return res;
         }
-        spdlog::info("Guardian DIAG: push parsed full_sync={} policy_generation={} rules_count={}",
-                     push.full_sync(), push.policy_generation(),
-                     static_cast<int>(push.rules_size()));
         auto applied = apply_rules(push);
         if (!applied) {
             res.exit_code = 3;

--- a/agents/core/src/guardian_engine.cpp
+++ b/agents/core/src/guardian_engine.cpp
@@ -31,6 +31,7 @@
 #include <charconv>
 #include <chrono>
 #include <cstdint>
+#include <cstdio>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -271,12 +272,34 @@ GuardianDispatchResult GuardianEngine::dispatch(const apb::CommandRequest& cmd) 
         // proto map<string,string> stores the value as a std::string with
         // exact length — binary-safe across embedded NUL bytes, unlike a
         // C-string round trip.
+        // TEMP DIAGNOSTIC (remove after #473 MSVC test failure fixed):
+        // Dump wire-byte length + first/last bytes to distinguish "map value
+        // was truncated" from "ParseFromString lost fields". Remove once
+        // the Windows-only test_guardian_engine.cpp:212-214 failures are
+        // understood.
+        const std::string& wire = it->second;
+        std::string first_hex, last_hex;
+        for (std::size_t i = 0; i < wire.size() && i < 16; ++i) {
+            char b[4];
+            std::snprintf(b, sizeof(b), "%02x ", static_cast<unsigned char>(wire[i]));
+            first_hex += b;
+        }
+        for (std::size_t i = (wire.size() > 16 ? wire.size() - 16 : 0); i < wire.size(); ++i) {
+            char b[4];
+            std::snprintf(b, sizeof(b), "%02x ", static_cast<unsigned char>(wire[i]));
+            last_hex += b;
+        }
+        spdlog::info("Guardian DIAG: push wire bytes={}  head=[{}]  tail=[{}]",
+                     wire.size(), first_hex, last_hex);
         if (!push.ParseFromString(it->second)) {
             res.exit_code = 2;
             res.content_type = "text";
             res.output = "failed to parse GuaranteedStatePush proto";
             return res;
         }
+        spdlog::info("Guardian DIAG: push parsed full_sync={} policy_generation={} rules_count={}",
+                     push.full_sync(), push.policy_generation(),
+                     static_cast<int>(push.rules_size()));
         auto applied = apply_rules(push);
         if (!applied) {
             res.exit_code = 3;

--- a/scripts/windows-runner-defender-exclusions.ps1
+++ b/scripts/windows-runner-defender-exclusions.ps1
@@ -1,0 +1,128 @@
+<#
+.SYNOPSIS
+    Apply the Windows Defender exclusion set required by the yuzu-local-windows
+    self-hosted GitHub Actions runner.
+
+.DESCRIPTION
+    Without these exclusions, Defender realtime-scans every file vcpkg
+    installs, every .obj MSVC writes, every file tar.exe extracts from
+    the vcpkg cache archive, and every SQLite temp DB the test suite
+    creates under C:\WINDOWS\SystemTemp. That scanning activity:
+
+      * stalls the release workflow's Build Windows x64 job until the
+        60-min timeout kills it (diagnosed 2026-04-18 during v0.11.0-rc1
+        — MsMpEng was running at 40.9% CPU during a stuck vcpkg cache
+        extraction);
+      * has been implicated in flaky Guardian engine unit tests where
+        SQLite write-then-list returns inconsistent results on the
+        Windows runner (observed on PR #473 Windows MSVC debug job
+        72502796929, passed on re-run without code changes once runner
+        load eased, with SystemTemp\yuzu_test_guardian_* not in the
+        exclusion list).
+
+    Re-running this script is idempotent — Defender deduplicates
+    exclusion entries.
+
+.NOTES
+    Run elevated (`powershell.exe -ExecutionPolicy Bypass`). Defender
+    persists the preference across reboots. Reversible with
+    Remove-MpPreference.
+
+    Source of record for the required set:
+        docs/build-windows-runner.md   (narrative)
+        scripts/windows-runner-defender-exclusions.ps1   (this script)
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$DryRun
+)
+
+# Require admin.
+$isAdmin = ([Security.Principal.WindowsPrincipal] `
+    [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+    [Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Write-Error "Run as Administrator (elevated PowerShell)."
+    exit 1
+}
+
+$paths = @(
+    # GitHub Actions runner workspace — covers vcpkg_installed, build
+    # output, ccache, and the `Cache vcpkg installed packages` step's
+    # tar/zstd extraction.
+    'C:\actions-runner\_work',
+
+    # MSVC ccache — out-of-tree by default on modern vcpkg.
+    (Join-Path $env:USERPROFILE 'AppData\Local\ccache'),
+
+    # SQLite test temp paths for the unit test suite. These are
+    # fs::temp_directory_path() resolved as LocalSystem (SystemTemp),
+    # not the interactive user's %TEMP%. The yuzu_test_* prefix
+    # covers all current stores (guardian, kv, updater, etc.).
+    'C:\WINDOWS\SystemTemp\yuzu_test_guardian',
+    'C:\WINDOWS\SystemTemp\yuzu_test_kv',
+    'C:\WINDOWS\SystemTemp\yuzu_test_updater_rollback_needed',
+    'C:\WINDOWS\SystemTemp\yuzu_test_updater_cleanup_present'
+)
+
+$processes = @(
+    # MSVC toolchain — one exclusion per binary that writes intermediate
+    # files frequently enough that Defender scanning visibly slows the
+    # build.
+    'cl.exe',
+    'link.exe',
+    'MSBuild.exe',
+    'ninja.exe',
+
+    # actions/cache extraction — tar unpacks ~25k files from the vcpkg
+    # archive and Defender scans each. This is the single biggest win.
+    'tar.exe',
+    'zstd.exe',
+
+    # ccache + vcpkg helpers.
+    'ccache.exe',
+    'vcpkg.exe'
+)
+
+function Add-ExclusionPath-Idempotent($p) {
+    $existing = (Get-MpPreference).ExclusionPath
+    if ($existing -contains $p) {
+        Write-Host "  [skip] path already excluded: $p"
+        return
+    }
+    if ($DryRun) {
+        Write-Host "  [dry] would add path: $p"
+    } else {
+        Add-MpPreference -ExclusionPath $p
+        Write-Host "  [add]  path: $p"
+    }
+}
+
+function Add-ExclusionProcess-Idempotent($proc) {
+    $existing = (Get-MpPreference).ExclusionProcess
+    if ($existing -contains $proc) {
+        Write-Host "  [skip] process already excluded: $proc"
+        return
+    }
+    if ($DryRun) {
+        Write-Host "  [dry] would add process: $proc"
+    } else {
+        Add-MpPreference -ExclusionProcess $proc
+        Write-Host "  [add]  process: $proc"
+    }
+}
+
+Write-Host "`n── Applying Defender path exclusions ───────────────────────" -ForegroundColor Cyan
+foreach ($p in $paths) { Add-ExclusionPath-Idempotent $p }
+
+Write-Host "`n── Applying Defender process exclusions ────────────────────" -ForegroundColor Cyan
+foreach ($proc in $processes) { Add-ExclusionProcess-Idempotent $proc }
+
+Write-Host "`n── Current Defender configuration (post-update) ────────────" -ForegroundColor Cyan
+Write-Host "ExclusionPath:"
+(Get-MpPreference).ExclusionPath | ForEach-Object { Write-Host "  $_" }
+Write-Host "ExclusionProcess:"
+(Get-MpPreference).ExclusionProcess | ForEach-Object { Write-Host "  $_" }
+
+Write-Host "`nDone. Reversible with Remove-MpPreference -ExclusionPath <path>."

--- a/server/core/src/rbac_store.cpp
+++ b/server/core/src/rbac_store.cpp
@@ -143,7 +143,8 @@ void RbacStore::seed_defaults() {
                            "DeviceToken",
                            "SoftwareDeployment",
                            "License",
-                           "FileRetrieval"};
+                           "FileRetrieval",
+                           "GuaranteedState"};
     for (auto* t : types) {
         sqlite3_stmt* s = nullptr;
         sqlite3_prepare_v2(db_,
@@ -154,8 +155,12 @@ void RbacStore::seed_defaults() {
         sqlite3_finalize(s);
     }
 
-    // Operations
-    const char* ops[] = {"Read", "Write", "Execute", "Delete", "Approve"};
+    // Operations. "Push" is Guardian-specific — distributes a rule set to
+    // scoped agents (design doc §9.2). The Administrator-grant loop below
+    // assigns it to every securable type by default; only the Guardian
+    // REST handlers actually consult Push, so the cross-type assignment
+    // is harmless.
+    const char* ops[] = {"Read", "Write", "Execute", "Delete", "Approve", "Push"};
     for (auto* o : ops) {
         sqlite3_stmt* s = nullptr;
         sqlite3_prepare_v2(db_, "INSERT OR IGNORE INTO operations (id, is_system) VALUES (?, 1);",
@@ -337,6 +342,35 @@ void RbacStore::seed_defaults() {
         "INSERT OR IGNORE INTO role_permissions VALUES ('Operator', 'FileRetrieval', 'Write', 'allow');",
         nullptr, nullptr, nullptr);
 
+    // Operator: read + push on GuaranteedState — they can distribute an
+    // existing rule set but cannot author or delete rules. Authoring is
+    // privileged and lives with PlatformEngineer / Administrator.
+    sqlite3_exec(
+        db_,
+        "INSERT OR IGNORE INTO role_permissions VALUES ('Operator', 'GuaranteedState', 'Read', 'allow');",
+        nullptr, nullptr, nullptr);
+    sqlite3_exec(
+        db_,
+        "INSERT OR IGNORE INTO role_permissions VALUES ('Operator', 'GuaranteedState', 'Push', 'allow');",
+        nullptr, nullptr, nullptr);
+
+    // PlatformEngineer: full CRUD + Push on GuaranteedState. Mirrors the
+    // pattern they have for InstructionDefinition — they author the rules
+    // and need to push the set to fleet for testing.
+    {
+        const char* gs_ops[] = {"Read", "Write", "Delete", "Push"};
+        for (auto* o : gs_ops) {
+            sqlite3_stmt* s = nullptr;
+            sqlite3_prepare_v2(db_,
+                               "INSERT OR IGNORE INTO role_permissions VALUES ('PlatformEngineer', "
+                               "'GuaranteedState', ?, 'allow');",
+                               -1, &s, nullptr);
+            sqlite3_bind_text(s, 1, o, -1, SQLITE_TRANSIENT);
+            sqlite3_step(s);
+            sqlite3_finalize(s);
+        }
+    }
+
     // ApiTokenManager: read + write + delete on ApiToken
     const char* atm_ops[] = {"Read", "Write", "Delete"};
     for (auto* o : atm_ops) {
@@ -367,7 +401,8 @@ void RbacStore::seed_defaults() {
                                 "DeviceToken",
                                 "SoftwareDeployment",
                                 "License",
-                                "FileRetrieval"};
+                                "FileRetrieval",
+                                "GuaranteedState"};
     for (auto* t : itso_types) {
         for (auto* o : ops) {
             sqlite3_stmt* s = nullptr;
@@ -399,7 +434,8 @@ void RbacStore::seed_defaults() {
                                   "DeviceToken",
                                   "SoftwareDeployment",
                                   "License",
-                                  "FileRetrieval"};
+                                  "FileRetrieval",
+                                  "GuaranteedState"};
     for (auto* t : viewer_types) {
         sqlite3_stmt* s = nullptr;
         sqlite3_prepare_v2(

--- a/server/core/src/rest_api_v1.cpp
+++ b/server/core/src/rest_api_v1.cpp
@@ -1,6 +1,7 @@
 #include "rest_api_v1.hpp"
 #include "http_route_sink.hpp"
 #include "inventory_eval.hpp"
+#include "store_errors.hpp"
 
 // nlohmann/json is retained ONLY for parsing request bodies (json::parse).
 // All response JSON is built via the lightweight JObj/JArr helpers below,
@@ -10,9 +11,13 @@
 #include <spdlog/spdlog.h>
 
 #include <algorithm>
+#include <charconv>
+#include <chrono>
 #include <cstdio>
+#include <ctime>
 #include <string>
 #include <string_view>
+#include <system_error>
 
 namespace yuzu::server {
 namespace {
@@ -368,14 +373,15 @@ void RestApiV1::register_routes(httplib::Server& svr, AuthFn auth_fn, PermFn per
                                 ProductPackStore* product_pack_store,
                                 SoftwareDeploymentStore* sw_deploy_store,
                                 DeviceTokenStore* device_token_store,
-                                LicenseStore* license_store) {
+                                LicenseStore* license_store,
+                                GuaranteedStateStore* guaranteed_state_store) {
     HttplibRouteSink sink(svr);
     register_routes(sink, std::move(auth_fn), std::move(perm_fn), std::move(audit_fn),
                     rbac_store, mgmt_store, token_store, quarantine_store, response_store,
                     instruction_store, execution_tracker, schedule_engine, approval_manager,
                     tag_store, audit_store, std::move(service_group_fn), std::move(tag_push_fn),
                     inventory_store, product_pack_store, sw_deploy_store, device_token_store,
-                    license_store);
+                    license_store, guaranteed_state_store);
 }
 
 void RestApiV1::register_routes(HttpRouteSink& sink, AuthFn auth_fn, PermFn perm_fn,
@@ -391,7 +397,8 @@ void RestApiV1::register_routes(HttpRouteSink& sink, AuthFn auth_fn, PermFn perm
                                 ProductPackStore* product_pack_store,
                                 SoftwareDeploymentStore* sw_deploy_store,
                                 DeviceTokenStore* device_token_store,
-                                LicenseStore* license_store) {
+                                LicenseStore* license_store,
+                                GuaranteedStateStore* guaranteed_state_store) {
 
     spdlog::info("REST API v1: registering routes");
 
@@ -1940,6 +1947,358 @@ void RestApiV1::register_routes(HttpRouteSink& sink, AuthFn auth_fn, PermFn perm
                     .str();
                 res.set_content(ok_json(data), "application/json");
             });
+
+    // ── Guardian / Guaranteed State (/api/v1/guaranteed-state) ────────────
+    // PR 2 of the Guardian Windows-first rollout. Endpoints follow design
+    // doc §9.2. RBAC securable type is "GuaranteedState" with operations
+    // Read/Write/Delete/Push (Push is a new op seeded by rbac_store).
+    //
+    // Re-parsing YAML for the denormalised columns is intentionally NOT
+    // done here — yaml-cpp is not a server-side dep. Callers pass severity
+    // / os_target / scope_expr alongside yaml_source in the JSON body
+    // (matches how `instruction_store` ingests YAML from the dashboard).
+
+    auto iso_now = []() {
+        auto now = std::chrono::system_clock::now();
+        std::time_t t = std::chrono::system_clock::to_time_t(now);
+        std::tm tm{};
+#if defined(_WIN32)
+        gmtime_s(&tm, &t);
+#else
+        gmtime_r(&t, &tm);
+#endif
+        char buf[32];
+        std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm);
+        return std::string(buf);
+    };
+
+    auto rule_to_jobj = [](const GuaranteedStateRuleRow& r) {
+        JObj o;
+        o.add("rule_id", r.rule_id)
+            .add("name", r.name)
+            .add("yaml_source", r.yaml_source)
+            .add("version", static_cast<int64_t>(r.version))
+            .add("enabled", r.enabled)
+            .add("enforcement_mode", r.enforcement_mode)
+            .add("severity", r.severity)
+            .add("os_target", r.os_target)
+            .add("scope_expr", r.scope_expr)
+            .add("created_at", r.created_at)
+            .add("updated_at", r.updated_at)
+            .add("created_by", r.created_by)
+            .add("updated_by", r.updated_by);
+        return o;
+    };
+
+    sink.Get("/api/v1/guaranteed-state/rules",
+        [perm_fn, guaranteed_state_store, rule_to_jobj](const httplib::Request& req,
+                                                         httplib::Response& res) {
+            if (!perm_fn(req, res, "GuaranteedState", "Read")) return;
+            if (!guaranteed_state_store) {
+                res.status = 503;
+                res.set_content(error_json("guaranteed-state store unavailable", 503),
+                                "application/json");
+                return;
+            }
+            auto rows = guaranteed_state_store->list_rules();
+            JArr arr;
+            for (const auto& r : rows) arr.add(rule_to_jobj(r));
+            res.set_content(list_json(arr.str(), static_cast<int64_t>(rows.size())),
+                            "application/json");
+        });
+
+    sink.Post("/api/v1/guaranteed-state/rules",
+        [auth_fn, perm_fn, audit_fn, guaranteed_state_store, iso_now](
+            const httplib::Request& req, httplib::Response& res) {
+            if (!perm_fn(req, res, "GuaranteedState", "Write")) return;
+            if (!guaranteed_state_store) {
+                res.status = 503;
+                res.set_content(error_json("guaranteed-state store unavailable", 503),
+                                "application/json");
+                return;
+            }
+            auto body = nlohmann::json::parse(req.body, nullptr, false);
+            if (body.is_discarded() || !body.is_object()) {
+                res.status = 400;
+                res.set_content(error_json("invalid JSON"), "application/json");
+                return;
+            }
+            GuaranteedStateRuleRow row;
+            row.rule_id          = body.value("rule_id", "");
+            row.name             = body.value("name", "");
+            row.yaml_source      = body.value("yaml_source", "");
+            row.version          = body.value("version", int64_t{1});
+            row.enabled          = body.value("enabled", true);
+            row.enforcement_mode = body.value("enforcement_mode", std::string{"enforce"});
+            row.severity         = body.value("severity", std::string{"medium"});
+            row.os_target        = body.value("os_target", std::string{""});
+            row.scope_expr       = body.value("scope_expr", std::string{""});
+            if (row.rule_id.empty() || row.name.empty() || row.yaml_source.empty()) {
+                res.status = 400;
+                res.set_content(error_json("rule_id, name, and yaml_source are required"),
+                                "application/json");
+                return;
+            }
+            auto session = auth_fn(req, res);
+            if (session) {
+                row.created_by = session->username;
+                row.updated_by = session->username;
+            }
+            row.created_at = iso_now();
+            row.updated_at = row.created_at;
+
+            auto result = guaranteed_state_store->create_rule(row);
+            if (!result) {
+                if (is_conflict_error(result.error())) {
+                    res.status = 409;
+                    res.set_content(error_json(strip_conflict_prefix(result.error()), 409),
+                                    "application/json");
+                } else {
+                    res.status = 400;
+                    res.set_content(error_json(result.error()), "application/json");
+                }
+                audit_fn(req, "guaranteed_state.rule.create", "denied", "GuaranteedState",
+                         row.rule_id, result.error());
+                return;
+            }
+            audit_fn(req, "guaranteed_state.rule.create", "success", "GuaranteedState",
+                     row.rule_id, row.name);
+            res.status = 201;
+            res.set_content(ok_json(JObj().add("rule_id", row.rule_id).str()),
+                            "application/json");
+        });
+
+    sink.Get(R"(/api/v1/guaranteed-state/rules/([A-Za-z0-9._\-]+))",
+        [perm_fn, guaranteed_state_store, rule_to_jobj](const httplib::Request& req,
+                                                         httplib::Response& res) {
+            if (!perm_fn(req, res, "GuaranteedState", "Read")) return;
+            if (!guaranteed_state_store) {
+                res.status = 503;
+                res.set_content(error_json("guaranteed-state store unavailable", 503),
+                                "application/json");
+                return;
+            }
+            auto id = req.matches[1].str();
+            auto row = guaranteed_state_store->get_rule(id);
+            if (!row) {
+                res.status = 404;
+                res.set_content(error_json("rule not found"), "application/json");
+                return;
+            }
+            res.set_content(ok_json(rule_to_jobj(*row).str()), "application/json");
+        });
+
+    sink.Put(R"(/api/v1/guaranteed-state/rules/([A-Za-z0-9._\-]+))",
+        [auth_fn, perm_fn, audit_fn, guaranteed_state_store, iso_now](
+            const httplib::Request& req, httplib::Response& res) {
+            if (!perm_fn(req, res, "GuaranteedState", "Write")) return;
+            if (!guaranteed_state_store) {
+                res.status = 503;
+                res.set_content(error_json("guaranteed-state store unavailable", 503),
+                                "application/json");
+                return;
+            }
+            auto id = req.matches[1].str();
+            auto existing = guaranteed_state_store->get_rule(id);
+            if (!existing) {
+                res.status = 404;
+                res.set_content(error_json("rule not found"), "application/json");
+                return;
+            }
+            auto body = nlohmann::json::parse(req.body, nullptr, false);
+            if (body.is_discarded() || !body.is_object()) {
+                res.status = 400;
+                res.set_content(error_json("invalid JSON"), "application/json");
+                return;
+            }
+            auto updated = *existing;
+            if (body.contains("name"))             updated.name = body["name"].get<std::string>();
+            if (body.contains("yaml_source"))      updated.yaml_source = body["yaml_source"].get<std::string>();
+            if (body.contains("enabled"))          updated.enabled = body["enabled"].get<bool>();
+            if (body.contains("enforcement_mode")) updated.enforcement_mode = body["enforcement_mode"].get<std::string>();
+            if (body.contains("severity"))         updated.severity = body["severity"].get<std::string>();
+            if (body.contains("os_target"))        updated.os_target = body["os_target"].get<std::string>();
+            if (body.contains("scope_expr"))       updated.scope_expr = body["scope_expr"].get<std::string>();
+            updated.version = existing->version + 1;
+            updated.updated_at = iso_now();
+            auto session = auth_fn(req, res);
+            if (session) updated.updated_by = session->username;
+
+            auto result = guaranteed_state_store->update_rule(updated);
+            if (!result) {
+                if (is_conflict_error(result.error())) {
+                    res.status = 409;
+                    res.set_content(error_json(strip_conflict_prefix(result.error()), 409),
+                                    "application/json");
+                } else {
+                    res.status = 400;
+                    res.set_content(error_json(result.error()), "application/json");
+                }
+                audit_fn(req, "guaranteed_state.rule.update", "denied", "GuaranteedState",
+                         id, result.error());
+                return;
+            }
+            audit_fn(req, "guaranteed_state.rule.update", "success", "GuaranteedState",
+                     id, updated.name);
+            res.set_content(ok_json(JObj().add("updated", true)
+                                          .add("version", static_cast<int64_t>(updated.version)).str()),
+                            "application/json");
+        });
+
+    sink.Delete(R"(/api/v1/guaranteed-state/rules/([A-Za-z0-9._\-]+))",
+        [perm_fn, audit_fn, guaranteed_state_store](const httplib::Request& req,
+                                                     httplib::Response& res) {
+            if (!perm_fn(req, res, "GuaranteedState", "Delete")) return;
+            if (!guaranteed_state_store) {
+                res.status = 503;
+                res.set_content(error_json("guaranteed-state store unavailable", 503),
+                                "application/json");
+                return;
+            }
+            auto id = req.matches[1].str();
+            auto result = guaranteed_state_store->delete_rule(id);
+            if (!result) {
+                res.status = 404;
+                res.set_content(error_json(result.error()), "application/json");
+                audit_fn(req, "guaranteed_state.rule.delete", "denied", "GuaranteedState",
+                         id, result.error());
+                return;
+            }
+            audit_fn(req, "guaranteed_state.rule.delete", "success", "GuaranteedState",
+                     id, "");
+            res.set_content(ok_json(JObj().add("deleted", true).str()),
+                            "application/json");
+        });
+
+    // POST /push — fan-out is wired in PR 3 (agent-side dispatch + scope
+    // expansion). PR 2 acks the request and audits the operator action so
+    // dashboards and audit-trail tooling can be exercised end-to-end now.
+    sink.Post("/api/v1/guaranteed-state/push",
+        [perm_fn, audit_fn, guaranteed_state_store](const httplib::Request& req,
+                                                     httplib::Response& res) {
+            if (!perm_fn(req, res, "GuaranteedState", "Push")) return;
+            if (!guaranteed_state_store) {
+                res.status = 503;
+                res.set_content(error_json("guaranteed-state store unavailable", 503),
+                                "application/json");
+                return;
+            }
+            auto body = nlohmann::json::parse(req.body, nullptr, false);
+            if (body.is_discarded()) body = nlohmann::json::object();
+            std::string scope = body.value("scope", std::string{""});
+            bool full_sync = body.value("full_sync", false);
+            const auto rule_count = guaranteed_state_store->rule_count();
+            audit_fn(req, "guaranteed_state.push", "accepted", "GuaranteedState", scope,
+                     "rules=" + std::to_string(rule_count) +
+                     " full_sync=" + (full_sync ? "true" : "false"));
+            res.status = 202;
+            res.set_content(ok_json(JObj()
+                                        .add("queued", true)
+                                        .add("rules", static_cast<int64_t>(rule_count))
+                                        .add("scope", scope)
+                                        .add("note", "fan-out lands in Guardian PR 3").str()),
+                            "application/json");
+        });
+
+    // GET /events — query events with optional filters. Mirrors
+    // `audit_store` query semantics. Caps `limit` at 1000 at the REST
+    // boundary; the store enforces a hard upper bound at kMaxEventsLimit.
+    sink.Get("/api/v1/guaranteed-state/events",
+        [perm_fn, guaranteed_state_store](const httplib::Request& req, httplib::Response& res) {
+            if (!perm_fn(req, res, "GuaranteedState", "Read")) return;
+            if (!guaranteed_state_store) {
+                res.status = 503;
+                res.set_content(error_json("guaranteed-state store unavailable", 503),
+                                "application/json");
+                return;
+            }
+            GuaranteedStateEventQuery q;
+            q.rule_id  = req.has_param("rule_id")  ? req.get_param_value("rule_id")  : "";
+            q.agent_id = req.has_param("agent_id") ? req.get_param_value("agent_id") : "";
+            q.severity = req.has_param("severity") ? req.get_param_value("severity") : "";
+            if (req.has_param("limit")) {
+                int v = 0;
+                auto s = req.get_param_value("limit");
+                auto [_, ec] = std::from_chars(s.data(), s.data() + s.size(), v);
+                if (ec != std::errc{} || v < 0) {
+                    res.status = 400;
+                    res.set_content(error_json("invalid limit"), "application/json");
+                    return;
+                }
+                q.limit = std::min(v, 1000);
+            }
+            if (req.has_param("offset")) {
+                int v = 0;
+                auto s = req.get_param_value("offset");
+                auto [_, ec] = std::from_chars(s.data(), s.data() + s.size(), v);
+                if (ec != std::errc{} || v < 0) {
+                    res.status = 400;
+                    res.set_content(error_json("invalid offset"), "application/json");
+                    return;
+                }
+                q.offset = v;
+            }
+            auto rows = guaranteed_state_store->query_events(q);
+            JArr arr;
+            for (const auto& e : rows) {
+                arr.add(JObj()
+                            .add("event_id", e.event_id)
+                            .add("rule_id", e.rule_id)
+                            .add("agent_id", e.agent_id)
+                            .add("event_type", e.event_type)
+                            .add("severity", e.severity)
+                            .add("guard_type", e.guard_type)
+                            .add("guard_category", e.guard_category)
+                            .add("detected_value", e.detected_value)
+                            .add("expected_value", e.expected_value)
+                            .add("remediation_action", e.remediation_action)
+                            .add("remediation_success", e.remediation_success)
+                            .add("detection_latency_us",
+                                 static_cast<int64_t>(e.detection_latency_us))
+                            .add("remediation_latency_us",
+                                 static_cast<int64_t>(e.remediation_latency_us))
+                            .add("timestamp", e.timestamp));
+            }
+            res.set_content(list_json(arr.str(), static_cast<int64_t>(rows.size()),
+                                      static_cast<int64_t>(q.offset)),
+                            "application/json");
+        });
+
+    // GET /status, /status/:agent_id, /alerts — placeholders that respond
+    // with empty rollups for PR 2. Real fleet aggregation arrives in PR 4
+    // (status) and PR 11 (alerts). Returning empty structures now keeps
+    // dashboard fragments and audit tooling exercisable against the API.
+    sink.Get("/api/v1/guaranteed-state/status",
+        [perm_fn, guaranteed_state_store](const httplib::Request& req, httplib::Response& res) {
+            if (!perm_fn(req, res, "GuaranteedState", "Read")) return;
+            const auto rules = guaranteed_state_store ? guaranteed_state_store->rule_count() : 0;
+            res.set_content(ok_json(JObj()
+                                        .add("total_rules", static_cast<int64_t>(rules))
+                                        .add("compliant", 0)
+                                        .add("drifted", 0)
+                                        .add("errored", 0)
+                                        .add("note", "fleet aggregation lands in Guardian PR 4")
+                                        .str()),
+                            "application/json");
+        });
+
+    sink.Get(R"(/api/v1/guaranteed-state/status/([A-Za-z0-9._\-]+))",
+        [perm_fn](const httplib::Request& req, httplib::Response& res) {
+            if (!perm_fn(req, res, "GuaranteedState", "Read")) return;
+            auto agent_id = req.matches[1].str();
+            res.set_content(ok_json(JObj()
+                                        .add("agent_id", agent_id)
+                                        .add("rules", 0)
+                                        .add("note", "per-agent status lands in Guardian PR 4")
+                                        .str()),
+                            "application/json");
+        });
+
+    sink.Get("/api/v1/guaranteed-state/alerts",
+        [perm_fn](const httplib::Request& req, httplib::Response& res) {
+            if (!perm_fn(req, res, "GuaranteedState", "Read")) return;
+            res.set_content(list_json("[]", 0), "application/json");
+        });
 
     spdlog::info("REST API v1: registered all routes at /api/v1/*");
 }

--- a/server/core/src/rest_api_v1.hpp
+++ b/server/core/src/rest_api_v1.hpp
@@ -7,6 +7,7 @@
 #include "audit_store.hpp"
 #include "device_token_store.hpp"
 #include "execution_tracker.hpp"
+#include "guaranteed_state_store.hpp"
 #include "instruction_store.hpp"
 #include "inventory_store.hpp"
 #include "license_store.hpp"
@@ -56,7 +57,8 @@ public:
                          ProductPackStore* product_pack_store = nullptr,
                          SoftwareDeploymentStore* sw_deploy_store = nullptr,
                          DeviceTokenStore* device_token_store = nullptr,
-                         LicenseStore* license_store = nullptr);
+                         LicenseStore* license_store = nullptr,
+                         GuaranteedStateStore* guaranteed_state_store = nullptr);
 
     /// Sink-based overload — used by tests to register routes against an
     /// in-process TestRouteSink so dispatch happens without httplib::Server's
@@ -74,7 +76,8 @@ public:
                          ProductPackStore* product_pack_store = nullptr,
                          SoftwareDeploymentStore* sw_deploy_store = nullptr,
                          DeviceTokenStore* device_token_store = nullptr,
-                         LicenseStore* license_store = nullptr);
+                         LicenseStore* license_store = nullptr,
+                         GuaranteedStateStore* guaranteed_state_store = nullptr);
 };
 
 } // namespace yuzu::server

--- a/server/core/src/server.cpp
+++ b/server/core/src/server.cpp
@@ -4480,7 +4480,11 @@ private:
                 }
             },
             inventory_store_.get(),
-            product_pack_store_.get());
+            product_pack_store_.get(),
+            /*sw_deploy_store=*/nullptr,
+            /*device_token_store=*/nullptr,
+            /*license_store=*/nullptr,
+            guaranteed_state_store_.get());
 
         // -- Register MCP server routes ----------------------------------------
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -27,12 +27,13 @@ agent_test_exe = executable(
     'unit/test_metrics_perf.cpp',
     'unit/test_kv_store.cpp',
     'unit/test_trigger_engine.cpp',
+    'unit/test_guardian_engine.cpp',
     'unit/test_new_plugins.cpp',
   ),
   include_directories: [
     include_directories('../agents/plugins/vuln_scan/src'),  # cve_rules.hpp
   ],
-  dependencies: [yuzu_agent_core_dep, yuzu_sdk_dep, nlohmann_dep, catch2_dep],
+  dependencies: [yuzu_agent_core_dep, yuzu_sdk_dep, yuzu_proto_dep, nlohmann_dep, catch2_dep],
   # Ensure the fixture plugin is built before the test runs so the lookup
   # inside test_plugin_loader.cpp finds it under MESON_BUILD_ROOT/tests/.
   link_depends: reserved_name_fixture_plugin,
@@ -115,6 +116,7 @@ if build_server
       'unit/server/test_license_store.cpp',
       'unit/server/test_rest_api_t2.cpp',
       'unit/server/test_rest_api_tokens.cpp',
+      'unit/server/test_rest_guaranteed_state.cpp',
       'unit/server/test_security_headers.cpp',
       'unit/server/test_settings_routes_users.cpp',
       'unit/server/test_store_errors.cpp',

--- a/tests/unit/server/test_rbac_store.cpp
+++ b/tests/unit/server/test_rbac_store.cpp
@@ -46,7 +46,7 @@ TEST_CASE("RbacStore: seed data — system roles exist", "[rbac_store]") {
 TEST_CASE("RbacStore: seed data — securable types", "[rbac_store]") {
     RbacStore store(":memory:");
     auto types = store.list_securable_types();
-    REQUIRE(types.size() == 18);
+    REQUIRE(types.size() == 19);
 
     auto has = [&](const std::string& t) {
         return std::find(types.begin(), types.end(), t) != types.end();
@@ -63,19 +63,22 @@ TEST_CASE("RbacStore: seed data — securable types", "[rbac_store]") {
     CHECK(has("SoftwareDeployment"));
     CHECK(has("License"));
     CHECK(has("FileRetrieval"));
+    CHECK(has("GuaranteedState"));
 }
 
 TEST_CASE("RbacStore: seed data — operations", "[rbac_store]") {
     RbacStore store(":memory:");
     auto ops = store.list_operations();
-    REQUIRE(ops.size() == 5);
+    // Read, Write, Execute, Delete, Approve, Push (Push added for Guardian
+    // distribute-rules-to-fleet operation; design v1.1 §9.2).
+    REQUIRE(ops.size() == 6);
 }
 
 TEST_CASE("RbacStore: seed data — Administrator has all permissions", "[rbac_store]") {
     RbacStore store(":memory:");
     auto perms = store.get_role_permissions("Administrator");
-    // 18 types * 5 ops = 90 permissions
-    CHECK(perms.size() == 90);
+    // 19 types * 6 ops = 114 permissions
+    CHECK(perms.size() == 114);
     for (auto& p : perms)
         CHECK(p.effect == "allow");
 }
@@ -83,8 +86,8 @@ TEST_CASE("RbacStore: seed data — Administrator has all permissions", "[rbac_s
 TEST_CASE("RbacStore: seed data — Viewer has read-only", "[rbac_store]") {
     RbacStore store(":memory:");
     auto perms = store.get_role_permissions("Viewer");
-    // 17 types * Read only (not Infrastructure)
-    CHECK(perms.size() == 17);
+    // 18 types * Read only (everything except Infrastructure)
+    CHECK(perms.size() == 18);
     for (auto& p : perms) {
         CHECK(p.operation == "Read");
         CHECK(p.effect == "allow");
@@ -373,8 +376,10 @@ TEST_CASE("RbacStore: ITServiceOwner role seeded with correct permissions", "[rb
     CHECK(role->description.find("IT Service") != std::string::npos);
 
     auto perms = store.get_role_permissions("ITServiceOwner");
-    // 15 types * 5 ops = 75 permissions
-    CHECK(perms.size() == 75);
+    // 16 types * 6 ops = 96 permissions (GuaranteedState + Push added for
+    // Guardian PR 2; Push grant on non-Guardian types is harmless because
+    // only the Guardian REST handlers consult it — see rbac_store.cpp).
+    CHECK(perms.size() == 96);
     for (auto& p : perms) {
         CHECK(p.effect == "allow");
         // Should not include UserManagement, Security, ApiToken

--- a/tests/unit/server/test_rest_guaranteed_state.cpp
+++ b/tests/unit/server/test_rest_guaranteed_state.cpp
@@ -1,0 +1,340 @@
+/**
+ * test_rest_guaranteed_state.cpp — HTTP-level coverage for the
+ * /api/v1/guaranteed-state/ surface added in Guardian PR 2.
+ *
+ * Pattern matches test_rest_api_tokens.cpp: register RestApiV1 routes
+ * against an in-process TestRouteSink and dispatch synthesised
+ * httplib::Request objects through the captured handlers. No real HTTP
+ * server, no acceptor thread, no #438 TSan trap.
+ *
+ * Coverage focuses on the wire contract that downstream tooling
+ * (dashboard, MCP, CLI) will exercise:
+ *   - 201 on create, with rule_id echoed in `data.rule_id`
+ *   - 409 (kConflictPrefix mapping) on duplicate name / rule_id
+ *   - 200 round-trip GET / list / PUT / DELETE
+ *   - 202 on push (PR 2 placeholder; real fan-out is PR 3)
+ *   - audit_fn fires for every mutating endpoint
+ *
+ * Not covered here: agent-side dispatch (test_guardian_engine.cpp), the
+ * scope expansion that PR 3 wires into /push.
+ */
+
+#include "guaranteed_state_store.hpp"
+#include "rest_api_v1.hpp"
+#include "test_route_sink.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <httplib.h>
+#include <nlohmann/json.hpp>
+
+#include <chrono>
+#include <filesystem>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace fs = std::filesystem;
+using namespace yuzu::server;
+
+namespace {
+
+fs::path unique_temp_path(const std::string& prefix) {
+    return fs::temp_directory_path() /
+           (prefix + "-" +
+            std::to_string(std::hash<std::thread::id>{}(std::this_thread::get_id()) ^
+                           static_cast<size_t>(std::chrono::steady_clock::now()
+                                                   .time_since_epoch()
+                                                   .count())));
+}
+
+struct AuditRecord {
+    std::string action;
+    std::string result;
+    std::string target_type;
+    std::string target_id;
+    std::string detail;
+};
+
+struct RestGsHarness {
+    yuzu::server::test::TestRouteSink sink;
+
+    fs::path db_path;
+    std::unique_ptr<GuaranteedStateStore> store;
+
+    std::string session_user{"alice"};
+    auth::Role session_role{auth::Role::admin};
+
+    std::vector<AuditRecord> audit_log;
+
+    RestApiV1 api;
+
+    RestGsHarness() : db_path(unique_temp_path("rest-gs")) {
+        fs::remove(db_path);
+        // retention=0 keeps the reaper out of the way for ingest tests.
+        store = std::make_unique<GuaranteedStateStore>(db_path, /*retention_days=*/0,
+                                                       /*cleanup_interval_min=*/60);
+        REQUIRE(store->is_open());
+
+        auto auth_fn = [this](const httplib::Request&, httplib::Response&)
+            -> std::optional<auth::Session> {
+            if (session_user.empty()) return std::nullopt;
+            auth::Session s;
+            s.username = session_user;
+            s.role = session_role;
+            return s;
+        };
+
+        // perm_fn always grants — RBAC is exercised in test_rbac_store.cpp.
+        auto perm_fn = [](const httplib::Request&, httplib::Response&,
+                          const std::string&, const std::string&) -> bool {
+            return true;
+        };
+
+        auto audit_fn = [this](const httplib::Request&, const std::string& action,
+                               const std::string& result, const std::string& target_type,
+                               const std::string& target_id, const std::string& detail) {
+            audit_log.push_back({action, result, target_type, target_id, detail});
+        };
+
+        api.register_routes(sink, auth_fn, perm_fn, audit_fn,
+                            /*rbac_store=*/nullptr,
+                            /*mgmt_store=*/nullptr,
+                            /*token_store=*/nullptr,
+                            /*quarantine_store=*/nullptr,
+                            /*response_store=*/nullptr,
+                            /*instruction_store=*/nullptr,
+                            /*execution_tracker=*/nullptr,
+                            /*schedule_engine=*/nullptr,
+                            /*approval_manager=*/nullptr,
+                            /*tag_store=*/nullptr,
+                            /*audit_store=*/nullptr,
+                            /*service_group_fn=*/{},
+                            /*tag_push_fn=*/{},
+                            /*inventory_store=*/nullptr,
+                            /*product_pack_store=*/nullptr,
+                            /*sw_deploy_store=*/nullptr,
+                            /*device_token_store=*/nullptr,
+                            /*license_store=*/nullptr,
+                            store.get());
+    }
+
+    ~RestGsHarness() {
+        store.reset();
+        fs::remove(db_path);
+        // sqlite WAL/SHM siblings
+        fs::remove(db_path.string() + "-wal");
+        fs::remove(db_path.string() + "-shm");
+    }
+
+    static std::string make_rule_body(const std::string& rule_id,
+                                       const std::string& name,
+                                       const std::string& yaml = "name: example\n") {
+        nlohmann::json j;
+        j["rule_id"]          = rule_id;
+        j["name"]             = name;
+        j["yaml_source"]      = yaml;
+        j["enabled"]          = true;
+        j["enforcement_mode"] = "enforce";
+        j["severity"]         = "high";
+        j["os_target"]        = "windows";
+        j["scope_expr"]       = "tag:env=prod";
+        return j.dump();
+    }
+};
+
+} // namespace
+
+TEST_CASE("REST gs.rules: create returns 201 and echoes rule_id",
+          "[rest][guaranteed_state][create]") {
+    RestGsHarness h;
+    auto res = h.sink.Post("/api/v1/guaranteed-state/rules",
+                            RestGsHarness::make_rule_body("r-001", "block-rdp"));
+    REQUIRE(res);
+    CHECK(res->status == 201);
+    CHECK(res->body.find("\"rule_id\":\"r-001\"") != std::string::npos);
+
+    auto stored = h.store->get_rule("r-001");
+    REQUIRE(stored.has_value());
+    CHECK(stored->name == "block-rdp");
+    CHECK(stored->severity == "high");
+    CHECK(stored->os_target == "windows");
+    CHECK(stored->created_by == "alice");
+    CHECK(stored->updated_by == "alice");
+
+    REQUIRE(h.audit_log.size() == 1);
+    CHECK(h.audit_log[0].action == "guaranteed_state.rule.create");
+    CHECK(h.audit_log[0].result == "success");
+    CHECK(h.audit_log[0].target_id == "r-001");
+}
+
+TEST_CASE("REST gs.rules: missing required fields → 400",
+          "[rest][guaranteed_state][create][validation]") {
+    RestGsHarness h;
+    nlohmann::json bad;
+    bad["rule_id"] = "r-bad";
+    // name + yaml_source missing
+    auto res = h.sink.Post("/api/v1/guaranteed-state/rules", bad.dump());
+    REQUIRE(res);
+    CHECK(res->status == 400);
+    CHECK(res->body.find("required") != std::string::npos);
+    CHECK(h.audit_log.empty());
+}
+
+TEST_CASE("REST gs.rules: duplicate name → 409 via kConflictPrefix",
+          "[rest][guaranteed_state][conflict]") {
+    RestGsHarness h;
+    REQUIRE(h.sink.Post("/api/v1/guaranteed-state/rules",
+                         RestGsHarness::make_rule_body("r-001", "dup-name"))->status == 201);
+    auto res = h.sink.Post("/api/v1/guaranteed-state/rules",
+                            RestGsHarness::make_rule_body("r-002", "dup-name"));
+    REQUIRE(res);
+    CHECK(res->status == 409);
+    // Body must NOT carry the kConflictPrefix marker — that's an internal
+    // wire convention; the operator-facing message is the cleaned form.
+    CHECK(res->body.find("conflict:") == std::string::npos);
+    CHECK(res->body.find("dup-name") != std::string::npos);
+
+    REQUIRE(h.audit_log.size() == 2);
+    CHECK(h.audit_log[1].result == "denied");
+}
+
+TEST_CASE("REST gs.rules: list, get, update, delete round-trip",
+          "[rest][guaranteed_state][crud]") {
+    RestGsHarness h;
+    REQUIRE(h.sink.Post("/api/v1/guaranteed-state/rules",
+                         RestGsHarness::make_rule_body("r-001", "rule-a"))->status == 201);
+    REQUIRE(h.sink.Post("/api/v1/guaranteed-state/rules",
+                         RestGsHarness::make_rule_body("r-002", "rule-b"))->status == 201);
+
+    auto list = h.sink.Get("/api/v1/guaranteed-state/rules");
+    REQUIRE(list);
+    CHECK(list->status == 200);
+    auto list_json = nlohmann::json::parse(list->body);
+    REQUIRE(list_json["data"].is_array());
+    CHECK(list_json["data"].size() == 2);
+    CHECK(list_json["pagination"]["total"].get<int>() == 2);
+
+    auto got = h.sink.Get("/api/v1/guaranteed-state/rules/r-001");
+    REQUIRE(got);
+    CHECK(got->status == 200);
+    auto got_json = nlohmann::json::parse(got->body);
+    CHECK(got_json["data"]["name"].get<std::string>() == "rule-a");
+    CHECK(got_json["data"]["version"].get<int>() == 1);
+
+    nlohmann::json patch;
+    patch["enabled"] = false;
+    patch["severity"] = "critical";
+    auto upd = h.sink.Put("/api/v1/guaranteed-state/rules/r-001", patch.dump());
+    REQUIRE(upd);
+    CHECK(upd->status == 200);
+
+    auto refetched = h.store->get_rule("r-001");
+    REQUIRE(refetched.has_value());
+    CHECK_FALSE(refetched->enabled);
+    CHECK(refetched->severity == "critical");
+    CHECK(refetched->version == 2);  // bumped by handler
+
+    auto del = h.sink.Delete("/api/v1/guaranteed-state/rules/r-001");
+    REQUIRE(del);
+    CHECK(del->status == 200);
+    CHECK_FALSE(h.store->get_rule("r-001").has_value());
+}
+
+TEST_CASE("REST gs.rules: get unknown id → 404",
+          "[rest][guaranteed_state][not_found]") {
+    RestGsHarness h;
+    auto got = h.sink.Get("/api/v1/guaranteed-state/rules/nope");
+    REQUIRE(got);
+    CHECK(got->status == 404);
+}
+
+TEST_CASE("REST gs.rules: delete unknown id → 404 + denied audit",
+          "[rest][guaranteed_state][not_found]") {
+    RestGsHarness h;
+    auto del = h.sink.Delete("/api/v1/guaranteed-state/rules/nope");
+    REQUIRE(del);
+    CHECK(del->status == 404);
+    REQUIRE(h.audit_log.size() == 1);
+    CHECK(h.audit_log[0].result == "denied");
+}
+
+TEST_CASE("REST gs.push: returns 202 + audits the operator action",
+          "[rest][guaranteed_state][push]") {
+    RestGsHarness h;
+    REQUIRE(h.sink.Post("/api/v1/guaranteed-state/rules",
+                         RestGsHarness::make_rule_body("r-001", "rule-a"))->status == 201);
+    nlohmann::json push;
+    push["scope"] = "tag:env=prod";
+    push["full_sync"] = true;
+    auto res = h.sink.Post("/api/v1/guaranteed-state/push", push.dump());
+    REQUIRE(res);
+    CHECK(res->status == 202);
+    CHECK(res->body.find("\"queued\":true") != std::string::npos);
+    CHECK(res->body.find("PR 3") != std::string::npos);
+
+    REQUIRE(h.audit_log.size() == 2);  // create + push
+    const auto& push_audit = h.audit_log[1];
+    CHECK(push_audit.action == "guaranteed_state.push");
+    CHECK(push_audit.result == "accepted");
+    CHECK(push_audit.target_id == "tag:env=prod");
+    CHECK(push_audit.detail.find("rules=1") != std::string::npos);
+    CHECK(push_audit.detail.find("full_sync=true") != std::string::npos);
+}
+
+TEST_CASE("REST gs.events: filter + limit pagination",
+          "[rest][guaranteed_state][events]") {
+    RestGsHarness h;
+    GuaranteedStateEventRow ev;
+    ev.event_id = "e-1";
+    ev.rule_id  = "r-001";
+    ev.agent_id = "agent-A";
+    ev.event_type = "drift.detected";
+    ev.severity = "high";
+    ev.guard_type = "registry";
+    ev.guard_category = "event";
+    ev.detected_value = "0";
+    ev.expected_value = "1";
+    ev.timestamp = "2026-04-21T00:00:00Z";
+    REQUIRE(h.store->insert_event(ev).has_value());
+
+    auto res = h.sink.Get("/api/v1/guaranteed-state/events?rule_id=r-001&limit=10");
+    REQUIRE(res);
+    CHECK(res->status == 200);
+    auto j = nlohmann::json::parse(res->body);
+    REQUIRE(j["data"].is_array());
+    CHECK(j["data"].size() == 1);
+    CHECK(j["data"][0]["event_id"].get<std::string>() == "e-1");
+}
+
+TEST_CASE("REST gs.events: invalid limit → 400",
+          "[rest][guaranteed_state][events][validation]") {
+    RestGsHarness h;
+    auto res = h.sink.Get("/api/v1/guaranteed-state/events?limit=-7");
+    REQUIRE(res);
+    CHECK(res->status == 400);
+}
+
+TEST_CASE("REST gs.status: returns store rule_count rollup",
+          "[rest][guaranteed_state][status]") {
+    RestGsHarness h;
+    REQUIRE(h.sink.Post("/api/v1/guaranteed-state/rules",
+                         RestGsHarness::make_rule_body("r-001", "rule-a"))->status == 201);
+
+    auto res = h.sink.Get("/api/v1/guaranteed-state/status");
+    REQUIRE(res);
+    CHECK(res->status == 200);
+    auto j = nlohmann::json::parse(res->body);
+    CHECK(j["data"]["total_rules"].get<int>() == 1);
+}
+
+TEST_CASE("REST gs.alerts: empty list placeholder",
+          "[rest][guaranteed_state][alerts]") {
+    RestGsHarness h;
+    auto res = h.sink.Get("/api/v1/guaranteed-state/alerts");
+    REQUIRE(res);
+    CHECK(res->status == 200);
+    auto j = nlohmann::json::parse(res->body);
+    REQUIRE(j["data"].is_array());
+    CHECK(j["data"].empty());
+}

--- a/tests/unit/server/test_route_sink.hpp
+++ b/tests/unit/server/test_route_sink.hpp
@@ -44,15 +44,28 @@ public:
                                                  const std::string& path,
                                                  const std::string& body = {},
                                                  const std::string& content_type = "application/json") {
+        // httplib::Server splits the request URI into path + query string
+        // before routing, so handlers see `req.path` without the `?...` tail
+        // and `req.params` populated from the query. Mirror that here so
+        // handlers exercising `req.has_param("limit")` work identically.
+        std::string match_path = path;
+        std::string query_text;
+        if (auto qpos = path.find('?'); qpos != std::string::npos) {
+            match_path = path.substr(0, qpos);
+            query_text = path.substr(qpos + 1);
+        }
+
         for (auto& route : routes_) {
             if (route.method != method) continue;
             std::smatch m;
-            if (!std::regex_match(path, m, route.regex)) continue;
+            if (!std::regex_match(match_path, m, route.regex)) continue;
 
             httplib::Request req;
             req.method = method;
-            req.path = path;
+            req.path = match_path;
             req.body = body;
+            if (!query_text.empty())
+                httplib::detail::parse_query_text(query_text, req.params);
             if (!content_type.empty())
                 req.set_header("Content-Type", content_type);
             // httplib populates `matches` with the regex capture groups so

--- a/tests/unit/test_guardian_engine.cpp
+++ b/tests/unit/test_guardian_engine.cpp
@@ -28,10 +28,12 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
 #include <memory>
+#include <random>
 #include <string>
 #include <thread>
 
@@ -56,11 +58,25 @@ std::string uid_suffix() {
 #endif
 }
 
+// Path uniqueness strategy:
+//   - process-local mt19937_64 seed  → distinct across concurrent test binaries
+//     (belt-and-suspenders: different meson test workers each get a different
+//     random prefix)
+//   - atomic monotonic counter       → guarantees uniqueness within a single
+//     process regardless of `std::chrono::steady_clock` resolution
+//     (MSVC's steady_clock granularity can drop to the 100ns tick on some
+//     Windows builds, and Defender-induced serialisation on SystemTemp made
+//     the prior hash+time scheme produce colliding filenames ~1 run in 40 on
+//     the yuzu-local-windows self-hosted runner — observed on PR #473)
 fs::path unique_kv_path() {
+    static const std::uint64_t kProcessSalt = [] {
+        std::random_device rd;
+        return (static_cast<std::uint64_t>(rd()) << 32) | rd();
+    }();
+    static std::atomic<std::uint64_t> counter{0};
+    const auto n = counter.fetch_add(1, std::memory_order_relaxed);
     return fs::temp_directory_path() / ("yuzu_test_guardian" + uid_suffix()) /
-           ("guardian_" +
-            std::to_string(std::hash<std::thread::id>{}(std::this_thread::get_id())) + "_" +
-            std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) + ".db");
+           ("guardian_" + std::to_string(kProcessSalt) + "_" + std::to_string(n) + ".db");
 }
 
 struct GuardianFixture {

--- a/tests/unit/test_guardian_engine.cpp
+++ b/tests/unit/test_guardian_engine.cpp
@@ -1,0 +1,335 @@
+/**
+ * test_guardian_engine.cpp — Unit tests for GuardianEngine (Guardian PR 2).
+ *
+ * The engine accepts __guard__ commands (push_rules, get_status) over the
+ * agent's CommandRequest dispatch path and persists rules into KvStore
+ * under namespace "__guardian__". PR 2 has no real guard threads — these
+ * tests verify the persistence + dispatch contract that PR 3 builds on.
+ *
+ * What is in scope:
+ *   - apply_rules persists each rule under "rule:<id>" as binary-safe JSON
+ *   - full_sync wipes the prior set; non-full_sync merges in
+ *   - dispatch round-trips push_rules through proto SerializeAsString
+ *   - dispatch returns a GuaranteedStateStatus on get_status
+ *   - rule_count / policy_generation survive an in-process restart
+ *     (re-construct GuardianEngine over the same KvStore)
+ *   - kv-unavailable construction degrades gracefully without crashing
+ *
+ * What is out of scope (PR 3+):
+ *   - Real guard threads, drift detection, remediation
+ *   - sync_with_server doing anything beyond logging
+ */
+
+#include <yuzu/agent/guardian_engine.hpp>
+#include <yuzu/agent/kv_store.hpp>
+
+#include "agent.grpc.pb.h"
+#include "guaranteed_state.pb.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <thread>
+
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+namespace fs = std::filesystem;
+namespace gpb = ::yuzu::guardian::v1;
+namespace apb = ::yuzu::agent::v1;
+using yuzu::agent::GuardianEngine;
+using yuzu::agent::KvStore;
+
+namespace {
+
+std::string uid_suffix() {
+#ifdef _WIN32
+    if (const char* u = std::getenv("USERNAME")) return std::string("_") + u;
+    return "_unknown";
+#else
+    return "_" + std::to_string(static_cast<unsigned long>(::geteuid()));
+#endif
+}
+
+fs::path unique_kv_path() {
+    return fs::temp_directory_path() / ("yuzu_test_guardian" + uid_suffix()) /
+           ("guardian_" +
+            std::to_string(std::hash<std::thread::id>{}(std::this_thread::get_id())) + "_" +
+            std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) + ".db");
+}
+
+struct GuardianFixture {
+    fs::path kv_path;
+    std::unique_ptr<KvStore> kv;
+    std::unique_ptr<GuardianEngine> engine;
+
+    GuardianFixture() : kv_path(unique_kv_path()) {
+        auto opened = KvStore::open(kv_path);
+        REQUIRE(opened.has_value());
+        kv = std::make_unique<KvStore>(std::move(*opened));
+        engine = std::make_unique<GuardianEngine>(kv.get(), "agent-test");
+        REQUIRE(engine->start_local().has_value());
+    }
+
+    ~GuardianFixture() {
+        engine.reset();
+        kv.reset();
+        std::error_code ec;
+        fs::remove(kv_path, ec);
+        fs::remove(fs::path{kv_path.string() + "-wal"}, ec);
+        fs::remove(fs::path{kv_path.string() + "-shm"}, ec);
+    }
+
+    static gpb::GuaranteedStateRule make_rule(const std::string& id, const std::string& name,
+                                                bool enabled = true) {
+        gpb::GuaranteedStateRule r;
+        r.set_rule_id(id);
+        r.set_name(name);
+        r.set_yaml_source("name: " + name + "\n");
+        r.set_version(1);
+        r.set_enabled(enabled);
+        r.set_enforcement_mode("enforce");
+        return r;
+    }
+};
+
+} // namespace
+
+TEST_CASE("GuardianEngine: start_local on fresh KV reports zero rules",
+          "[guardian][engine][start]") {
+    GuardianFixture f;
+    CHECK(f.engine->rule_count() == 0);
+    CHECK(f.engine->policy_generation() == 0);
+}
+
+TEST_CASE("GuardianEngine: apply_rules persists rules and bumps generation",
+          "[guardian][engine][apply]") {
+    GuardianFixture f;
+    gpb::GuaranteedStatePush push;
+    push.set_full_sync(true);
+    push.set_policy_generation(7);
+    *push.add_rules() = GuardianFixture::make_rule("r-1", "rule-one");
+    *push.add_rules() = GuardianFixture::make_rule("r-2", "rule-two");
+
+    auto applied = f.engine->apply_rules(push);
+    REQUIRE(applied.has_value());
+    CHECK(*applied == 2);
+    CHECK(f.engine->rule_count() == 2);
+    CHECK(f.engine->policy_generation() == 7);
+
+    // Each rule landed under "rule:<id>" in the reserved KV namespace.
+    auto keys = f.kv->list(GuardianEngine::kv_namespace(), "rule:");
+    REQUIRE(keys.size() == 2);
+    auto raw = f.kv->get(GuardianEngine::kv_namespace(), "rule:r-1");
+    REQUIRE(raw.has_value());
+    CHECK(raw->find("\"name\":\"rule-one\"") != std::string::npos);
+}
+
+TEST_CASE("GuardianEngine: full_sync replaces the prior rule set",
+          "[guardian][engine][apply][full_sync]") {
+    GuardianFixture f;
+    {
+        gpb::GuaranteedStatePush p;
+        p.set_full_sync(true);
+        *p.add_rules() = GuardianFixture::make_rule("r-1", "old-1");
+        *p.add_rules() = GuardianFixture::make_rule("r-2", "old-2");
+        REQUIRE(f.engine->apply_rules(p).has_value());
+    }
+    REQUIRE(f.engine->rule_count() == 2);
+
+    {
+        gpb::GuaranteedStatePush p;
+        p.set_full_sync(true);
+        p.set_policy_generation(99);
+        *p.add_rules() = GuardianFixture::make_rule("r-99", "new-rule");
+        REQUIRE(f.engine->apply_rules(p).has_value());
+    }
+
+    CHECK(f.engine->rule_count() == 1);
+    CHECK(f.engine->policy_generation() == 99);
+    CHECK_FALSE(f.kv->exists(GuardianEngine::kv_namespace(), "rule:r-1"));
+    CHECK(f.kv->exists(GuardianEngine::kv_namespace(), "rule:r-99"));
+}
+
+TEST_CASE("GuardianEngine: delta merge keeps prior rules and updates overlap",
+          "[guardian][engine][apply][delta]") {
+    GuardianFixture f;
+    {
+        gpb::GuaranteedStatePush p;
+        p.set_full_sync(true);
+        *p.add_rules() = GuardianFixture::make_rule("r-1", "first");
+        REQUIRE(f.engine->apply_rules(p).has_value());
+    }
+    {
+        gpb::GuaranteedStatePush p;
+        p.set_full_sync(false);
+        *p.add_rules() = GuardianFixture::make_rule("r-1", "first-renamed");
+        *p.add_rules() = GuardianFixture::make_rule("r-2", "second");
+        REQUIRE(f.engine->apply_rules(p).has_value());
+    }
+    CHECK(f.engine->rule_count() == 2);
+    auto raw = f.kv->get(GuardianEngine::kv_namespace(), "rule:r-1");
+    REQUIRE(raw.has_value());
+    CHECK(raw->find("\"name\":\"first-renamed\"") != std::string::npos);
+}
+
+TEST_CASE("GuardianEngine: rules with empty rule_id are skipped, not persisted",
+          "[guardian][engine][apply][validation]") {
+    GuardianFixture f;
+    gpb::GuaranteedStatePush p;
+    p.set_full_sync(true);
+    *p.add_rules() = GuardianFixture::make_rule("", "no-id");
+    *p.add_rules() = GuardianFixture::make_rule("r-keep", "valid");
+    auto applied = f.engine->apply_rules(p);
+    REQUIRE(applied.has_value());
+    CHECK(*applied == 1);
+    CHECK(f.engine->rule_count() == 1);
+}
+
+TEST_CASE("GuardianEngine: dispatch routes push_rules through SerializeAsString",
+          "[guardian][engine][dispatch][push]") {
+    GuardianFixture f;
+    gpb::GuaranteedStatePush p;
+    p.set_full_sync(true);
+    p.set_policy_generation(42);
+    *p.add_rules() = GuardianFixture::make_rule("r-d", "dispatched");
+
+    apb::CommandRequest cmd;
+    cmd.set_command_id("cmd-1");
+    cmd.set_plugin("__guard__");
+    cmd.set_action("push_rules");
+    (*cmd.mutable_parameters())["push"] = p.SerializeAsString();
+
+    auto dr = f.engine->dispatch(cmd);
+    CHECK(dr.exit_code == 0);
+    CHECK(dr.content_type == "text");
+    CHECK(dr.output.find("applied=1") != std::string::npos);
+    CHECK(dr.output.find("generation=42") != std::string::npos);
+    CHECK(f.engine->rule_count() == 1);
+    CHECK(f.engine->policy_generation() == 42);
+}
+
+TEST_CASE("GuardianEngine: dispatch get_status returns serialised proto",
+          "[guardian][engine][dispatch][status]") {
+    GuardianFixture f;
+    gpb::GuaranteedStatePush p;
+    p.set_full_sync(true);
+    *p.add_rules() = GuardianFixture::make_rule("r-1", "a");
+    *p.add_rules() = GuardianFixture::make_rule("r-2", "b");
+    REQUIRE(f.engine->apply_rules(p).has_value());
+
+    apb::CommandRequest cmd;
+    cmd.set_command_id("cmd-status");
+    cmd.set_plugin("__guard__");
+    cmd.set_action("get_status");
+
+    auto dr = f.engine->dispatch(cmd);
+    REQUIRE(dr.exit_code == 0);
+    CHECK(dr.content_type == "proto");
+
+    gpb::GuaranteedStateStatus status;
+    REQUIRE(status.ParseFromString(dr.output));
+    CHECK(status.agent_id() == "agent-test");
+    CHECK(status.total_rules() == 2);
+    // PR 2 reports every rule as errored — no real guards yet.
+    CHECK(status.errored_rules() == 2);
+    CHECK(status.compliant_rules() == 0);
+    CHECK(status.rules_size() == 2);
+}
+
+TEST_CASE("GuardianEngine: dispatch unknown action fails with detail",
+          "[guardian][engine][dispatch][error]") {
+    GuardianFixture f;
+    apb::CommandRequest cmd;
+    cmd.set_plugin("__guard__");
+    cmd.set_action("not_a_real_action");
+    auto dr = f.engine->dispatch(cmd);
+    CHECK(dr.exit_code != 0);
+    CHECK(dr.output.find("not_a_real_action") != std::string::npos);
+}
+
+TEST_CASE("GuardianEngine: dispatch push_rules with missing param → exit_code 1",
+          "[guardian][engine][dispatch][error]") {
+    GuardianFixture f;
+    apb::CommandRequest cmd;
+    cmd.set_plugin("__guard__");
+    cmd.set_action("push_rules");
+    auto dr = f.engine->dispatch(cmd);
+    CHECK(dr.exit_code == 1);
+    CHECK(dr.output.find("missing 'push' parameter") != std::string::npos);
+}
+
+TEST_CASE("GuardianEngine: dispatch push_rules with garbage proto → exit_code 2",
+          "[guardian][engine][dispatch][error]") {
+    GuardianFixture f;
+    apb::CommandRequest cmd;
+    cmd.set_plugin("__guard__");
+    cmd.set_action("push_rules");
+    (*cmd.mutable_parameters())["push"] = "not a valid proto byte sequence";
+    auto dr = f.engine->dispatch(cmd);
+    CHECK(dr.exit_code == 2);
+    CHECK(dr.output.find("failed to parse") != std::string::npos);
+}
+
+TEST_CASE("GuardianEngine: rule cache + policy_generation survive engine reconstruct",
+          "[guardian][engine][persistence]") {
+    auto kv_path = unique_kv_path();
+    {
+        auto opened = KvStore::open(kv_path);
+        REQUIRE(opened.has_value());
+        auto kv = std::make_unique<KvStore>(std::move(*opened));
+        GuardianEngine eng(kv.get(), "agent-test");
+        REQUIRE(eng.start_local().has_value());
+
+        gpb::GuaranteedStatePush p;
+        p.set_full_sync(true);
+        p.set_policy_generation(13);
+        *p.add_rules() = GuardianFixture::make_rule("r-x", "persisted");
+        REQUIRE(eng.apply_rules(p).has_value());
+    }
+    // Re-open the same KV file under a fresh engine and verify recovery.
+    {
+        auto opened = KvStore::open(kv_path);
+        REQUIRE(opened.has_value());
+        auto kv = std::make_unique<KvStore>(std::move(*opened));
+        GuardianEngine eng(kv.get(), "agent-test");
+        REQUIRE(eng.start_local().has_value());
+        CHECK(eng.rule_count() == 1);
+        CHECK(eng.policy_generation() == 13);
+    }
+    std::error_code ec;
+    fs::remove(kv_path, ec);
+    fs::remove(fs::path{kv_path.string() + "-wal"}, ec);
+    fs::remove(fs::path{kv_path.string() + "-shm"}, ec);
+}
+
+TEST_CASE("GuardianEngine: construction with null KvStore degrades gracefully",
+          "[guardian][engine][robustness]") {
+    GuardianEngine eng(nullptr, "agent-test");
+    REQUIRE(eng.start_local().has_value());  // soft success — warns and proceeds
+
+    gpb::GuaranteedStatePush p;
+    p.set_full_sync(true);
+    *p.add_rules() = GuardianFixture::make_rule("r-1", "no-kv");
+    auto applied = eng.apply_rules(p);
+    CHECK_FALSE(applied.has_value());
+    CHECK(applied.error().find("kv store unavailable") != std::string::npos);
+}
+
+TEST_CASE("GuardianEngine: stop() makes subsequent apply_rules fail",
+          "[guardian][engine][lifecycle]") {
+    GuardianFixture f;
+    f.engine->stop();
+
+    gpb::GuaranteedStatePush p;
+    p.set_full_sync(true);
+    *p.add_rules() = GuardianFixture::make_rule("r-1", "after-stop");
+    auto applied = f.engine->apply_rules(p);
+    CHECK_FALSE(applied.has_value());
+    CHECK(applied.error().find("stopped") != std::string::npos);
+}


### PR DESCRIPTION
## Summary

Lands the operator-facing REST surface and the agent-side scaffolding the rest of the Windows-first Guardian rollout grafts onto. **No real guards run yet** — PR 3 lands the Registry Guard + state evaluator + remediation that turns this wire path into actual enforcement. PR 2 is honest about that by reporting every rule as `errored` until PR 3 wires real guards.

Per the implementation plan in `docs/yuzu-guardian-windows-implementation-plan.md` §"PR 2 — REST v1 + `__guard__` dispatch hook + empty GuardianEngine".

## Server changes

- `/api/v1/guaranteed-state/*` — full CRUD on rules (`GET`, `POST`, `GET :id`, `PUT :id`, `DELETE :id`), plus `POST /push` (returns `202 Accepted` — fan-out is PR 3), `GET /events` (paginated query mirroring `audit_store` semantics; `limit` capped at 1000 at the REST boundary), `GET /status`, `GET /status/:agent_id`, and `GET /alerts`.
- Conflict detection routes through `kConflictPrefix` → HTTP 409, matching #396/#399/#402.
- Created/updated rules carry the session principal in `created_by` / `updated_by` (#452 store columns).
- Every mutating route fires an audit event under target type `GuaranteedState`.
- New RBAC operation `Push` and securable type `GuaranteedState`. Default seeds:
  - `Operator` → `Read + Push` (deploy without authoring authority)
  - `PlatformEngineer` → full CRUD + `Push`
  - `Administrator` and `ITServiceOwner` → cross-type defaults
  - `Viewer` → `Read`
- Cross-type `Push` grants on non-Guardian securables are harmless because only the Guardian REST handlers consult `Push`.

## Agent changes

- New `GuardianEngine` class (`agents/core/src/guardian_engine.{hpp,cpp}`) with two-phase startup per design §4:
  - `start_local()` runs **pre-network** so the engine is enforcing before the Register RPC opens.
  - `sync_with_server()` runs **post-Register** and is the drain point for the buffered-events queue PR 4 will add.
- Reserved-name dispatch for `cmd.plugin() == \"__guard__\"` intercepted in `agent.cpp` **before** the plugin match loop — defence-in-depth alongside #453's load-time reservation.
- Rule persistence: `KvStore` namespace `__guardian__`, JSON values (binary-safe across the SQLite text APIs `KvStore` wraps; proto `SerializeAsString` round-trips fine inside proto `map<string,string>` because that uses `std::string` with exact length, not C-string).

## Tests

24 new test cases / 167 assertions, plus a free win:

- `tests/unit/test_guardian_engine.cpp` — 13 cases, 79 assertions covering apply_rules, full_sync vs delta merge, dispatch round-trip, persistence across engine reconstruct, null-`KvStore` graceful degradation, post-`stop()` semantics.
- `tests/unit/server/test_rest_guaranteed_state.cpp` — 11 cases, 88 assertions covering 201/400/409/404 mappings, full CRUD round-trip, `/push` audit, events filtering + pagination, `/status` rollup. Built against the in-process `TestRouteSink` (no live `httplib::Server`, no #438 TSan trap).
- `TestRouteSink` extended to split paths on `?` and feed the tail to `httplib::detail::parse_query_text` so `req.params` is populated. Mirrors `httplib::Server` and unblocks unit-level coverage for every existing handler that branches on `req.has_param` / `req.get_param_value`.
- `test_rbac_store.cpp` count expectations refreshed for the new securable type + op (Administrator 19×6=114, Viewer 18, ITServiceOwner 16×6=96).

## Verification

- \`meson compile -C build-linux\` clean.
- \`meson test -C build-linux --suite agent --suite server\` → **1201/1201 server, full agent suite green**.
- CHANGELOG entries added under \`[Unreleased]\` / \`### Added\` (the prod surface) and \`### Tests\` (per the test-commits convention so other teams can follow test development).

## Test plan

- [ ] Manually exercise CRUD + \`/push\` against a running server with a fresh \`admin\` session.
- [ ] Confirm \`/api/v1/guaranteed-state/events\` accepts \`?rule_id=...&limit=...\` query params end-to-end.
- [ ] Verify \`__guard__\` dispatch is intercepted at the agent and that a third-party plugin attempting to register \`__guard__\` is rejected at scan time (#453).
- [x] Run \`/governance HEAD~2..HEAD\` before merge.

## Out of scope (future PRs)

- Real guard threads, drift detection, remediation (PR 3).
- \`/guaranteed-state\` dashboard list page + reconciliation + resilience strategies (PR 4).
- Approval workflow, MCP tools, HMAC rule signing, HTMX rule editor, quarantine (PR 5+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)