### PR TITLE
ci(windows): upload meson-logs as artifact on test failure (#501)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,19 @@ jobs:
           export PATH="$bin_dir:$GITHUB_WORKSPACE/vcpkg_installed/x64-windows/tools/protobuf:$GITHUB_WORKSPACE/vcpkg_installed/x64-windows/tools/grpc:$PATH"
           meson test -C build-windows-ci --print-errorlogs
 
+      # meson+ninja truncate test stdout to the last 100 lines in the Actions
+      # UI. testlog.txt in meson-logs/ contains the full Catch2 output for
+      # every failed test — without this artifact, a multi-assertion failure
+      # only exposes ONE expansion in the workflow log. Issue #501.
+      - name: Upload meson-logs on test failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: meson-logs-windows-${{ matrix.build_type }}-${{ github.run_attempt }}
+          path: build-windows-ci/meson-logs/
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: ccache stats
         if: always()
         run: ccache -s

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CI observability: upload `meson-logs/` as artifact on Windows test
+  failure (#501).** meson + ninja truncate test stdout to the last 100
+  lines in the GitHub Actions UI, which hides all but one assertion
+  expansion when a test fails with multiple asserts.
+  `meson-logs/testlog.txt` contains the full Catch2 output for every
+  failed test. Issue #501 tracks a Windows-only `yuzu_agent_tests`
+  failure that can't be diagnosed from the truncated log —
+  two failing test cases and seven assertions are known, but only one
+  expansion currently escapes the truncation. Artifact retention 14
+  days, keyed on `build-type + run-attempt` so re-runs don't overwrite
+  each other. Added to the Windows MSVC leg only; Linux and macOS
+  will get the same treatment in a follow-up once this one has proven
+  useful.
+
 - **Windows runner hardening: broaden Defender exclusions + migrate
   project scripting to PowerShell 7+ (`pwsh.exe`) (#501, #516, #517).**
   Two coupled changes shipped together.


### PR DESCRIPTION
## Summary

- Adds \`actions/upload-artifact\` to the Windows MSVC leg of CI, guarded by \`if: failure()\`, capturing \`build-windows-ci/meson-logs/\` when \`meson test\` fails.
- Motivated by **#501** — \`yuzu_agent_tests\` on dev post-#493 fails with 2 test cases / 7 assertions on Windows MSVC debug, but meson+ninja truncate stdout to the last 100 lines and we can only see ONE assertion expansion in the workflow log. \`meson-logs/testlog.txt\` has the full Catch2 output for every failed test.
- Artifact name: \`meson-logs-windows-{debug|release}-{run_attempt}\` — re-runs don't overwrite each other.
- Retention: 14 days.
- Scope deliberately narrow: Windows only. Linux and macOS get the same treatment in a follow-up once this has proven useful; no point adding dead weight to green lanes.

## Test plan

- [x] YAML syntax scanned — only append-after-Test step on the existing Windows job
- [x] No changes to the \`Test\` step itself — so existing behaviour is preserved, artifact upload is additive
- [ ] CI: next Windows failure should produce a downloadable \`meson-logs-windows-debug-1\` artifact; use that to resolve #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)