### PR TITLE
test(guardian): switch two tests from Map::operator[] to Map::insert (#501)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Tests: switch two Guardian dispatch tests from `Map::operator[]` to
+  `Map::insert` — unblocks Windows MSVC debug CI (#501).** In
+  `tests/unit/test_guardian_engine.cpp`, the two test cases at lines 193
+  ("dispatch routes push_rules through SerializeAsString") and 265
+  ("dispatch push_rules with garbage proto → exit_code 2") populated
+  `CommandRequest.parameters` via
+  `(*cmd.mutable_parameters())["push"] = value;`. On Windows MSVC debug
+  the subsequent `cmd.parameters().find("push")` in `GuardianEngine::dispatch`
+  returned `end()` — the key was written but not findable — so dispatch
+  fell into the "missing 'push' parameter" branch, yielding exit_code=1
+  instead of the expected 0 / 2 and making every downstream substring /
+  state check fail. The failure reproduces deterministically on a clean
+  `build-windows-ci` (issue #501 has the testlog captured off the
+  runner). Signature matches an abseil / protobuf ODR layout mismatch
+  specific to the Windows static-linkage workaround documented in
+  CLAUDE.md / #375: `Map::operator[]` and `Map::find` resolving to
+  different `absl::container_internal::raw_hash_set` instantiations.
+  Switching to `insert({key, value})` takes a different internal code
+  path that is not tripped by the mismatch. Semantically equivalent
+  here because `cmd` is freshly constructed. Test-only unblock;
+  production agents are unaffected because `CommandRequest.parameters`
+  in production is populated by protobuf wire deserialization (gRPC),
+  not by C++ `operator[]`. Follow-up noted in PR description:
+  `server/core/src/server.cpp:2395,4316,4434,4577` uses the same
+  `(*cmd.mutable_parameters())[k] = v;` pattern — harmless today
+  because the server is not shipped for native Windows MSVC, but worth
+  the same switch for cross-platform robustness.
+
 - **`.claude/agents/` cleanup — token efficiency + routing effectiveness.**
   Audit-driven sweep of the subagent frontmatter and a few body-text
   fixes that bring the descriptions in line with how the parent agent

--- a/tests/unit/test_guardian_engine.cpp
+++ b/tests/unit/test_guardian_engine.cpp
@@ -201,7 +201,13 @@ TEST_CASE("GuardianEngine: dispatch routes push_rules through SerializeAsString"
     cmd.set_command_id("cmd-1");
     cmd.set_plugin("__guard__");
     cmd.set_action("push_rules");
-    (*cmd.mutable_parameters())["push"] = p.SerializeAsString();
+    // protobuf Map's operator[] is silently lossy on MSVC debug when absl's
+    // flat_hash_map gets linked in via the Windows static-linkage workaround
+    // (CLAUDE.md / #375): insert lands in one instantiation, find searches
+    // another. insert() takes a different code path inside the Map and does
+    // not trip the ODR mismatch. See #501. Semantically equivalent here
+    // because `cmd` is freshly constructed and the key does not pre-exist.
+    cmd.mutable_parameters()->insert({"push", p.SerializeAsString()});
 
     auto dr = f.engine->dispatch(cmd);
     CHECK(dr.exit_code == 0);
@@ -268,7 +274,8 @@ TEST_CASE("GuardianEngine: dispatch push_rules with garbage proto → exit_code 
     apb::CommandRequest cmd;
     cmd.set_plugin("__guard__");
     cmd.set_action("push_rules");
-    (*cmd.mutable_parameters())["push"] = "not a valid proto byte sequence";
+    // See #501 — operator[] is the broken path on MSVC debug; insert() works.
+    cmd.mutable_parameters()->insert({"push", "not a valid proto byte sequence"});
     auto dr = f.engine->dispatch(cmd);
     CHECK(dr.exit_code == 2);
     CHECK(dr.output.find("failed to parse") != std::string::npos);


### PR DESCRIPTION
## Summary

Two tests in \`tests/unit/test_guardian_engine.cpp\` were populating \`CommandRequest.parameters\` via \`(*cmd.mutable_parameters())["push"] = value;\`. On Windows MSVC debug this is silently lossy — the subsequent \`cmd.parameters().find("push")\` returns \`end()\`, so \`GuardianEngine::dispatch\` falls into the \"missing 'push' parameter\" branch instead of proceeding to \`ParseFromString()\`. Every downstream assertion then fails.

Switching both sites to \`insert({"push", value})\` — a different internal code path inside protobuf's \`Map\` — sidesteps the bug.

## Why this isn't a code regression

- **Production is not affected.** Real agents populate \`CommandRequest.parameters\` via protobuf wire deserialization (gRPC), not via C++ \`operator[]\`. The dispatch-side \`.find()\` works correctly for wire-deserialized maps (otherwise all gateway-proxied commands would fail, which they manifestly do not).
- **Semantics are preserved.** \`operator[] = v\` inserts if absent and overwrites if present; \`insert({k, v})\` inserts if absent and returns false if present. Both tests construct a fresh \`apb::CommandRequest cmd;\` immediately before the assignment, so the key does not pre-exist and the two calls are behaviourally equivalent.

## Root cause (hypothesis, tracked in #501)

Matches the signature of an abseil / protobuf ODR layout mismatch specific to the Windows static-linkage workaround documented in CLAUDE.md / #375: \`Map::operator[]\` and \`Map::find\` resolving to different \`absl::container_internal::raw_hash_set\` instantiations in the same binary. Clean-build on the runner still fails (we wiped \`build-windows-ci/\` and reran — #501 has the testlog), so this is **not** runner-state bleed. A proper root-cause fix would audit the Windows link order and deduplicate the abseil instantiations — tracked in #501.

## Follow-up already identified

\`server/core/src/server.cpp\` uses the same \`(*cmd.mutable_parameters())[k] = v;\` pattern in four places:

- \`server.cpp:2395\`
- \`server.cpp:4316\`
- \`server.cpp:4434\`
- \`server.cpp:4577\`

Harmless today because the server is not shipped for native Windows MSVC. Worth the same switch for cross-platform robustness when someone picks up the follow-up — **not in scope here** to keep this PR tightly scoped to the CI unblock.

## Test plan

- [x] \`meson compile -C build-linux yuzu_agent_tests\` — clean
- [x] \`./tests-build-agent-linux_x64/yuzu_agent_tests [guardian]\` — 13 cases / 79 assertions, all green
- [x] Full \`yuzu_agent_tests\` — 366 cases / 29332 assertions, all green
- [ ] CI: Windows MSVC debug must go green on this PR (the proof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)