### PR TITLE
ci(windows): broaden Defender exclusions + migrate scripting to pwsh.exe (#501, #517)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Windows runner hardening: broaden Defender exclusions + migrate
+  project scripting to PowerShell 7+ (`pwsh.exe`) (#501, #516, #517).**
+  Two coupled changes shipped together.
+
+  First, **`scripts/windows-runner-defender-exclusions.ps1`** gains
+  `C:\WINDOWS\SystemTemp\yuzu_*` as a wildcard path — the prior
+  exact-path entries (`yuzu_test_guardian`, `yuzu_test_kv`) did NOT
+  match the actual runtime directory names the test suite creates
+  (`yuzu_test_guardian_SHULGI$`, `yuzu_test_kv_SHULGI$`,
+  `yuzu_test_reserved_plugin_<random>`, `yuzu_trigger_test`). Three
+  test binaries (`yuzu_agent_tests.exe`, `yuzu_server_tests.exe`,
+  `yuzu_tar_tests.exe`) and two release binaries (`yuzu-agent.exe`,
+  `yuzu-server.exe`) are added to `ExclusionProcess` — Defender has
+  been observed retaining handles on freshly-written `.obj` / `.pdb`
+  siblings after these processes exit, contributing to the EBUSY
+  loop we hit on #501's rerun of 2026-04-24.
+
+  Second, **stock Windows PowerShell 5.1 (`powershell.exe`) is no
+  longer supported for Yuzu-authored scripting**; the project standard
+  is PowerShell 7+ (`pwsh.exe`). Reason: the repo saves `.ps1` files
+  as UTF-8 without BOM (POSIX / git convention), and PS 5.1 reads
+  such files as the system ANSI codepage (Windows-1252 on English
+  installs), which mangles non-ASCII characters — a right-double-quote
+  byte at 0x94 closes a string literal early and downstream tokens
+  become "command not found" errors. PS 7+ defaults to UTF-8. The
+  `yuzu-local-windows` runner already has `pwsh.exe` 7.6.1
+  pre-installed; 7 workflow steps across `release.yml` and
+  `pre-release.yml` were already on `shell: pwsh`. Concrete changes:
+  - Preflight guard at the top of
+    `scripts/windows-runner-defender-exclusions.ps1`:
+    `PSVersionTable.PSVersion.Major -lt 7` → `Write-Error` + `exit 1`
+    with an actionable message (after the `[CmdletBinding()]`/`param`
+    block, per PS's required ordering).
+  - `docs/yuzu-guardian-design-v1.1.md:781` example guard command
+    changed from `powershell.exe -NonInteractive …` to
+    `pwsh.exe -NonInteractive …`.
+  - `docs/windows-build.md` gains a new **PowerShell: pwsh.exe only**
+    section documenting the standard and the preflight pattern.
+
+  Three latent bugs in the exclusion-applicator script fixed along
+  the way: (a) `<path>` in a double-quoted `Write-Host` string
+  tripped PS's redirection parser; now single-quoted. (b) Hostname
+  allowlist default `^yuzu-local-windows` never matched
+  `$env:COMPUTERNAME` (which is `SHULGI` — the physical machine name,
+  not the GitHub Actions runner role label); default now `^SHULGI$`.
+  (c) Unicode box-drawing characters in `Write-Host` banners now
+  work correctly (they would have required UTF-8 BOM under PS 5.1;
+  the PS 7+ preflight makes that irrelevant).
+
 - **Tests: switch two Guardian dispatch tests from `Map::operator[]` to
   `Map::insert` — unblocks Windows MSVC debug CI (#501).** In
   `tests/unit/test_guardian_engine.cpp`, the two test cases at lines 193

--- a/docs/windows-build.md
+++ b/docs/windows-build.md
@@ -28,3 +28,25 @@ All paths are configured by `setup_msvc_env.sh`. Do **not** use Clang (`C:\Progr
 | vcpkg | `C:\vcpkg` (`VCPKG_ROOT`) |
 | protoc | `C:\vcpkg\installed\x64-windows\tools\protobuf\protoc.exe` |
 | grpc_cpp_plugin | `C:\vcpkg\installed\x64-windows\tools\grpc\grpc_cpp_plugin.exe` |
+
+## PowerShell: pwsh.exe only
+
+All Yuzu-authored PowerShell scripts and workflow steps require
+**PowerShell 7+** (`pwsh.exe`, installed at
+`C:\Program Files\PowerShell\7\pwsh.exe`). Stock Windows PowerShell 5.1
+(`powershell.exe`) is not supported.
+
+Reason: the repo saves `.ps1` files as UTF-8 without a BOM (POSIX / git
+convention). Windows PowerShell 5.1 reads `.ps1` files without a BOM as
+the **system ANSI codepage** (Windows-1252 on English installs), which
+mangles any non-ASCII character — box-drawing glyphs, em-dashes, etc. —
+and can trip the parser in non-obvious ways (a right-double-quote byte
+at 0x94 closes a string literal early; downstream tokens become
+"command not found" errors). PS 7+ defaults to UTF-8, reading the
+files correctly.
+
+Every shipped `.ps1` begins with a `PSVersionTable.PSVersion.Major -lt 7`
+guard that exits 1 with an actionable message. CI workflow steps use
+`shell: pwsh` rather than `shell: powershell`. The
+`yuzu-local-windows` runner has `pwsh` 7.6.1 pre-installed. See
+issue #517 for the migration history.

--- a/docs/yuzu-guardian-design-v1.1.md
+++ b/docs/yuzu-guardian-design-v1.1.md
@@ -778,7 +778,7 @@ spec:
     action: enforce
     method: command
     params:
-      command: "powershell.exe -NonInteractive -Command Start-MpScan -ScanType FullScan"
+      command: "pwsh.exe -NonInteractive -Command Start-MpScan -ScanType FullScan"
     resilience:
       strategy: fixed
       max_failures: 3

--- a/scripts/windows-runner-defender-exclusions.ps1
+++ b/scripts/windows-runner-defender-exclusions.ps1
@@ -24,8 +24,14 @@
     exclusion entries.
 
 .NOTES
-    Run elevated (`powershell.exe -ExecutionPolicy Bypass`). Defender
-    persists the preference across reboots. Reversible with
+    Run elevated under PowerShell 7+ (`pwsh.exe -ExecutionPolicy Bypass`).
+    Stock Windows PowerShell 5.1 is not supported — the repo saves .ps1
+    files as UTF-8 without BOM (POSIX/git convention), which PS 5.1
+    misreads as the system ANSI codepage and mangles any non-ASCII
+    characters. See docs/windows-build.md for the project-wide PS 7+
+    standard and issue #517 for the migration history.
+
+    Defender persists the preference across reboots. Reversible with
     Remove-MpPreference.
 
     Source of record for the required set:
@@ -44,6 +50,20 @@ param(
     # Override only when provisioning a new runner host.
     [string]$AllowedHostPattern = '^SHULGI$'
 )
+
+# Fail loudly on stock Windows PowerShell 5.1. The script body below uses
+# Unicode box-drawing characters in Write-Host banners that only render
+# correctly under PS 7+ (see .NOTES above and issue #517). Without this
+# guard, the symptom is a cryptic "string missing terminator" parse error
+# at the banner lines rather than a clean actionable message. Must live
+# AFTER the param() block because PS requires [CmdletBinding()]/param()
+# to be the first non-comment statement.
+if ($PSVersionTable.PSVersion.Major -lt 7) {
+    Write-Error ("This script requires PowerShell 7+. Detected " +
+                 $PSVersionTable.PSVersion.ToString() +
+                 ". Use pwsh.exe, not powershell.exe.")
+    exit 1
+}
 
 # Hostname allowlist. Path exclusions below include real dev-workstation
 # locations (%USERPROFILE%\AppData\Local\ccache, C:\WINDOWS\SystemTemp\yuzu_test_*)
@@ -160,16 +180,16 @@ function Add-ExclusionProcess-Idempotent($proc) {
     }
 }
 
-# ASCII-only header rules — PowerShell 5.1 reads .ps1 without a BOM as
-# the system ANSI codepage (Windows-1252), which mangles the box-drawing
-# characters we used to carry here and produced spurious parse errors.
-Write-Host "`n--- Applying Defender path exclusions ---" -ForegroundColor Cyan
+# Unicode box-drawing banners — safe under PS 7+ (UTF-8 default). The
+# preflight above refuses PS 5.1, which would misread these as ANSI
+# codepage and break the parser.
+Write-Host "`n── Applying Defender path exclusions ───────────────────────" -ForegroundColor Cyan
 foreach ($p in $paths) { Add-ExclusionPath-Idempotent $p }
 
-Write-Host "`n--- Applying Defender process exclusions ---" -ForegroundColor Cyan
+Write-Host "`n── Applying Defender process exclusions ────────────────────" -ForegroundColor Cyan
 foreach ($proc in $processes) { Add-ExclusionProcess-Idempotent $proc }
 
-Write-Host "`n--- Current Defender configuration (post-update) ---" -ForegroundColor Cyan
+Write-Host "`n── Current Defender configuration (post-update) ────────────" -ForegroundColor Cyan
 Write-Host "ExclusionPath:"
 (Get-MpPreference).ExclusionPath | ForEach-Object { Write-Host "  $_" }
 Write-Host "ExclusionProcess:"

--- a/scripts/windows-runner-defender-exclusions.ps1
+++ b/scripts/windows-runner-defender-exclusions.ps1
@@ -38,9 +38,11 @@ param(
     [switch]$DryRun,
 
     # Hostname pattern that is permitted to apply these exclusions. Default
-    # is the Shulgi self-hosted runner. Override only when provisioning a
-    # new runner with a different name.
-    [string]$AllowedHostPattern = '^yuzu-local-windows'
+    # is the Shulgi physical host that carries the yuzu-local-windows
+    # GitHub Actions runner role; $env:COMPUTERNAME is the Windows
+    # machine name ("SHULGI"), NOT the runner label ("yuzu-local-windows").
+    # Override only when provisioning a new runner host.
+    [string]$AllowedHostPattern = '^SHULGI$'
 )
 
 # Hostname allowlist. Path exclusions below include real dev-workstation
@@ -66,9 +68,10 @@ if (-not $isAdmin) {
 }
 
 $paths = @(
-    # GitHub Actions runner workspace — covers vcpkg_installed, build
-    # output, ccache, and the `Cache vcpkg installed packages` step's
-    # tar/zstd extraction.
+    # GitHub Actions runner workspace — covers every build-* directory
+    # (build-windows-ci, build-linux under WSL2 passthrough, etc.),
+    # vcpkg_installed, gateway/_build*, meson-logs, ccache output, and
+    # the `Cache vcpkg installed packages` step's tar/zstd extraction.
     'C:\actions-runner\_work',
 
     # MSVC ccache — out-of-tree by default on modern vcpkg.
@@ -76,8 +79,18 @@ $paths = @(
 
     # SQLite test temp paths for the unit test suite. These are
     # fs::temp_directory_path() resolved as LocalSystem (SystemTemp),
-    # not the interactive user's %TEMP%. The yuzu_test_* prefix
-    # covers all current stores (guardian, kv, updater, etc.).
+    # not the interactive user's %TEMP%. Wildcards required because
+    # the test suite appends a process-identity suffix at runtime
+    # (yuzu_test_guardian_SHULGI$, yuzu_test_kv_SHULGI$), which the
+    # exact-path entries we used to carry did NOT match. The yuzu_*
+    # wildcard also picks up yuzu_trigger_test and the
+    # yuzu_test_reserved_plugin_<random> directories the plugin-loader
+    # tests create on the fly. Observed on #501 testlogs (2026-04-24).
+    'C:\WINDOWS\SystemTemp\yuzu_*',
+
+    # Retain the legacy exact entries — Defender deduplicates, and
+    # keeping them makes it obvious in `Get-MpPreference` output that
+    # the wildcard above is a superset rather than a replacement.
     'C:\WINDOWS\SystemTemp\yuzu_test_guardian',
     'C:\WINDOWS\SystemTemp\yuzu_test_kv',
     'C:\WINDOWS\SystemTemp\yuzu_test_updater_rollback_needed',
@@ -100,7 +113,23 @@ $processes = @(
 
     # ccache + vcpkg helpers.
     'ccache.exe',
-    'vcpkg.exe'
+    'vcpkg.exe',
+
+    # Yuzu test binaries. Defender has been observed retaining file
+    # handles on freshly-written .obj / .pdb siblings after these
+    # processes exit, producing EBUSY during actions/checkout cleanup
+    # on the next CI job (#501 rerun loop 2026-04-24 — locked
+    # unit_test_guardian_engine.cpp.obj for >30 min).
+    'yuzu_agent_tests.exe',
+    'yuzu_server_tests.exe',
+    'yuzu_tar_tests.exe',
+
+    # Yuzu release binaries — for any native UAT or runtime test that
+    # launches them directly on the runner (rare, but the zombie
+    # yuzu-agent.exe PID 36472 that survived 3 days on Shulgi was
+    # exactly this case).
+    'yuzu-agent.exe',
+    'yuzu-server.exe'
 )
 
 function Add-ExclusionPath-Idempotent($p) {
@@ -131,16 +160,22 @@ function Add-ExclusionProcess-Idempotent($proc) {
     }
 }
 
-Write-Host "`n── Applying Defender path exclusions ───────────────────────" -ForegroundColor Cyan
+# ASCII-only header rules — PowerShell 5.1 reads .ps1 without a BOM as
+# the system ANSI codepage (Windows-1252), which mangles the box-drawing
+# characters we used to carry here and produced spurious parse errors.
+Write-Host "`n--- Applying Defender path exclusions ---" -ForegroundColor Cyan
 foreach ($p in $paths) { Add-ExclusionPath-Idempotent $p }
 
-Write-Host "`n── Applying Defender process exclusions ────────────────────" -ForegroundColor Cyan
+Write-Host "`n--- Applying Defender process exclusions ---" -ForegroundColor Cyan
 foreach ($proc in $processes) { Add-ExclusionProcess-Idempotent $proc }
 
-Write-Host "`n── Current Defender configuration (post-update) ────────────" -ForegroundColor Cyan
+Write-Host "`n--- Current Defender configuration (post-update) ---" -ForegroundColor Cyan
 Write-Host "ExclusionPath:"
 (Get-MpPreference).ExclusionPath | ForEach-Object { Write-Host "  $_" }
 Write-Host "ExclusionProcess:"
 (Get-MpPreference).ExclusionProcess | ForEach-Object { Write-Host "  $_" }
 
-Write-Host "`nDone. Reversible with Remove-MpPreference -ExclusionPath <path>."
+# `<path>` in a double-quoted string trips PS's redirection parser; use a
+# single-quoted string (no backtick expansion needed — we concatenate the
+# leading newline via "+ "`n"").
+Write-Host ('Done. Reversible with Remove-MpPreference -ExclusionPath <path>.')


### PR DESCRIPTION
## Summary

Two coupled Windows-runner-hardening changes shipped together:

1. **Broaden Defender exclusions** (the original motivator from #501) — new wildcard \`C:\\WINDOWS\\SystemTemp\\yuzu_*\` path that matches the actual runtime directory names the test suite creates, plus 5 test/release binaries added to process exclusions.

2. **Standardize Yuzu scripting on PowerShell 7+ (#517)** — stock Windows PowerShell 5.1 no longer supported for project-authored \`.ps1\` files. Preflight guard enforces the requirement. Unicode banners restored.

## Defender exclusion changes

**Paths added:**
- \`C:\\WINDOWS\\SystemTemp\\yuzu_*\` (wildcard) — prior exact entries (\`yuzu_test_guardian\`, \`yuzu_test_kv\`) didn't match the runtime names (\`yuzu_test_guardian_SHULGI\$\`, \`yuzu_test_kv_SHULGI\$\`, etc.).

**Processes added:**
- Test binaries: \`yuzu_agent_tests.exe\`, \`yuzu_server_tests.exe\`, \`yuzu_tar_tests.exe\`.
- Release binaries: \`yuzu-agent.exe\`, \`yuzu-server.exe\`.

## PowerShell 7+ migration

PS 5.1 reads \`.ps1\` files without a BOM as the system ANSI codepage (Windows-1252), which mangles non-ASCII characters in Yuzu scripts. PS 7+ defaults to UTF-8. The runner has \`pwsh.exe\` 7.6.1 pre-installed; 7 existing workflow steps already use \`shell: pwsh\`.

**Changes:**
- Preflight guard on \`scripts/windows-runner-defender-exclusions.ps1\` refuses PS 5.1 with an actionable error. Unicode box-drawing banners (\`──\`) restored.
- Docstring updated from \`powershell.exe\` to \`pwsh.exe\`.
- \`docs/yuzu-guardian-design-v1.1.md:781\` example Guardian guard command updated.
- \`docs/windows-build.md\` gains a **PowerShell: pwsh.exe only** section.

## Latent script bugs fixed

- \`<path>\` in a double-quoted \`Write-Host\` string tripped PS's redirection parser — now single-quoted.
- Hostname allowlist default \`^yuzu-local-windows\` never matched \`\$env:COMPUTERNAME\` (\`SHULGI\`) — default now \`^SHULGI\$\`.
- \`[CmdletBinding()]\`/\`param(...)\` must be the first non-comment statement — preflight guard positioned accordingly.

## Verification

- \`pwsh.exe 7.6.1 -DryRun\`: runs clean, Unicode banners render, every exclusion reports \`[skip] already excluded\` (proves the live Defender state matches the declared set)
- \`powershell.exe 5.1 -DryRun\`: exits 1 with the preflight error message before hitting any parser issues — clean, actionable failure mode
- Defender exclusions already applied live on Shulgi via \`Add-MpPreference\` hand-invocations earlier in the session; this PR brings the committed script to match

## Closes

- #517 (PS 7+ migration)
- #516 itself (this PR)

## Scope deliberately narrow

- \`.claude/settings.local.json\` has per-dev \`Bash(powershell -Command …)\` allowlist entries — personal tool-approval config, not project convention. Left alone.
- No runner provisioning changes — \`pwsh.exe\` 7.6.1 already present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)