### PR TITLE
 - pbkdf2_sha256() accepts any iteration count from callers with no f…

### DIFF
--- a/server/core/src/auth.cpp
+++ b/server/core/src/auth.cpp
@@ -67,6 +67,8 @@ std::vector<uint8_t> AuthManager::hex_to_bytes(const std::string& hex) {
 std::string AuthManager::pbkdf2_sha256(const std::string& password,
                                        const std::vector<uint8_t>& salt, int iterations) {
     constexpr int kKeyLen = 32; // SHA-256 output
+    constexpr int kMinIterations = 210'000;
+    iterations = std::max(iterations, kMinIterations);
     std::vector<uint8_t> derived(kKeyLen);
 
 #ifdef _WIN32


### PR DESCRIPTION

## Summary

 - pbkdf2_sha256() accepts any iteration count from callers with no floor. OWASP recommends ≥ 210,000 iterations for PBKDF2-SHA256.
 
  This PR is a fix to  Add iterations = std::max(iterations, 210'000u) or assert at function entry.

## Type of Change

- [ ] Feature (new functionality)
- [x] Bug fix
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] CI / Build

## Testing

<!-- What testing was done? -->

## Checklist

- [ ] Builds on Linux (GCC and Clang)
- [ ] Builds on Windows (MSVC)
- [ ] Tests pass (`ctest --preset linux-debug`)
- [ ] No new clang-tidy warnings
- [ ] No new compiler warnings
- [ ] I have signed the [Contributor License Agreement](../CLA.md) (either via the CLA workflow comment on this PR, or by appending my name to the Signatories section of `CLA.md`)
