### PR TITLE
fix(server): audit-coverage + SSE dedup decision + login latency (PR 4 of governance ladder)

### DIFF
--- a/server/core/include/yuzu/server/auth.hpp
+++ b/server/core/include/yuzu/server/auth.hpp
@@ -9,6 +9,7 @@
 #include <unordered_map>
 #include <vector>
 
+namespace yuzu { class MetricsRegistry; }
 namespace yuzu::server { class AuthDB; }
 
 namespace yuzu::server::auth {
@@ -106,6 +107,11 @@ public:
     /// If set, user operations go through the DB instead of config file.
     /// If not set, falls back to config file I/O (backwards compatible).
     void set_auth_db(yuzu::server::AuthDB* db) { auth_db_ = db; }
+
+    /// Set the metrics registry for emitting login-latency histograms.
+    /// Optional; if null, authenticate() emits no metric (used by tests
+    /// that don't construct the server's MetricsRegistry).
+    void set_metrics_registry(yuzu::MetricsRegistry* m) { metrics_ = m; }
 
     /// Create a session for an externally-authenticated user (OIDC).
     /// Role: admin if user is in the admin group, or email/name matches a local admin.
@@ -215,6 +221,9 @@ private:
 
     // Non-owning pointer to AuthDB; if set, persistence goes through DB.
     yuzu::server::AuthDB* auth_db_ = nullptr;
+
+    // Non-owning pointer to MetricsRegistry; null in tests/CLI tools.
+    yuzu::MetricsRegistry* metrics_ = nullptr;
 
     // Enrollment tokens keyed by token_id
     std::unordered_map<std::string, EnrollmentToken> enrollment_tokens_;

--- a/server/core/src/audit_store.cpp
+++ b/server/core/src/audit_store.cpp
@@ -109,8 +109,20 @@ void AuditStore::log(const AuditEvent& event) {
     sqlite3_bind_text(stmt, 11, event.result.c_str(), -1, SQLITE_TRANSIENT);
     sqlite3_bind_int64(stmt, 12, ttl);
 
-    sqlite3_step(stmt);
+    int step_rc = sqlite3_step(stmt);
     sqlite3_finalize(stmt);
+
+    // SOC 2 CC7.2: a privileged-mutation handler that emits an audit event
+    // and silently fails to persist it produces a forensically-empty row.
+    // Surface the failure count so operators can alert on a non-zero rate.
+    // We still bucket the per-result counter below so the success/failure
+    // ratio remains observable separately from the emit-failed signal.
+    if (step_rc != SQLITE_DONE) {
+        emit_failed_.fetch_add(1, std::memory_order_relaxed);
+        spdlog::error("AuditStore: sqlite3_step rc={} ({}); event lost",
+                      step_rc, sqlite3_errmsg(db_));
+        return;
+    }
 
     // Bucket the write into a Prometheus-friendly counter so the audit subsystem
     // is observable from the /metrics scrape. Result vocabulary is open-ended at

--- a/server/core/src/audit_store.hpp
+++ b/server/core/src/audit_store.hpp
@@ -59,6 +59,14 @@ public:
     /// Prometheus scraping; reset at process start. Lock-free reads.
     uint64_t events_written(const std::string& result) const noexcept;
 
+    /// Cumulative count of audit events that failed to persist (sqlite3_step
+    /// did not return SQLITE_DONE). Audit pipeline degradation is a SOC 2
+    /// CC7.2 evidence-chain risk; surface it on /metrics so operators can
+    /// page on a non-zero rate.
+    uint64_t emit_failed_count() const noexcept {
+        return emit_failed_.load(std::memory_order_relaxed);
+    }
+
     void start_cleanup();
     void stop_cleanup();
 
@@ -73,6 +81,9 @@ private:
     std::atomic<uint64_t> events_failure_{0};
     std::atomic<uint64_t> events_denied_{0};
     std::atomic<uint64_t> events_other_{0};
+    // Persistence-failure counter: rows where the INSERT step returned
+    // anything other than SQLITE_DONE.
+    std::atomic<uint64_t> emit_failed_{0};
 #ifdef __cpp_lib_jthread
     std::jthread cleanup_thread_;
 #else

--- a/server/core/src/auth.cpp
+++ b/server/core/src/auth.cpp
@@ -1,5 +1,6 @@
 #include <yuzu/server/auth.hpp>
 #include <yuzu/server/auth_db.hpp>
+#include <yuzu/metrics.hpp>
 
 #include <spdlog/spdlog.h>
 
@@ -395,11 +396,25 @@ bool AuthManager::first_run_setup(const std::filesystem::path& cfg_path) {
 
 std::optional<std::string> AuthManager::authenticate(const std::string& username,
                                                      const std::string& password) {
+    // Time the PBKDF2 verify path. Histogram is observed even on failure
+    // (unknown user / bad password) because the dominant cost on a busy
+    // server is the iteration loop itself, and a regression there hits
+    // both branches equally. Buckets default to ms-scale; PBKDF2 at
+    // 100k iterations runs ~50-150 ms on commodity hardware.
+    const auto t_start = std::chrono::steady_clock::now();
+
     std::unique_lock lock(mu_);
 
     auto it = users_.find(username);
     if (it == users_.end()) {
         spdlog::warn("Auth failed: unknown user '{}'", username);
+        if (metrics_) {
+            const auto elapsed = std::chrono::duration<double>(
+                std::chrono::steady_clock::now() - t_start).count();
+            metrics_->histogram("yuzu_auth_login_duration_seconds",
+                                {{"method", "password"}, {"result", "unknown_user"}})
+                .observe(elapsed);
+        }
         return std::nullopt;
     }
 
@@ -408,6 +423,13 @@ std::optional<std::string> AuthManager::authenticate(const std::string& username
 
     if (!constant_time_compare(hash, it->second.hash_hex)) {
         spdlog::warn("Auth failed: bad password for '{}'", username);
+        if (metrics_) {
+            const auto elapsed = std::chrono::duration<double>(
+                std::chrono::steady_clock::now() - t_start).count();
+            metrics_->histogram("yuzu_auth_login_duration_seconds",
+                                {{"method", "password"}, {"result", "bad_password"}})
+                .observe(elapsed);
+        }
         return std::nullopt;
     }
 
@@ -429,6 +451,13 @@ std::optional<std::string> AuthManager::authenticate(const std::string& username
     sessions_[token] = std::move(s);
 
     spdlog::info("User '{}' authenticated (role={})", username, role_to_string(it->second.role));
+    if (metrics_) {
+        const auto elapsed = std::chrono::duration<double>(
+            std::chrono::steady_clock::now() - t_start).count();
+        metrics_->histogram("yuzu_auth_login_duration_seconds",
+                            {{"method", "password"}, {"result", "success"}})
+            .observe(elapsed);
+    }
     return token;
 }
 

--- a/server/core/src/auth_routes.cpp
+++ b/server/core/src/auth_routes.cpp
@@ -143,6 +143,11 @@ bool AuthRoutes::require_admin(const httplib::Request& req, httplib::Response& r
     if (!session)
         return false;
     if (session->role != auth::Role::admin) {
+        // SOC 2 CC7.2: every privileged-endpoint denial must surface in
+        // the audit chain, not just the request log. Emitting here closes
+        // the gap for every caller in one place rather than threading an
+        // audit_fn through dozens of route registrations (governance PR4).
+        audit_log(req, "auth.admin_required", "denied", "endpoint", req.path);
         res.status = 403;
         res.set_content(
             R"({"error":{"code":403,"message":"admin role required"},"meta":{"api_version":"v1"}})",

--- a/server/core/src/server.cpp
+++ b/server/core/src/server.cpp
@@ -249,6 +249,19 @@ public:
                           "gauge");
         metrics_.describe("yuzu_server_audit_events_total",
                           "Audit events written, bucketed by result", "counter");
+        // Audit-pipeline observability (governance PR4 OBS-4). Increments when
+        // audit_store->add_event()'s SQLite step does not return DONE — pages
+        // operators that the audit chain itself is degraded.
+        metrics_.describe("yuzu_server_audit_emit_failed_total",
+                          "Audit events that failed to persist (sqlite3_step != DONE)",
+                          "counter");
+        // Login-latency observability (governance PR4 OBS-2). Histogram of
+        // PBKDF2 verify duration, labelled by result so alerts can fire on
+        // success-path regressions independently of brute-force noise on
+        // bad_password / unknown_user.
+        metrics_.describe("yuzu_auth_login_duration_seconds",
+                          "Login PBKDF2 verify latency in seconds, by method and result",
+                          "histogram");
         // Guardian observability (#452 §6). Sized at zero before ingest
         // starts so Prometheus alert rules on these metric names can be
         // authored up front — e.g. events_total > 5e6 as an early-warning
@@ -276,6 +289,11 @@ public:
 
         // Wire health store into agent service
         agent_service_.set_health_store(&health_store_);
+
+        // Wire metrics registry into auth manager so authenticate() can
+        // observe login latency. Optional in tests/CLI tools that don't
+        // construct a ServerImpl (auth_mgr_.metrics_ stays nullptr there).
+        auth_mgr_.set_metrics_registry(&metrics_);
 
         // Create gateway upstream service if configured
         if (!cfg_.gateway_upstream_address.empty()) {
@@ -860,6 +878,9 @@ public:
                         .set(static_cast<double>(audit_store_->events_written("denied")));
                     metrics_.gauge("yuzu_server_audit_events_total", {{"result", "other"}})
                         .set(static_cast<double>(audit_store_->events_written("other")));
+                    // OBS-4: surface audit-pipeline persistence failures.
+                    metrics_.gauge("yuzu_server_audit_emit_failed_total")
+                        .set(static_cast<double>(audit_store_->emit_failed_count()));
                 }
                 // Guardian scalars + cumulative write/reap counters. Use
                 // gauges for the count-now values (SQL COUNT(*)) and for the

--- a/server/core/src/settings_routes.cpp
+++ b/server/core/src/settings_routes.cpp
@@ -2471,6 +2471,20 @@ void SettingsRoutes::register_routes(HttpRouteSink& sink,
             return;
         }
         auto username = req.matches[1].str();
+        // Username allowlist before any state mutation. Without this a
+        // hand-crafted DELETE against `..%2Ffoo` or characters that
+        // bypass URL canonicalisation reaches remove_user() with bytes
+        // that should never have entered the user-store path.
+        if (!is_valid_username(username)) {
+            audit_fn_(req, "user.delete", "denied", "User", username, "invalid_username");
+            res.status = 400;
+            res.set_header(
+                "HX-Trigger",
+                R"({"showToast":{"message":"Invalid username format","level":"error"}})");
+            res.set_content(render_users_fragment(session->username),
+                            "text/html; charset=utf-8");
+            return;
+        }
         // Self-deletion lockout guard (#397). Deleting the currently
         // authenticated operator — typically the sole admin on a single-
         // seat deployment — leaves the running server with zero usable
@@ -2505,6 +2519,15 @@ void SettingsRoutes::register_routes(HttpRouteSink& sink,
             audit_fn_(req, "user.delete", "success", "User", username, "");
             res.set_header("HX-Trigger",
                 R"({"showToast":{"message":"User deleted","level":"success"}})");
+        } else {
+            // remove_user() returns false when the username is not in the
+            // user store. A no-op DELETE is still a privileged-mutation
+            // attempt and must surface in the audit chain.
+            audit_fn_(req, "user.delete", "denied", "User", username, "user_not_found");
+            res.status = 404;
+            res.set_header(
+                "HX-Trigger",
+                R"({"showToast":{"message":"User not found","level":"error"}})");
         }
         res.set_content(render_users_fragment(session->username),
                         "text/html; charset=utf-8");
@@ -2531,6 +2554,11 @@ void SettingsRoutes::register_routes(HttpRouteSink& sink,
 
         // H1 FIX: Validate username in path parameter
         if (!is_valid_username(target_username)) {
+            // SOC 2 CC7.2: every denied branch on a privileged-mutation
+            // endpoint emits an audit event so the SIEM evidence chain is
+            // complete (governance PR4 audit-coverage).
+            audit_fn_(req, "user.role_change", "denied", "User", target_username,
+                      "invalid_username");
             res.status = 400;
             res.set_header(
                 "HX-Trigger",
@@ -2561,6 +2589,8 @@ void SettingsRoutes::register_routes(HttpRouteSink& sink,
         try {
             auto json = nlohmann::json::parse(req.body);
             if (!json.contains("role") || !json["role"].is_string()) {
+                audit_fn_(req, "user.role_change", "denied", "User", target_username,
+                          "missing_role");
                 res.status = 400;
                 res.set_header(
                     "HX-Trigger",
@@ -2571,6 +2601,8 @@ void SettingsRoutes::register_routes(HttpRouteSink& sink,
             }
             requested_role = json["role"].get<std::string>();
         } catch (const std::exception& e) {
+            audit_fn_(req, "user.role_change", "denied", "User", target_username,
+                      "invalid_json");
             res.status = 400;
             res.set_header(
                 "HX-Trigger",
@@ -2587,6 +2619,8 @@ void SettingsRoutes::register_routes(HttpRouteSink& sink,
         } else if (requested_role == "user") {
             new_role = auth::Role::user;
         } else {
+            audit_fn_(req, "user.role_change", "denied", "User", target_username,
+                      "invalid_role");
             res.status = 400;
             res.set_header(
                 "HX-Trigger",
@@ -2599,6 +2633,8 @@ void SettingsRoutes::register_routes(HttpRouteSink& sink,
         // Get current role for audit logging
         auto current_entry_opt = auth_mgr_->get_user_role(target_username);
         if (!current_entry_opt) {
+            audit_fn_(req, "user.role_change", "denied", "User", target_username,
+                      "user_not_found");
             res.status = 404;
             res.set_header(
                 "HX-Trigger",
@@ -2611,6 +2647,11 @@ void SettingsRoutes::register_routes(HttpRouteSink& sink,
 
         // No-op if role unchanged
         if (old_role == new_role) {
+            // No state change, but audit the operator's intent — distinguishes
+            // "tried to set already-current role" from "no request was made"
+            // for compliance review.
+            audit_fn_(req, "user.role_change", "no_op", "User", target_username,
+                      "same_role=" + auth::role_to_string(new_role));
             res.set_header(
                 "HX-Trigger",
                 R"({"showToast":{"message":"Role unchanged","level":"info"}})");
@@ -2622,6 +2663,8 @@ void SettingsRoutes::register_routes(HttpRouteSink& sink,
         // Perform role change (AuthManager.update_role() handles DB + session invalidation)
         if (!auth_mgr_->update_role(target_username, new_role)) {
             spdlog::error("Failed to update role for '{}'", target_username);
+            audit_fn_(req, "user.role_change", "denied", "User", target_username,
+                      "db_failure");
             res.status = 500;
             res.set_header(
                 "HX-Trigger",

--- a/server/core/src/workflow_routes.cpp
+++ b/server/core/src/workflow_routes.cpp
@@ -612,10 +612,15 @@ void WorkflowRoutes::register_routes(HttpRouteSink& sink, Deps deps) {
     //      EventSource error). Unsubscribes from the channel; the channel
     //      itself is GC'd by `gc_terminal_channels` when retention expires.
     //
-    // Audit policy: emit `execution.live_subscribe` ONCE per session per
-    // execution, not per SSE reconnect — the SSE reconnect storm under a
-    // brief network hiccup must not spray audit rows. Per-session dedup
-    // is handled by the seen-set the handler keeps in scope.
+    // Audit policy: emit `execution.live_subscribe` on every successful
+    // Subscribe. The handler does NOT dedup per session-per-execution
+    // currently — dedup is deferred (governance Deferred-5 / #700) because
+    // a correct implementation needs lock-protected seen-set state, and a
+    // naive dedup has a TOCTOU window where a concurrent reconnect can
+    // both observe "not seen" and both emit. Operators on the SOC 2 evidence
+    // chain currently get a row per reconnect; the forensic-grade audit on
+    // first-load remains on /fragments/executions/{id}/detail's
+    // `execution.detail.view`.
     sink.Get(R"(/sse/executions/([A-Za-z0-9_-]{1,128}))",
         [auth_fn, perm_fn, audit_fn, execution_tracker, execution_event_bus](
             const httplib::Request& req, httplib::Response& res) {
@@ -655,9 +660,9 @@ void WorkflowRoutes::register_routes(HttpRouteSink& sink, Deps deps) {
                 return;
             }
 
-            // sec audit: per-session-per-execution dedup. The session
-            // username + execution id is the dedup key. Skipping the
-            // audit on reconnect is policy (see comment block above).
+            // Audit every successful subscribe. Dedup is deferred per
+            // governance Deferred-5 / #700; the comment block above this
+            // route registration explains the contract.
             audit_fn(req, "execution.live_subscribe", "success", "Execution",
                      exec_id, "");
 

--- a/tests/unit/server/test_auth.cpp
+++ b/tests/unit/server/test_auth.cpp
@@ -7,6 +7,8 @@
 
 #include <yuzu/server/auth.hpp>
 
+#include "../test_helpers.hpp"
+
 #include <catch2/catch_test_macros.hpp>
 
 #include <filesystem>
@@ -18,28 +20,23 @@ using namespace yuzu::server::auth;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-/// Create an AuthManager configured to use a temp directory for config files.
+/// Create an AuthManager configured to use a per-test config file.
+///
+/// Previously this used a hardcoded shared `yuzu_test_auth` directory and a
+/// process-wide cleanup_guard, which meant any two tests running in the same
+/// process saw each other's state via the on-disk file even though they
+/// thought they had a clean AuthManager. Migrated to the canonical helper —
+/// every call gets its own unique path so tests are independent.
+/// (governance qe-B2; flake-class #473.)
 static std::unique_ptr<AuthManager> make_temp_auth() {
     auto mgr = std::make_unique<AuthManager>();
-    auto tmp = fs::temp_directory_path() / "yuzu_test_auth";
-    fs::create_directories(tmp);
-    auto cfg = tmp / "auth.cfg";
-    // Ensure clean state by removing stale config
+    auto cfg = yuzu::test::unique_temp_path("yuzu-test-auth-");
+    cfg += ".cfg";
+    fs::create_directories(cfg.parent_path());
     fs::remove(cfg);
-    // Load will return false (no file yet) — that's fine, we start empty
     mgr->load_config(cfg);
     return mgr;
 }
-
-/// Clean up the temp directory after tests.
-struct TempAuthCleanup {
-    ~TempAuthCleanup() {
-        std::error_code ec;
-        fs::remove_all(fs::temp_directory_path() / "yuzu_test_auth", ec);
-    }
-};
-
-static TempAuthCleanup cleanup_guard;
 
 // ── Crypto Primitives ────────────────────────────────────────────────────────
 
@@ -313,7 +310,9 @@ TEST_CASE("list_pending_agents", "[auth][pending]") {
 // ── Config Persistence ───────────────────────────────────────────────────────
 
 TEST_CASE("save and reload config preserves users", "[auth][config]") {
-    auto tmp = fs::temp_directory_path() / "yuzu_test_auth" / "roundtrip.cfg";
+    auto tmp = yuzu::test::unique_temp_path("yuzu-test-auth-roundtrip-");
+    tmp += ".cfg";
+    fs::create_directories(tmp.parent_path());
     fs::remove(tmp);
 
     {

--- a/tests/unit/server/test_settings_routes_users.cpp
+++ b/tests/unit/server/test_settings_routes_users.cpp
@@ -37,6 +37,7 @@
 #include "tag_store.hpp"
 #include "test_route_sink.hpp"
 #include "update_registry.hpp"
+#include "../test_helpers.hpp"
 #include <yuzu/server/auth.hpp>
 #include <yuzu/server/auto_approve.hpp>
 #include <yuzu/server/server.hpp>
@@ -45,13 +46,10 @@
 
 #include <httplib.h>
 
-#include <atomic>
-#include <chrono>
 #include <filesystem>
 #include <memory>
 #include <shared_mutex>
 #include <string>
-#include <thread>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -59,14 +57,11 @@ using namespace yuzu::server;
 
 namespace {
 
+/// Shim: callers below pass a "prefix" string; route through the canonical
+/// helper in tests/unit/test_helpers.hpp so we don't recreate the
+/// hash<thread::id>+chrono+getpid pattern that drove flake #473.
 static fs::path unique_temp_path(const std::string& prefix) {
-    static std::atomic<unsigned> seq{0};
-    auto tid = std::hash<std::thread::id>{}(std::this_thread::get_id());
-    auto t = std::chrono::steady_clock::now().time_since_epoch().count();
-    return fs::temp_directory_path() /
-           (prefix + "-" + std::to_string(::getpid()) + "-" +
-            std::to_string(tid) + "-" + std::to_string(t) + "-" +
-            std::to_string(seq.fetch_add(1)));
+    return yuzu::test::unique_temp_path(prefix + "-");
 }
 
 /// RAII wrapper around a temp directory. Constructing it creates the
@@ -497,4 +492,167 @@ TEST_CASE("SettingsRoutes GET /fragments/settings/users: non-self rows all get R
     CHECK(res->body.find("hx-delete=\"/api/settings/users/bob\"") != std::string::npos);
     CHECK(res->body.find("hx-delete=\"/api/settings/users/carol\"") != std::string::npos);
     CHECK(res->body.find("hx-delete=\"/api/settings/users/admin\"") == std::string::npos);
+}
+
+// ── DELETE /api/settings/users — invalid_username + user_not_found audit ─────
+//
+// PR 4 closed two evidence-chain holes on DELETE: (1) a hand-crafted DELETE
+// against an invalid username reached remove_user() with bytes that should
+// never have entered the user-store path, and (2) DELETE on an unknown user
+// silently re-rendered the fragment without auditing the privileged-mutation
+// attempt. Both are SOC 2 CC7.2 evidence-chain failures.
+
+TEST_CASE("SettingsRoutes DELETE /api/settings/users: invalid username audited and 400",
+          "[settings][users][audit]") {
+    SettingsRoutesHarness h;
+    h.session_user = "admin";
+    h.session_role = auth::Role::admin;
+
+    // is_valid_username rejects anything outside [A-Za-z0-9._-]; a literal
+    // `$` survives URL canonicalisation and reaches the handler with
+    // exactly that byte, exercising the username-validation branch.
+    auto res = h.Delete("/api/settings/users/$bogus");
+    REQUIRE(res);
+    CHECK(res->status == 400);
+    CHECK(h.has_audit("user.delete", "denied", "User", "$bogus"));
+}
+
+TEST_CASE("SettingsRoutes DELETE /api/settings/users: unknown user audited and 404",
+          "[settings][users][audit]") {
+    SettingsRoutesHarness h;
+    h.session_user = "admin";
+    h.session_role = auth::Role::admin;
+
+    auto res = h.Delete("/api/settings/users/nosuchuser");
+    REQUIRE(res);
+    CHECK(res->status == 404);
+    CHECK(h.has_audit("user.delete", "denied", "User", "nosuchuser"));
+}
+
+// ── POST /api/settings/users/:username/role — success + audit ────────────────
+
+TEST_CASE("SettingsRoutes POST role: admin promotes user to admin",
+          "[settings][users][role]") {
+    SettingsRoutesHarness h;
+    h.session_user = "admin";
+    h.session_role = auth::Role::admin;
+
+    auto res = h.Post("/api/settings/users/bob/role", R"({"role":"admin"})");
+    REQUIRE(res);
+    CHECK(res->status == 200);
+    auto role = h.role_of("bob");
+    REQUIRE(role.has_value());
+    CHECK(*role == auth::Role::admin);
+    CHECK(h.has_audit("user.role_change", "success", "User", "bob"));
+}
+
+TEST_CASE("SettingsRoutes POST role: self-target denied and audited",
+          "[settings][users][role][self]") {
+    SettingsRoutesHarness h;
+    h.session_user = "admin";
+    h.session_role = auth::Role::admin;
+
+    auto res = h.Post("/api/settings/users/admin/role", R"({"role":"user"})");
+    REQUIRE(res);
+    CHECK(res->status == 403);
+    CHECK(res->get_header_value("HX-Trigger") == kSelfDemoteToast);
+    auto role = h.role_of("admin");
+    REQUIRE(role.has_value());
+    CHECK(*role == auth::Role::admin);
+    CHECK(h.has_audit("user.role_change", "denied", "User", "admin"));
+}
+
+TEST_CASE("SettingsRoutes POST role: invalid username audited and 400",
+          "[settings][users][role][audit]") {
+    SettingsRoutesHarness h;
+    h.session_user = "admin";
+    h.session_role = auth::Role::admin;
+
+    auto res = h.Post("/api/settings/users/$evil/role", R"({"role":"user"})");
+    REQUIRE(res);
+    CHECK(res->status == 400);
+    CHECK(h.has_audit("user.role_change", "denied", "User", "$evil"));
+}
+
+TEST_CASE("SettingsRoutes POST role: invalid JSON audited and 400",
+          "[settings][users][role][audit]") {
+    SettingsRoutesHarness h;
+    h.session_user = "admin";
+    h.session_role = auth::Role::admin;
+
+    auto res = h.Post("/api/settings/users/bob/role", "not-json-at-all");
+    REQUIRE(res);
+    CHECK(res->status == 400);
+    CHECK(h.has_audit("user.role_change", "denied", "User", "bob"));
+}
+
+TEST_CASE("SettingsRoutes POST role: missing role field audited and 400",
+          "[settings][users][role][audit]") {
+    SettingsRoutesHarness h;
+    h.session_user = "admin";
+    h.session_role = auth::Role::admin;
+
+    auto res = h.Post("/api/settings/users/bob/role", R"({"foo":"bar"})");
+    REQUIRE(res);
+    CHECK(res->status == 400);
+    CHECK(h.has_audit("user.role_change", "denied", "User", "bob"));
+}
+
+TEST_CASE("SettingsRoutes POST role: invalid role value audited and 400",
+          "[settings][users][role][audit]") {
+    SettingsRoutesHarness h;
+    h.session_user = "admin";
+    h.session_role = auth::Role::admin;
+
+    auto res = h.Post("/api/settings/users/bob/role", R"({"role":"superadmin"})");
+    REQUIRE(res);
+    CHECK(res->status == 400);
+    CHECK(h.has_audit("user.role_change", "denied", "User", "bob"));
+}
+
+TEST_CASE("SettingsRoutes POST role: unknown user audited and 404",
+          "[settings][users][role][audit]") {
+    SettingsRoutesHarness h;
+    h.session_user = "admin";
+    h.session_role = auth::Role::admin;
+
+    auto res = h.Post("/api/settings/users/nosuchuser/role",
+                      R"({"role":"admin"})");
+    REQUIRE(res);
+    CHECK(res->status == 404);
+    CHECK(h.has_audit("user.role_change", "denied", "User", "nosuchuser"));
+}
+
+TEST_CASE("SettingsRoutes POST role: same-role no-op audited as no_op",
+          "[settings][users][role][audit]") {
+    SettingsRoutesHarness h;
+    h.session_user = "admin";
+    h.session_role = auth::Role::admin;
+
+    // bob is seeded as Role::user; setting role=user is a no-op. The handler
+    // returns 200 and does not invoke update_role(), but the operator's
+    // intent is captured as a `no_op` audit so compliance review can
+    // distinguish "tried to set already-current role" from "no request was
+    // made at all."
+    auto res = h.Post("/api/settings/users/bob/role", R"({"role":"user"})");
+    REQUIRE(res);
+    CHECK(res->status == 200);
+    CHECK(h.has_audit("user.role_change", "no_op", "User", "bob"));
+    auto role = h.role_of("bob");
+    REQUIRE(role.has_value());
+    CHECK(*role == auth::Role::user);
+}
+
+TEST_CASE("SettingsRoutes POST role: non-admin session rejected by admin_fn",
+          "[settings][users][role]") {
+    SettingsRoutesHarness h;
+    h.session_user = "bob";
+    h.session_role = auth::Role::user;
+
+    auto res = h.Post("/api/settings/users/admin/role", R"({"role":"user"})");
+    REQUIRE(res);
+    CHECK(res->status == 403);
+    // The handler is gated by admin_fn_ which fires before the body even
+    // executes, so no user.role_change audit is emitted.
+    CHECK_FALSE(h.has_audit("user.role_change", "denied", "User", "admin"));
 }

--- a/tests/unit/server/test_workflow_routes.cpp
+++ b/tests/unit/server/test_workflow_routes.cpp
@@ -78,6 +78,13 @@ struct ExecHarness {
     /// registered BEFORE dispatch). Empty when the dispatch path has no
     /// tracker context.
     std::string last_dispatch_execution_id;
+    /// PR 4 audit-coverage regression net: captures every audit_fn call
+    /// the routes layer makes so tests can assert the SSE handler's
+    /// audit-on-success / audit-absence-on-denied policy (qe-S4).
+    struct AuditCall {
+        std::string action, result, target_type, target_id, detail;
+    };
+    std::vector<AuditCall> audit_calls;
     WorkflowRoutes routes;
 
     /// Per-process monotonic counter for execution IDs. Replaces the prior
@@ -87,7 +94,11 @@ struct ExecHarness {
     /// collision edge cases. Atomic so parallel test workers cannot collide.
     static inline std::atomic<int> exec_counter{0};
 
-    ExecHarness()
+    /// `with_bus = false` opts out of constructing the per-execution event
+    /// bus so SSE-handler 503-on-no-bus tests can exercise the path where
+    /// the route is registered but the underlying bus is intentionally
+    /// not wired (governance qe-S1).
+    explicit ExecHarness(bool with_bus = true)
         : tracker_db(uniq("wf-routes-exec")),
           instr_db(uniq("wf-routes-inst")),
           resp_db(uniq("wf-routes-resp")) {
@@ -97,11 +108,17 @@ struct ExecHarness {
         // throwing REQUIRE in any later constructor step still closes it.
         REQUIRE(sqlite3_open(tracker_db.string().c_str(), &tracker_guard.db) == SQLITE_OK);
         // PR 3: bus must outlive the tracker (the tracker borrows the
-        // bus pointer). Build the bus first.
-        event_bus = std::make_unique<ExecutionEventBus>();
+        // bus pointer). Build the bus first when wanted; the no-bus
+        // harness leaves event_bus as nullptr so the route registration
+        // takes the 503 path.
+        if (with_bus) {
+            event_bus = std::make_unique<ExecutionEventBus>();
+        }
         tracker = std::make_unique<ExecutionTracker>(tracker_guard.db);
         tracker->create_tables();
-        tracker->set_event_bus(event_bus.get());
+        if (event_bus) {
+            tracker->set_event_bus(event_bus.get());
+        }
 
         instructions = std::make_unique<InstructionStore>(instr_db);
         REQUIRE(instructions->is_open());
@@ -124,9 +141,11 @@ struct ExecHarness {
             }
             return true;
         };
-        auto audit_fn = [](const httplib::Request&, const std::string&,
-                           const std::string&, const std::string&,
-                           const std::string&, const std::string&) {};
+        auto audit_fn = [this](const httplib::Request&, const std::string& action,
+                                const std::string& result, const std::string& target_type,
+                                const std::string& target_id, const std::string& detail) {
+            audit_calls.push_back({action, result, target_type, target_id, detail});
+        };
         auto emit_fn = [](const std::string&, const httplib::Request&) {};
         auto scope_fn = [](const std::string&) -> std::pair<std::size_t, std::size_t> {
             return {0, 0};
@@ -160,7 +179,8 @@ struct ExecHarness {
         wf_deps.command_dispatch_fn = cmd_dispatch;
         wf_deps.response_store = responses.get();
         // PR 3 — wire the per-execution event bus. The SSE handler at
-        // /sse/executions/{id} only registers when this is non-null.
+        // /sse/executions/{id} returns 503 at request time when this is
+        // nullptr but is still registered, which is the qe-S1 path.
         wf_deps.execution_event_bus = event_bus.get();
         routes.register_routes(sink, std::move(wf_deps));
     }
@@ -1103,4 +1123,76 @@ TEST_CASE("SSE handler: per-agent status badge has .per-agent-status class for p
     CHECK(res->status == 200);
     CHECK(res->body.find("per-agent-status") != std::string::npos);
     CHECK(res->body.find("per-agent-exit-code") != std::string::npos);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PR 4 — SSE handler audit + no-bus 503 contracts
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEST_CASE("SSE handler: 503 when execution_event_bus is null (no-bus path)",
+          "[workflow][executions][pr3][pr4]") {
+    // qe-S1: the route is registered even when the bus is intentionally
+    // not wired (test harness opt-out, configuration path that omits the
+    // bus). Hitting it must return 503, not 200 — opening an EventSource
+    // against a missing bus would freeze the drawer waiting for events
+    // that will never publish.
+    ExecHarness h(/*with_bus=*/false);
+    h.make_def("def-NO-BUS", "NoBus");
+    auto exec_id = h.make_exec("def-NO-BUS", "running", 3, 0, 0);
+
+    auto res = h.sink.Get("/sse/executions/" + exec_id);
+    REQUIRE(res);
+    CHECK(res->status == 503);
+    // Audit must NOT fire on the no-bus path — the request never reached
+    // the live-subscribe success branch.
+    bool saw_subscribe = false;
+    for (const auto& a : h.audit_calls) {
+        if (a.action == "execution.live_subscribe") saw_subscribe = true;
+    }
+    CHECK_FALSE(saw_subscribe);
+}
+
+TEST_CASE("SSE handler: 200 path emits execution.live_subscribe audit",
+          "[workflow][executions][pr3][pr4]") {
+    // Positive control for the audit-absence test below: the happy path
+    // DOES emit the audit. Without this pin, a refactor that drops the
+    // emit entirely would silently pass the absence test.
+    ExecHarness h;
+    h.make_def("def-SUB", "Sub");
+    auto exec_id = h.make_exec("def-SUB", "running", 1, 0, 0);
+
+    auto res = h.sink.Get("/sse/executions/" + exec_id);
+    REQUIRE(res);
+    CHECK(res->status == 200);
+
+    bool saw = false;
+    for (const auto& a : h.audit_calls) {
+        if (a.action == "execution.live_subscribe" && a.result == "success" &&
+            a.target_type == "Execution" && a.target_id == exec_id) {
+            saw = true;
+            break;
+        }
+    }
+    CHECK(saw);
+}
+
+TEST_CASE("SSE handler: 403 perm-deny does NOT emit live_subscribe audit",
+          "[workflow][executions][pr3][pr4]") {
+    // qe-S4: a denied subscribe must not leave a forensic ghost row in
+    // audit_store — the success-shaped audit only fires after perm_fn
+    // approves. Pin this so a future refactor that hoists the audit
+    // ahead of perm_fn (the kind of "log first, check later" pattern
+    // that surfaces in compliance reviews) is caught.
+    ExecHarness h;
+    h.make_def("def-DENY", "Deny");
+    auto exec_id = h.make_exec("def-DENY", "running", 1, 0, 0);
+    h.perm_grant = false;
+
+    auto res = h.sink.Get("/sse/executions/" + exec_id);
+    REQUIRE(res);
+    CHECK(res->status == 403);
+
+    for (const auto& a : h.audit_calls) {
+        CHECK_FALSE(a.action == "execution.live_subscribe");
+    }
 }


### PR DESCRIPTION
## Summary

PR 4 of the 6-PR post-governance hardening ladder following the /governance review of `4433683..7ea7be6` (SSE + AuthDB).

Closes the audit-coverage gaps, the false dedup claim on the SSE handler, and lights up the OBS-2 login-latency + OBS-4 audit-emit-failed metrics. Tests migrate two more files off the banned `hash<thread::id>+chrono+getpid` salt pattern and add 14 new regression cases.

## Scope

### SOC 2 CC7.2 — audit on every denied branch

- **POST `/api/settings/users/:username/role`** — every 4xx/5xx exit emits `audit_fn_("user.role_change", "denied", ...)`. Reasons: `invalid_username`, `missing_role`, `invalid_json`, `invalid_role`, `user_not_found`, `db_failure`. Same-role no-op emits `"no_op"` so compliance review can distinguish operator intent from inaction.
- **DELETE `/api/settings/users/:name`** — added `invalid_username` 400 + audit before the self-delete check; added audit + 404 on the unknown-user path that was previously silent.
- **`AuthRoutes::require_admin`** — emits `audit_log("auth.admin_required", "denied", "endpoint", req.path)` on the role-mismatch 403. One-touch fix at the gate, not every caller.

### SSE dedup decision (governance Deferred-5 / #700)

The `execution.live_subscribe` audit fires on every successful subscribe — the previous comment claimed dedup that did not exist. Replaced with the truthful policy: audit-every-connect, dedup deferred per #700 because a correct implementation needs lock-protected seen-state and a naive version has a TOCTOU window.

### Login-latency observability (OBS-2)

- `AuthManager::set_metrics_registry()` injection.
- `authenticate()` observes `yuzu_auth_login_duration_seconds` (histogram) with `method=password` and `result=unknown_user|bad_password|success`. Wired in `ServerImpl`; tests/CLI tools leave the pointer null and emit no metric.

### Audit-pipeline observability (OBS-4)

- `AuditStore::log()` captures `sqlite3_step` return; non-`DONE` increments `emit_failed_` and spdlog::errors. Surfaced as `yuzu_server_audit_emit_failed_total` via ServerImpl's periodic refresh loop.

### Test hygiene (governance qe-B2 / flake #473)

- `test_settings_routes_users.cpp` routed local `unique_temp_path` through `yuzu::test::unique_temp_path`.
- `test_auth.cpp` dropped the hardcoded shared `yuzu_test_auth` path + process cleanup_guard; every `make_temp_auth()` call now gets a unique path. Roundtrip test migrated likewise.

### New tests

- 9 cases on POST role (success+audit, self-target denied+audit, invalid_username, invalid_json, missing_role, invalid_role, unknown_user, no_op, non-admin 403).
- 2 cases on DELETE (invalid_username, unknown user).
- 3 SSE handler cases:
  - **qe-S1**: 503 when bus is null (handler registered, bus intentionally not wired).
  - **qe-S4 positive**: 200 emits `execution.live_subscribe` audit.
  - **qe-S4 negative**: 403 perm-deny does NOT emit audit (catches future "log first, check later" refactors).
- `ExecHarness` gained `with_bus=false` opt-out and captures audit calls into a vector.

## Stacking

Independent of PRs 1, 2, 3, 4.5 (#694, #695, #702, #701). Branched from `origin/dev` directly. Lands in any order.

## Test plan

- [x] Linux gcc-13 debug `meson compile -C build-linux` clean.
- [x] `meson test --suite server --print-errorlogs` — 1369 cases / 16506 assertions passing.
- [x] `meson test --suite agent --suite tar` passing (no cross-cutting break).
- [x] Windows MSVC + macOS Apple Clang via CI matrix.
- [x] Linux gcc-13 + clang-19 release variants via CI matrix.

## What's NOT in this PR

- `/readyz` AuthDB coverage (PR 5, depends on #694).
- systemd `StartLimitBurst` + `LimitNOFILE` (PR 5).
- `docker-start-UAT.sh` `${SERVER_PORT}` parameterisation (PR 5).
- `docs/ops-runbooks/auth-db-recovery.md` (PR 5).
- REST API docs / CHANGELOG / `docs/security-reviews/authdb-2026-04-30.md` (PR 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)