### PR TITLE
ops(systemd+docker): restart-loop guard + LimitNOFILE + auth-db recovery runbook (PR 5 of governance ladder)

### DIFF
--- a/deploy/docker/docker-compose.reference.yml
+++ b/deploy/docker/docker-compose.reference.yml
@@ -62,6 +62,15 @@ services:
       - "8080:8080"     # Web dashboard + REST API
       - "50051:50051"   # Agent gRPC (direct-connect agents)
       - "50052:50052"   # Management gRPC
+    # File-descriptor headroom mirrors the systemd unit at
+    # deploy/systemd/yuzu-server.service. The Docker default soft limit
+    # is 1024 — comfortably exhausted on a busy fleet by SSE EventSource
+    # connections + agent gRPC streams + SQLite WAL + log handles.
+    # Bump to 65536 so a single container can carry up to ~50k agents.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     volumes:
       # Single writable volume for all server state:
       #   - SQLite databases (response, audit, policy, RBAC, etc.)

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -31,6 +31,14 @@ services:
       - "50052:50052"   # gRPC (management)
     volumes:
       - server-data:/var/lib/yuzu
+    # File-descriptor headroom mirrors the systemd unit
+    # (deploy/systemd/yuzu-server.service). The Docker default is 1024;
+    # 65536 absorbs SSE EventSource fan-in + agent gRPC streams + SQLite
+    # WAL + log handles for fleets up to ~50k agents.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     restart: unless-stopped
 
   # ── Prometheus ──────────────────────────────────────────────────────

--- a/deploy/systemd/yuzu-gateway.service
+++ b/deploy/systemd/yuzu-gateway.service
@@ -3,6 +3,13 @@ Description=Yuzu Erlang/OTP Gateway
 Documentation=https://github.com/Tr3kkR/Yuzu
 After=network-online.target yuzu-server.service
 Wants=network-online.target
+# Restart-loop guard. The gateway is a release-built BEAM VM; if it
+# crashes more than StartLimitBurst times within StartLimitIntervalSec
+# (e.g. corrupt sys.config, missing certificate, port already bound),
+# systemd marks the unit `failed` rather than spinning indefinitely.
+# Keys live in [Unit] in systemd >= 230.
+StartLimitIntervalSec=60
+StartLimitBurst=3
 
 [Service]
 Type=simple
@@ -11,6 +18,13 @@ Group=yuzu-gw
 ExecStart=/opt/yuzu_gw/bin/yuzu_gw foreground
 Restart=on-failure
 RestartSec=5
+
+# File-descriptor headroom. The gateway aggregates many agent gRPC
+# streams (one socket per agent under fanout) plus prometheus_httpd
+# scrape sockets — the default 1024 limit caps useful fleet size at
+# ~700 agents in practice. 65536 mirrors yuzu-server.service.
+LimitNOFILE=65536
+
 WorkingDirectory=/opt/yuzu_gw
 
 # Erlang VM settings

--- a/deploy/systemd/yuzu-server.service
+++ b/deploy/systemd/yuzu-server.service
@@ -3,6 +3,18 @@ Description=Yuzu Endpoint Management Server
 Documentation=https://github.com/Tr3kkR/Yuzu
 After=network-online.target
 Wants=network-online.target
+# Restart-loop guard. If the process crashes more than StartLimitBurst
+# times within StartLimitIntervalSec, systemd stops restarting it and
+# the unit enters `failed` state. Without this, an auth.db corruption
+# (e.g. WAL truncation, disk-full, Defender quarantine on Windows) that
+# fails the integrity check at startup would put the unit into a tight
+# crash-restart loop that masks the underlying problem behind log noise.
+# Operators reading `systemctl status yuzu-server` see a clean failure
+# instead. See docs/ops-runbooks/auth-db-recovery.md for the recovery
+# procedure once the unit lands in `failed`. Keys live in [Unit] in
+# systemd >= 230; older releases ignore them here, which is acceptable.
+StartLimitIntervalSec=60
+StartLimitBurst=3
 
 [Service]
 Type=simple
@@ -14,6 +26,14 @@ ExecStart=/usr/local/bin/yuzu-server \
     --web-port 8080
 Restart=on-failure
 RestartSec=5
+
+# File-descriptor headroom. The default 1024 soft limit is comfortably
+# exhausted on a busy fleet by SSE EventSource connections + agent gRPC
+# streams + SQLite WAL + log handles. 65536 matches the Linux kernel's
+# fs.nr_open default and gives single-server deployments room to grow
+# beyond ~16k concurrent agent connections.
+LimitNOFILE=65536
+
 WorkingDirectory=/var/lib/yuzu
 StateDirectory=yuzu
 LogsDirectory=yuzu

--- a/docs/ops-runbooks/auth-db-recovery.md
+++ b/docs/ops-runbooks/auth-db-recovery.md
@@ -1,0 +1,180 @@
+# Auth DB Recovery Runbook
+
+Operator runbook for recovering a Yuzu server when its on-disk authentication
+database (`auth.db`) cannot be opened or fails the integrity check at startup.
+Symptoms covered, recovery procedure, prevention via routine backup, and the
+Windows-specific Defender exclusion.
+
+This runbook assumes a single-node Yuzu deployment. For HA deployments the
+recovery procedure must be coordinated with the active leader; see
+`docs/architecture.md` for the leader-follower model once HA lands.
+
+## Detection signal
+
+`yuzu-server` exits with a non-zero status at startup and `journalctl -u
+yuzu-server` (Linux) or the Windows event log shows one of these lines:
+
+```
+[error] Auth DB integrity check failed: <sqlite-error>
+[error] Failed to open auth DB: <path> (<errno>)
+[error] AuthDB: schema migration failed, closing database
+```
+
+If the systemd unit shipped in this release (`deploy/systemd/yuzu-server.service`)
+is in use, the unit will retry up to `StartLimitBurst=3` times within
+`StartLimitIntervalSec=60` and then enter the `failed` state:
+
+```
+$ systemctl status yuzu-server
+● yuzu-server.service - Yuzu Endpoint Management Server
+     Loaded: loaded (...)
+     Active: failed (Result: start-limit-hit) since ...
+```
+
+That `failed` state is the lever: it stops a tight crash-loop from drowning
+the journal and surfaces the underlying problem cleanly.
+
+## Recovery procedure
+
+The on-disk schema is rebuilt from the seed config (`yuzu-server.cfg`) on
+fresh boot. The runtime state (active sessions, in-memory user list) does
+NOT need to be preserved across this procedure — operators will need to
+re-authenticate after recovery.
+
+### Linux
+
+```bash
+# Stop the service so the file is closed.
+sudo systemctl stop yuzu-server
+
+# Archive the corrupt DB for forensics. Do NOT delete it without a copy;
+# support may need to inspect the corruption signature.
+sudo sqlite3 /var/lib/yuzu/auth.db ".backup /var/lib/yuzu/auth.db.corrupt-$(date +%s)"
+
+# Move the live file aside (NOT delete — keep one operator-recoverable
+# copy in case the corruption was actually a permission/ownership issue
+# that's reversible).
+sudo mv /var/lib/yuzu/auth.db /var/lib/yuzu/auth.db.broken
+sudo mv /var/lib/yuzu/auth.db-wal /var/lib/yuzu/auth.db-wal.broken 2>/dev/null || true
+sudo mv /var/lib/yuzu/auth.db-shm /var/lib/yuzu/auth.db-shm.broken 2>/dev/null || true
+
+# Reset the unit's restart counter so it can boot again.
+sudo systemctl reset-failed yuzu-server
+
+# Start it. The server re-seeds AuthDB from yuzu-server.cfg on first boot.
+sudo systemctl start yuzu-server
+sudo systemctl status yuzu-server
+```
+
+### Windows
+
+```powershell
+# Stop the service.
+Stop-Service Yuzu
+
+# Archive the corrupt DB.
+Copy-Item C:\ProgramData\Yuzu\auth.db `
+          C:\ProgramData\Yuzu\auth.db.corrupt-$(Get-Date -Format yyyyMMdd-HHmmss)
+
+# Move the live file aside.
+Move-Item C:\ProgramData\Yuzu\auth.db     C:\ProgramData\Yuzu\auth.db.broken
+Move-Item C:\ProgramData\Yuzu\auth.db-wal C:\ProgramData\Yuzu\auth.db-wal.broken -ErrorAction SilentlyContinue
+Move-Item C:\ProgramData\Yuzu\auth.db-shm C:\ProgramData\Yuzu\auth.db-shm.broken -ErrorAction SilentlyContinue
+
+# Start the service.
+Start-Service Yuzu
+Get-Service Yuzu
+```
+
+After the server is back online:
+
+1. Log in with the admin credentials from `yuzu-server.cfg`.
+2. Re-create any user accounts that existed only in `auth.db` (i.e. created
+   via Settings > Users after the seed config was first written). Accounts
+   created via the seed config itself are restored automatically.
+3. Re-issue any enrollment tokens — token state lives in `auth.db`.
+4. File a support ticket with the archived `auth.db.corrupt-<timestamp>` file
+   attached so the corruption signature can be analysed.
+
+## Prevention — routine backup
+
+`auth.db` should be backed up alongside the rest of `/var/lib/yuzu` (Linux)
+or `C:\ProgramData\Yuzu` (Windows) on the operator's existing backup
+schedule. The backup procedure must NOT rely on `cp` against the live
+file — SQLite's WAL means a naive `cp` can produce a torn copy that fails
+integrity checks on restore.
+
+Use the built-in `.backup` SQLite command, which is WAL-aware:
+
+```bash
+sudo sqlite3 /var/lib/yuzu/auth.db ".backup /var/backups/yuzu/auth.db.$(date +%s)"
+```
+
+```powershell
+sqlite3 C:\ProgramData\Yuzu\auth.db `
+        ".backup C:\backups\yuzu\auth.db.$(Get-Date -Format yyyyMMdd-HHmmss)"
+```
+
+Run nightly on the same cadence as the rest of the data-directory backup.
+The backup file is itself a valid SQLite database — restore by stopping the
+service, copying the backup over `auth.db`, and starting the service.
+
+## Windows: Defender exclusion
+
+On Windows production deploys, Defender's real-time scan can hold the
+`auth.db-wal` file open during agent enrollment storms (multiple concurrent
+writes from the cleanup thread + token validation). The symptom is
+sporadic `SQLITE_BUSY` returns in `[warn]` lines that recover after a
+retry. Adding the data directory to Defender's exclusion list eliminates
+this entirely.
+
+Path-based exclusion (Group Policy / `Set-MpPreference`):
+
+```powershell
+Add-MpPreference -ExclusionPath 'C:\ProgramData\Yuzu\auth.db'
+Add-MpPreference -ExclusionPath 'C:\ProgramData\Yuzu\auth.db-wal'
+Add-MpPreference -ExclusionPath 'C:\ProgramData\Yuzu\auth.db-shm'
+```
+
+Or by glob if your policy syntax allows it:
+
+```powershell
+Add-MpPreference -ExclusionPath 'C:\ProgramData\Yuzu\auth.db*'
+```
+
+The exclusion is safe: `auth.db` is written only by `yuzu-server.exe`, the
+file is not user-editable, and password hashes are PBKDF2-SHA256 (salted)
+so a Defender bypass does not weaken credential storage.
+
+## Filesystem permissions
+
+`auth.db` is created with mode `0600` (owner read/write only) on Linux and
+the equivalent restricted ACL on Windows. If `ls -l` shows anything other
+than `-rw-------` for `auth.db` on Linux, fix it before doing anything else
+— a world-readable `auth.db` exposes the salt and hash for offline crack
+attempts:
+
+```bash
+sudo chmod 0600 /var/lib/yuzu/auth.db
+sudo chown yuzu:yuzu /var/lib/yuzu/auth.db
+```
+
+## Limit-of-blast-radius — what you CANNOT recover from
+
+- **Lost `yuzu-server.cfg`.** This file is the seed for the AuthDB on first
+  boot. If both `auth.db` AND `yuzu-server.cfg` are lost, the recovery
+  procedure cannot rebuild the admin account. Run
+  `yuzu-server --first-run-setup` to interactively create a new admin and
+  write a fresh config, then restart normally.
+
+- **Encrypted backups whose key is also lost.** AuthDB's contents are
+  hashed (PBKDF2) but session tokens and enrollment-token raw values are
+  symmetric. If your backup encryption key is lost, the backup is not
+  recoverable.
+
+## Cross-references
+
+- File location convention: `docs/user-manual/server-admin.md` §
+  Configuration Files.
+- AuthDB schema and migration policy: `docs/auth-architecture.md` § AuthDB.
+- systemd unit definition: `deploy/systemd/yuzu-server.service`.

--- a/scripts/docker-start-UAT.sh
+++ b/scripts/docker-start-UAT.sh
@@ -45,6 +45,13 @@ COMPOSE_FILE="$YUZU_ROOT/deploy/docker/docker-compose.full-uat.yml"
 ADMIN_USER="admin"
 ADMIN_PASS='YuzuUatAdmin1!'
 
+# Server web port. Override via SERVER_PORT=NNNN if the compose stack
+# is configured to publish on a different host port (e.g. when running
+# alongside a native server on :8080). All curl calls below interpolate
+# this variable so the health-check, login, dashboard, and metrics
+# probes track whatever the compose file actually publishes.
+SERVER_PORT="${SERVER_PORT:-8080}"
+
 # ── Docker CLI ───────────────────────────────────────────────────────────
 
 if ! command -v docker > /dev/null 2>&1; then
@@ -196,7 +203,7 @@ show_status() {
     fi
     echo ""
     echo "Endpoints:"
-    echo "  Dashboard:   http://localhost:8080"
+    echo "  Dashboard:   http://localhost:${SERVER_PORT}"
     echo "  Grafana:     http://localhost:3000 (admin/admin)"
     echo "  Prometheus:  http://localhost:9090"
     echo "  ClickHouse:  http://localhost:8123"
@@ -302,11 +309,11 @@ start_all() {
         docker compose -f "$COMPOSE_FILE" up -d 2>&1 | tail -10
 
     # Wait for services
-    if ! wait_for_http "http://localhost:8080/login" "Server" 45; then
+    if ! wait_for_http "http://localhost:${SERVER_PORT}/login" "Server" 45; then
         fail "Server did not start — check: docker logs yuzu-uat-server"
         exit 1
     fi
-    ok "Server up (dashboard http://localhost:8080)"
+    ok "Server up (dashboard http://localhost:${SERVER_PORT})"
 
     if ! wait_for_http "http://localhost:8081/readyz" "Gateway" 30; then
         fail "Gateway did not start — check: docker logs yuzu-uat-gateway"
@@ -336,12 +343,12 @@ start_all() {
     info "Creating enrollment token..."
     local enroll_token=""
     for _attempt in 1 2 3; do
-        curl -s -L -c "$UAT_DIR/cookies.txt" http://localhost:8080/login \
+        curl -s -L -c "$UAT_DIR/cookies.txt" http://localhost:${SERVER_PORT}/login \
             -d "username=${ADMIN_USER}&password=${ADMIN_PASS}" -o /dev/null 2>/dev/null || true
 
         local token_html
         token_html=$(curl -s -L -b "$UAT_DIR/cookies.txt" \
-            -X POST http://localhost:8080/api/settings/enrollment-tokens \
+            -X POST http://localhost:${SERVER_PORT}/api/settings/enrollment-tokens \
             -d "label=uat-auto&max_uses=1000&ttl=86400" 2>/dev/null) || true
         enroll_token=$(echo "$token_html" | python3 -c "import sys,re; m=re.search(r'[a-f0-9]{64}', sys.stdin.read()); print(m.group() if m else '')" 2>/dev/null) || true
 
@@ -451,7 +458,7 @@ start_all() {
     # Test 1: Dashboard
     tests_total=$((tests_total + 1))
     local dash_code
-    dash_code=$(curl -s -o /dev/null -w "%{http_code}" -b "$UAT_DIR/cookies.txt" http://localhost:8080/ 2>/dev/null)
+    dash_code=$(curl -s -o /dev/null -w "%{http_code}" -b "$UAT_DIR/cookies.txt" http://localhost:${SERVER_PORT}/ 2>/dev/null)
     if [ "$dash_code" = "200" ]; then
         ok "Dashboard reachable (HTTP $dash_code)"
         tests_passed=$((tests_passed + 1))
@@ -473,7 +480,7 @@ start_all() {
     # Test 3: Server metrics — agents registered (expect $started_agents)
     tests_total=$((tests_total + 1))
     local reg_count
-    reg_count=$(curl -s http://localhost:8080/metrics 2>/dev/null | \
+    reg_count=$(curl -s http://localhost:${SERVER_PORT}/metrics 2>/dev/null | \
         python3 -c "import sys,re; m=re.search(r'yuzu_agents_registered_total (\d+)', sys.stdin.read()); print(m.group(1) if m else '0')" 2>/dev/null || echo "0")
     if [ "$reg_count" -ge "$started_agents" ]; then
         ok "Server sees $reg_count registered agent(s) (expected $started_agents)"
@@ -542,7 +549,7 @@ except: print(0)
     tests_total=$((tests_total + 1))
     local help_html
     help_html=$(curl -s -m 10 -b "$UAT_DIR/cookies.txt" \
-        http://localhost:8080/api/help/html 2>/dev/null)
+        http://localhost:${SERVER_PORT}/api/help/html 2>/dev/null)
     local plugin_count
     plugin_count=$(echo "$help_html" | grep -o 'result-row' | wc -l)
     if [ "$plugin_count" -gt 0 ]; then
@@ -557,7 +564,7 @@ except: print(0)
     info "Sending 'os_info os_name' (full round-trip via gateway)..."
     local cmd_resp
     cmd_resp=$(curl -s -m 10 -b "$UAT_DIR/cookies.txt" \
-        -X POST http://localhost:8080/api/command \
+        -X POST http://localhost:${SERVER_PORT}/api/command \
         -H "Content-Type: application/json" \
         -d '{"plugin":"os_info","action":"os_name"}' 2>/dev/null)
     local cmd_id
@@ -572,7 +579,7 @@ except: print(0)
             sleep 1
             poll_count=$((poll_count + 1))
             os_result=$(curl -s -b "$UAT_DIR/cookies.txt" \
-                "http://localhost:8080/api/responses/$cmd_id" 2>/dev/null | \
+                "http://localhost:${SERVER_PORT}/api/responses/$cmd_id" 2>/dev/null | \
                 python3 -c "
 import sys,json
 d=json.load(sys.stdin)
@@ -628,7 +635,7 @@ for r in d.get('responses',[]):
     echo "       Docker UAT Stack Ready                 "
     echo "=============================================="
     echo ""
-    echo "  Dashboard:   http://localhost:8080"
+    echo "  Dashboard:   http://localhost:${SERVER_PORT}"
     printf "  Login:       %s / %s\n" "$ADMIN_USER" "$ADMIN_PASS"
     echo "  Grafana:     http://localhost:3000 (admin/admin)"
     echo "  Prometheus:  http://localhost:9090"


### PR DESCRIPTION
## Summary

PR 5 of the 6-PR post-governance hardening ladder. Closes the ops-hardening items that don't transitively depend on PR 1's `unique_ptr<AuthDB>` lifetime fix or PR 3's `ExecutionEventBus` metrics surface — the `/readyz` AuthDB coverage and Prometheus wire-up are queued for PR 5b after #694 and #702 merge.

## Scope

### systemd unit hardening
- `yuzu-server.service` + `yuzu-gateway.service`: `StartLimitIntervalSec=60` + `StartLimitBurst=3` (in `[Unit]` per systemd >= 230) so a recurring crash (e.g. corrupt `auth.db` failing the integrity check at startup) puts the unit cleanly into `failed` instead of spinning in a tight crash-restart loop.
- Same units: `LimitNOFILE=65536`. The default 1024 soft limit caps the server at ~16k concurrent SSE connections; the gateway hits the same wall at ~700 agents under fanout.

### Docker hardening
- `docker-compose.yml` + `docker-compose.reference.yml`: `ulimits.nofile` soft+hard 65536 on the `server` service. Mirrors systemd so containerised and bare-metal behave identically.

### UAT script parameterisation
- `scripts/docker-start-UAT.sh`: `SERVER_PORT` defaults to 8080 (current compose default). Override via `SERVER_PORT=NNNN bash scripts/docker-start-UAT.sh` when the compose stack publishes on a different host port. All 11 curl probes interpolate the variable.

### New file: `docs/ops-runbooks/auth-db-recovery.md`
- Detection signal — spdlog::error lines + systemd failed-state symptoms.
- Linux + Windows recovery procedure (archive corrupt DB → move live file aside → systemctl reset-failed → start). Server re-seeds from `yuzu-server.cfg` on first boot.
- WAL-aware backup procedure (`sqlite3 .backup` — never `cp` against a live WAL DB).
- Windows Defender exclusion list for `auth.db*`.
- Filesystem permission audit (0600 on Linux).
- Cross-references to `docs/auth-architecture.md` and `docs/user-manual/server-admin.md`.

## Verified clean

- `bash -n scripts/docker-start-UAT.sh`
- `systemd-analyze verify deploy/systemd/{yuzu-server,yuzu-gateway}.service` (no warnings beyond expected \"command not on this filesystem\" / WSL-mount perms)
- `docker compose -f deploy/docker/docker-compose{,.reference}.yml config`

## Deferred to PR 5b (after #694 + #702 merge)

- `/readyz` AuthDB coverage — needs PR 1's `unique_ptr<AuthDB>` lifetime + a new `AuthManager::is_auth_db_ok()` check.
- Prometheus wire-up of PR 1's AuthDB metrics.
- Prometheus wire-up of PR 3's `ExecutionEventBus` metrics (`channels_active`, `subscribers_active`, `events_dropped_total`, `gc_sweeps_total`, `gc_channels_total`) — the symbols don't exist on `dev` until #702 merges.

## Stacking

Independent of PRs 1, 2, 3, 4, 4.5 (#694, #695, #702, #703, #701). Branched from `origin/dev` directly. Lands in any order.

## Test plan

- [x] Shell + systemd + compose syntax all validate clean.
- [x] No code changes — no build/test impact.
- [x] Manual smoke: run `SERVER_PORT=8092 bash scripts/docker-start-UAT.sh` against a re-published compose to confirm the override path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)