### PR TITLE
ops(server): /readyz auth_db coverage + Prometheus wire-up of SSE bus metrics (PR 5b of governance ladder)

### DIFF
--- a/server/core/include/yuzu/server/auth.hpp
+++ b/server/core/include/yuzu/server/auth.hpp
@@ -108,6 +108,14 @@ public:
     /// If not set, falls back to config file I/O (backwards compatible).
     void set_auth_db(yuzu::server::AuthDB* db) { auth_db_ = db; }
 
+    /// True iff a configured AuthDB is set AND it reports `is_ready()`.
+    /// Wired into /readyz; operators rely on this to detect a corrupt or
+    /// half-migrated auth.db without having to scrape spdlog. Returns
+    /// true in the legacy config-file-only path (auth_db_ == nullptr is
+    /// fine — the deployment isn't using AuthDB) so the readyz signal
+    /// only fires on an actual AuthDB integrity failure.
+    bool is_auth_db_ok() const noexcept;
+
     /// Set the metrics registry for emitting login-latency histograms.
     /// Optional; if null, authenticate() emits no metric (used by tests
     /// that don't construct the server's MetricsRegistry).

--- a/server/core/include/yuzu/server/auth_db.hpp
+++ b/server/core/include/yuzu/server/auth_db.hpp
@@ -67,6 +67,12 @@ public:
     /// Must be called once before any other method.
     std::expected<void, AuthDBError> initialize();
 
+    /// True iff initialize() succeeded AND the SQLite handle is still
+    /// open (integrity_check passed, schema migrations ran cleanly).
+    /// Wired into /readyz so an operator can detect a corrupt or
+    /// half-migrated auth.db without having to scrape spdlog. Lock-free.
+    bool is_ready() const noexcept;
+
     // ── User Operations ──────────────────────────────────────────────────
 
     /// Create or update a user.

--- a/server/core/src/auth.cpp
+++ b/server/core/src/auth.cpp
@@ -495,6 +495,16 @@ bool AuthManager::has_users() const {
     return !users_.empty();
 }
 
+bool AuthManager::is_auth_db_ok() const noexcept {
+    // Legacy config-file-only deployments leave auth_db_ as nullptr.
+    // That is not a /readyz failure — the readyz check should report ok
+    // unless the operator opted into AuthDB and the DB is unhealthy.
+    if (!auth_db_) {
+        return true;
+    }
+    return auth_db_->is_ready();
+}
+
 std::vector<UserEntry> AuthManager::list_users() const {
     if (auth_db_) {
         auto result = auth_db_->list_users();

--- a/server/core/src/auth_db.cpp
+++ b/server/core/src/auth_db.cpp
@@ -178,6 +178,15 @@ AuthDB::AuthDB(const std::filesystem::path& data_dir)
 
 AuthDB::~AuthDB() = default;
 
+bool AuthDB::is_ready() const noexcept {
+    // initialize() closes impl_->db on every failure path: open error,
+    // migration failure, integrity_check != "ok". So a non-null handle
+    // here is a true positive for "ready to serve queries". No lock —
+    // the pointer is set once during initialize() before the server
+    // starts accepting traffic, and never reassigned thereafter.
+    return impl_ && impl_->db != nullptr;
+}
+
 // ── Database Initialization ──────────────────────────────────────────────────
 
 std::expected<void, AuthDBError> AuthDB::initialize() {

--- a/server/core/src/server.cpp
+++ b/server/core/src/server.cpp
@@ -286,6 +286,28 @@ public:
                           "Number of in-flight command executions", "gauge");
         metrics_.describe("yuzu_server_uptime_seconds",
                           "Server process uptime in seconds", "gauge");
+        // PR 5b — surface ExecutionEventBus internals so SREs can alert on
+        // SSE backpressure (events_dropped non-zero rate), retention-window
+        // sizing (gc_channels_total trend), and live-subscriber load
+        // (subscribers_active gauge). Pairs with the bounded ring buffer
+        // contract documented in CLAUDE.md "Executions-history ladder PR 3".
+        metrics_.describe("yuzu_server_sse_channels_active",
+                          "Per-execution SSE channels currently in the bus map",
+                          "gauge");
+        metrics_.describe("yuzu_server_sse_subscribers_active",
+                          "Total live SSE subscribers across all channels",
+                          "gauge");
+        metrics_.describe("yuzu_server_sse_events_dropped_total",
+                          "Cumulative SSE events dropped by the ring buffer "
+                          "(slow-subscriber backpressure signal)",
+                          "counter");
+        metrics_.describe("yuzu_server_sse_gc_sweeps_total",
+                          "Cumulative ExecutionEventBus GC sweeps run",
+                          "counter");
+        metrics_.describe("yuzu_server_sse_gc_channels_total",
+                          "Cumulative SSE channels reaped after retention "
+                          "window + zero subscribers",
+                          "counter");
 
         // Wire health store into agent service
         agent_service_.set_health_store(&health_store_);
@@ -881,6 +903,25 @@ public:
                     // OBS-4: surface audit-pipeline persistence failures.
                     metrics_.gauge("yuzu_server_audit_emit_failed_total")
                         .set(static_cast<double>(audit_store_->emit_failed_count()));
+                }
+                // PR 5b — ExecutionEventBus observability. Same scrape-as-
+                // gauge pattern used for AuditStore + GuaranteedStateStore
+                // counters above; the bus exposes the counters via lock-
+                // free atomic accessors so reading from this thread is safe.
+                if (execution_event_bus_) {
+                    metrics_.gauge("yuzu_server_sse_channels_active")
+                        .set(static_cast<double>(execution_event_bus_->channel_count()));
+                    metrics_.gauge("yuzu_server_sse_subscribers_active")
+                        .set(static_cast<double>(execution_event_bus_->subscribers_total()));
+                    metrics_.gauge("yuzu_server_sse_events_dropped_total")
+                        .set(static_cast<double>(
+                            execution_event_bus_->events_dropped_total()));
+                    metrics_.gauge("yuzu_server_sse_gc_sweeps_total")
+                        .set(static_cast<double>(
+                            execution_event_bus_->gc_sweeps_total()));
+                    metrics_.gauge("yuzu_server_sse_gc_channels_total")
+                        .set(static_cast<double>(
+                            execution_event_bus_->gc_channels_total()));
                 }
                 // Guardian scalars + cumulative write/reap counters. Use
                 // gauges for the count-now values (SQL COUNT(*)) and for the
@@ -1852,6 +1893,13 @@ private:
                  custom_properties_store_ && custom_properties_store_->is_open()},
                 {"guaranteed_state_store",
                  guaranteed_state_store_ && guaranteed_state_store_->is_open()},
+                // PR 5b: AuthDB integrity-check coverage. Reports "ok" on
+                // legacy config-file-only deployments (auth_db_ == nullptr
+                // in AuthManager) and false only when an opted-in AuthDB
+                // failed the integrity check or migration. SOC 2 evidence:
+                // an operator can detect a corrupt auth.db without scraping
+                // spdlog; pairs with docs/ops-runbooks/auth-db-recovery.md.
+                {"auth_db", auth_mgr_.is_auth_db_ok()},
             };
 
             std::string failed_list;


### PR DESCRIPTION
## Summary

Closes the deferred items from PR 5 (#704) that depended on PR 1 (#694) and PR 3 (#702) merging first. Both prerequisites are now on `dev` — wire them up.

## Scope

### `/readyz` AuthDB coverage
- `AuthDB::is_ready()` — returns true iff `initialize()` succeeded and the SQLite handle is still open. `initialize()` closes `impl_->db` on every failure path (open error, migration failure, `integrity_check != "ok"`), so a non-null handle is a true positive for "ready to serve queries". Lock-free.
- `AuthManager::is_auth_db_ok()` — pass-through. Returns `true` in the legacy config-file-only path (`auth_db_ == nullptr` is fine — the deployment isn't using AuthDB) so `/readyz` only fires on an actual AuthDB integrity failure, not on opt-out.
- New 14th `StoreCheck` row `{"auth_db", auth_mgr_.is_auth_db_ok()}` in `server.cpp`'s `/readyz` handler. Pairs with [`docs/ops-runbooks/auth-db-recovery.md`](../blob/dev/docs/ops-runbooks/auth-db-recovery.md) — operators detect corruption without scraping spdlog.

### `ExecutionEventBus` Prometheus wire-up (5 new metrics)

| Metric | Type | Purpose |
|---|---|---|
| `yuzu_server_sse_channels_active` | gauge | Per-execution channels currently in the bus map |
| `yuzu_server_sse_subscribers_active` | gauge | Total live SSE subscribers across all channels |
| `yuzu_server_sse_events_dropped_total` | counter | Cumulative events dropped by the ring buffer — non-zero rate is the slow-subscriber backpressure alarm |
| `yuzu_server_sse_gc_sweeps_total` | counter | Cumulative GC sweeps run |
| `yuzu_server_sse_gc_channels_total` | counter | Cumulative channels reaped after retention window + zero subscribers |

Wired in the same periodic refresh loop as `AuditStore` / `GuaranteedStateStore` counters; pulled via the bus's lock-free atomic accessors (`channel_count()`, `subscribers_total()`, `events_dropped_total()`, `gc_sweeps_total()`, `gc_channels_total()`) so reading is safe from this thread.

## Stacking

Independent of all other PRs. Branched from current `origin/dev` (post-merge-of-the-7-PR-ladder).

## Tests

- `meson compile -C build-linux` clean.
- `meson test --suite server --print-errorlogs` passes (1369 cases / 16506 assertions).
- `strings build-linux/server/core/yuzu-server | grep yuzu_server_sse_` shows all 5 metrics linked.
- `AuthManager::is_auth_db_ok` mangled symbol present in the binary.
- No new test cases — existing `test_execution_event_bus.cpp` pins the counters; existing `/readyz` integration tests pin the conjunction shape; the wire-up itself is one assignment per metric.

## Closes the ladder, for real this time

This is the genuine end of the governance hardening ladder. No more deferred items remain from the SSE/AuthDB rollout. The only outstanding tracking is in [`docs/known-issues/pr3-ladder-deferred.md`](../blob/dev/docs/known-issues/pr3-ladder-deferred.md) (issues #696, #697, #698, #699, #700) — those are scope-deferred per their original triage, not blocked on a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)