### PR TITLE
fix(ci): create eunit surefire output dir + run gateway tests on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,21 @@ jobs:
       - name: Test
         run: meson test -C build-linux-${{ matrix.compiler }}-${{ matrix.build_type }} --print-errorlogs
 
+      # Mirror the windows job's upload step so a Linux test failure is
+      # diagnosable. meson `--print-errorlogs` truncates per-test output to
+      # the last 100 lines, which is enough for a Catch2 failure but loses
+      # the failing test name when an Erlang eunit run reports
+      # `Failed: 1. Passed: 144.` with no surviving `*failed*` marker.
+      # Without this artifact we cannot identify which gateway test failed.
+      - name: Upload meson-logs on test failure or cancel
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: meson-logs-linux-${{ matrix.compiler }}-${{ matrix.build_type }}-${{ github.run_attempt }}
+          path: build-linux-${{ matrix.compiler }}-${{ matrix.build_type }}/meson-logs/
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: ccache stats
         if: always()
         run: ccache -s
@@ -610,6 +625,18 @@ jobs:
 
       - name: Test
         run: meson test -C build-macos --print-errorlogs
+
+      # Same rationale as the linux + windows upload steps: keep test
+      # failures diagnosable when meson's `--print-errorlogs` truncation
+      # drops the test name (notably: gateway eunit summaries).
+      - name: Upload meson-logs on test failure or cancel
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: meson-logs-macos-${{ matrix.build_type }}-${{ github.run_attempt }}
+          path: build-macos/meson-logs/
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: ccache stats
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,24 @@ jobs:
           pip3 install --user --break-system-packages --require-hashes -r requirements-ci.txt
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
+      # OTP + rebar3 for the gateway test legs. Without these, meson's
+      # `find_program('rebar3', required: false)` returns not-found,
+      # `gateway eunit` and `gateway ct` are silently skipped, and the
+      # Linux matrix can't catch gateway regressions until they hit the
+      # Windows leg (where rebar3 is pre-baked via choco). Pin matches
+      # release.yml's "Build Gateway (Erlang)" job so any OTP bump moves
+      # both halves together — see CLAUDE.md "Toolchain activation".
+      # ImageOS is required because erlef/setup-beam can't auto-detect
+      # the runner OS on self-hosted; set at step scope so the rest of
+      # the job doesn't see it.
+      - name: Install Erlang/OTP and rebar3
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
+        env:
+          ImageOS: ubuntu24
+        with:
+          otp-version: '28'
+          rebar3-version: '3.24'
+
       # ccache cache lives at ~/.cache/ccache on the self-hosted Linux
       # runner, which persists in the github-runner user's home between
       # jobs by definition. No actions/cache round-trip needed — paying

--- a/gateway/apps/yuzu_gw/src/yuzu_gw_health.erl
+++ b/gateway/apps/yuzu_gw/src/yuzu_gw_health.erl
@@ -14,7 +14,7 @@
 -behaviour(gen_server).
 
 %% API
--export([start_link/0]).
+-export([start_link/0, port/0]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
@@ -32,6 +32,16 @@
 
 start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+%% Returns the actual port the health endpoint is listening on. Useful
+%% when the configured port is 0 (OS-assigned ephemeral), as is the case
+%% in eunit tests that need to avoid colliding with whatever already owns
+%% a fixed port on the host (Windows dev tools squatting on 18080 was
+%% the trigger — 302 instead of 200 because the test was hitting a
+%% different HTTP server bound to the same port).
+-spec port() -> {ok, inet:port_number()} | {error, term()}.
+port() ->
+    gen_server:call(?SERVER, get_port, 5000).
 
 %%%===================================================================
 %%% gen_server callbacks
@@ -54,6 +64,8 @@ init([]) ->
             {stop, {listen_failed, Reason}}
     end.
 
+handle_call(get_port, _From, #state{listen_sock = LSock} = State) ->
+    {reply, inet:port(LSock), State};
 handle_call(_Request, _From, State) ->
     {reply, {error, unknown_call}, State}.
 

--- a/gateway/apps/yuzu_gw/test/yuzu_gw_health_tests.erl
+++ b/gateway/apps/yuzu_gw/test/yuzu_gw_health_tests.erl
@@ -23,9 +23,14 @@ health_test_() ->
      ]}.
 
 setup() ->
-    %% Use a high port to avoid conflicts
-    Port = 18080,
-    application:set_env(yuzu_gw, health_port, Port),
+    %% Bind to port 0 — the OS picks an ephemeral free port and we read
+    %% it back from the started gen_server via yuzu_gw_health:port/0.
+    %% A previous version of this test hardcoded port 18080, which is
+    %% squatted on the Windows CI runner by an unidentified HTTP server
+    %% that returns 302 Found for every request — making the eunit
+    %% assertion `?assertEqual(200, Status)` fail with `value, 302`.
+    %% Ephemeral binding eliminates that whole class of port collision.
+    application:set_env(yuzu_gw, health_port, 0),
 
     %% Start mock processes for readiness checks.
     %% Only register names that aren't already taken by other test suites.
@@ -62,9 +67,12 @@ setup() ->
             whereis(yuzu_gw_upstream)
     end,
 
-    %% Start the health endpoint
+    %% Start the health endpoint, then read back the actual ephemeral
+    %% port the OS assigned. The 100ms sleep keeps the original timing
+    %% margin so the listener's accept loop is up before any test fires.
     {ok, HealthPid} = yuzu_gw_health:start_link(),
     timer:sleep(100),
+    {ok, Port} = yuzu_gw_health:port(),
     {Port, HealthPid, UpPid, NeedUpstream, MockPids}.
 
 cleanup({_Port, HealthPid, UpPid, NeedUpstream, MockPids}) ->
@@ -100,13 +108,19 @@ mock_loop() ->
 %%% Tests
 %%%===================================================================
 
+%% setup() bound the listener on port 0 (OS-assigned). Each test reads
+%% the actual port from the running gen_server. Eunit's `{setup, …, [Tests]}`
+%% form does not pass the setup return value to the tests, so the indirection
+%% via yuzu_gw_health:port/0 is the cheapest way to thread the port through.
 healthz_ok() ->
-    {Status, Body} = http_get(18080, "/healthz"),
+    {ok, Port} = yuzu_gw_health:port(),
+    {Status, Body} = http_get(Port, "/healthz"),
     ?assertEqual(200, Status),
     ?assert(binary:match(Body, <<"ok">>) =/= nomatch).
 
 readyz_ok() ->
-    {Status, Body} = http_get(18080, "/readyz"),
+    {ok, Port} = yuzu_gw_health:port(),
+    {Status, Body} = http_get(Port, "/readyz"),
     ?assertEqual(200, Status),
     ?assert(binary:match(Body, <<"ready">>) =/= nomatch),
     %% Core checks should be true
@@ -115,7 +129,8 @@ readyz_ok() ->
     ?assert(binary:match(Body, <<"\"circuit_breaker\":true">>) =/= nomatch).
 
 unknown_path_404() ->
-    {Status, _Body} = http_get(18080, "/unknown"),
+    {ok, Port} = yuzu_gw_health:port(),
+    {Status, _Body} = http_get(Port, "/unknown"),
     ?assertEqual(404, Status).
 
 %%%===================================================================

--- a/gateway/apps/yuzu_gw/test/yuzu_gw_scale_tests.erl
+++ b/gateway/apps/yuzu_gw/test/yuzu_gw_scale_tests.erl
@@ -314,6 +314,23 @@ heartbeat_batch_scale() ->
     %% without blocking callers.
     N = 10000,
 
+    %% Defensive unload of grpcbox_channel/grpcbox_client before re-mocking.
+    %% setup() at the top of this module mocks only telemetry and does NOT
+    %% pre-unload these two — every other test in the file leaves them
+    %% alone, so on most discovery orders they are absent. But other test
+    %% modules in apps/yuzu_gw/test (circuit_breaker_*, upstream, health,
+    %% heartbeat_metrics, perf_helpers→perf_SUITE, integration, e2e,
+    %% metrics_e2e, fullstack) all mock grpcbox_client and rely on their
+    %% own setup/teardown to balance. If any of them crash mid-test or
+    %% are run with `--dir apps/yuzu_gw/test` discovery interleaving
+    %% scale_tests after them, grpcbox_client/grpcbox_channel are still
+    %% registered when we reach this line and `meck:new` aborts with
+    %% `{already_started, <pid>}`. CI Linux saw this on first eunit run
+    %% with the full module set; local WSL2 happened to discover scale
+    %% before the leakers.
+    catch meck:unload(grpcbox_channel),
+    catch meck:unload(grpcbox_client),
+
     %% Mock upstream so it doesn't actually connect.
     meck:new(grpcbox_channel, [non_strict, no_link]),
     meck:expect(grpcbox_channel, pick, fun(_, _) -> {ok, fake_ch} end),

--- a/scripts/test_gateway.py
+++ b/scripts/test_gateway.py
@@ -77,6 +77,21 @@ cmd = ["rebar3", "as", "test", suite]
 if suite == "eunit":
     cmd += ["--dir", "apps/yuzu_gw/test"]
 
+    # eunit_surefire writes its XML report to the literal path declared
+    # in gateway/rebar.config eunit_opts (`{dir, "_build/test/eunit"}`),
+    # which resolves relative to the rebar3 CWD = gateway_dir. That
+    # path is NOT auto-created — `eunit_surefire:write_report/2` calls
+    # `file:open` directly and crashes with `{error,enoent}` if the
+    # directory is missing. On Linux runners with a long-lived gateway
+    # checkout the dir often pre-exists from older non-REBAR_BASE_DIR
+    # runs, hiding the bug. On the Windows runner — and on any fresh
+    # checkout — REBAR_BASE_DIR redirects rebar3's own `_build` to
+    # `_build_eunit`, so `_build/test/eunit` is never created and the
+    # surefire listener crashes after every test passes (exit 1 on the
+    # gateway eunit test even with 0 actual test failures).
+    surefire_dir = Path(gateway_dir) / "_build" / "test" / "eunit"
+    surefire_dir.mkdir(parents=True, exist_ok=True)
+
 # For CT runs, set minimal perf parameters so the heavyweight perf suite
 # finishes quickly.  The perf suite defaults to 10k agents, 50k heartbeats,
 # and a 300-second endurance test — far too long for CI.


### PR DESCRIPTION
## Summary

Two related CI-infra fixes that surfaced together when the Windows MSVC debug leg failed on PR #706 (job [73866614293](https://github.com/Tr3kkR/Yuzu/actions/runs/25192825851/job/73866614293)) with `eunit_surefire` crashing on `{error,enoent}`.

## Bug 1 — `eunit_surefire` write_report crash (Windows MSVC)

`gateway/rebar.config:84` declares the eunit surefire report dir as the literal relative path `_build/test/eunit`. `meson.build` sets `REBAR_BASE_DIR=<gateway>/_build_eunit` per-suite so eunit and ct don't race on the same `_build/test/lib/<dep>/` ebin tree.

- rebar3 honors `REBAR_BASE_DIR` for its OWN `_build` root (creating `_build_eunit/test/lib/yuzu_gw/ebin/`).
- The `eunit_opts` `dir` value is passed verbatim to `eunit_surefire` and resolves relative to CWD = `gateway/`, NOT relative to `REBAR_BASE_DIR`.

So surefire writes to `gateway/_build/test/eunit/` — a directory that is **never created** when `REBAR_BASE_DIR` points elsewhere. Linux runners with a long-lived gateway checkout often have it pre-existing from older default-`REBAR_BASE_DIR` runs, hiding the bug. The Windows runner (and any fresh checkout) hits `eunit_surefire:write_report/2` calling `file:open` on a missing dir → `{error,enoent}`. The eunit run itself completes (145 tests pass) but the listener crash counts as 3 spurious failures and rebar3 exits non-zero.

**Fix:** `scripts/test_gateway.py` pre-creates the surefire dir before invoking rebar3 for eunit. Path is computed identically to the resolved CWD so it matches what surefire ends up writing to.

```
=ERROR REPORT==== ...
{{nocatch,{error,enoent}},
 [{eunit_surefire,write_report,2,[{file,"eunit_surefire.erl"},{line,320}]},
  ...
```

## Bug 2 — Linux CI matrix never ran gateway tests at all

`ci.yml`'s `linux` matrix job did not install Erlang/OTP, so meson's `find_program('rebar3', required: false)` returned not-found and the `gateway eunit` + `gateway ct` tests were silently skipped on every Linux leg. The Windows runner has rebar3 pre-baked via choco; that's the only matrix leg where gateway tests ran. As a result the Windows leg was the only one that could surface a gateway regression — and the surefire bug above proves that's a real coverage hole.

**Fix:** add `Install Erlang/OTP and rebar3` step using the same `erlef/setup-beam@v1.24.0` pin + OTP 28 / rebar3 3.24 as `release.yml`'s "Build Gateway (Erlang)" job. Lockstep pinning is the contract documented in CLAUDE.md "Toolchain activation". `ImageOS=ubuntu24` is set at step scope (self-hosted runners don't populate it automatically) so it doesn't pollute the wider job env.

After this lands, the Linux matrix runs 7 tests instead of 5 (adds `gateway eunit` + `gateway ct`) and any future regression of this class will surface on every PR's Linux leg, not just Windows.

## Verification

- `python3 -c "import ast; ast.parse(open('scripts/test_gateway.py'))"` clean.
- Local repro on a clean `gateway/_build/` with `REBAR_BASE_DIR` override:
  - **Before fix:** surefire crash, 0 XMLs written, rebar3 exit 1.
  - **After fix:** surefire wrote the XML report, rebar3 exit 0.

## Unblocks

PR #706 currently has the Windows MSVC debug leg failing on this exact crash. After this PR merges, #706 can rebase and its CI should clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)