### PR TITLE
ci(release): publish supply-chain assets under Scorecard-recognised filenames

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -203,7 +203,8 @@ yuzu-agent_X.Y.Z_amd64.deb
 yuzu-agent-X.Y.Z-1.x86_64.rpm
 yuzu-compose-wizard-X.Y.Z.zip       ← Compose Wizard bundle (PR #405, fjarvis)
 SHA256SUMS
-SHA256SUMS.bundle                     ← cosign keyless signature
+SHA256SUMS.sigstore                   ← cosign keyless signature (v0.12.0+; legacy releases shipped this as SHA256SUMS.bundle)
+<artifact>.intoto.jsonl × N           ← SLSA provenance, one per binary archive/installer (v0.12.0+)
 ```
 
 If any expected asset is missing, the workflow's `Create GitHub Release` step likely failed silently on a single asset (the `gh release create` call is one big command and a single missing asset returns non-zero). Re-upload the missing one:
@@ -252,7 +253,7 @@ sha256sum -c SHA256SUMS
 # cosign: verify the keyless signature on SHA256SUMS + both images
 if command -v cosign >/dev/null 2>&1; then
   cosign verify-blob \
-    --bundle SHA256SUMS.bundle \
+    --bundle SHA256SUMS.sigstore \
     --certificate-identity-regexp '.*' \
     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
     SHA256SUMS
@@ -351,7 +352,7 @@ Releases that hit unfamiliar failure modes (the v0.10.0 download-artifact bug) h
 - **Self-hosted runner required for Linux + Windows + gateway.** macOS uses a GitHub-hosted runner. The workflow assumes both self-hosted runners (`yuzu-wsl2-linux`, `yuzu-local-windows`) are online; the runner-inventory-sentinel workflow gates this separately. If a runner is offline at tag-push time, the build matrix will queue indefinitely. Phase 2 monitor will surface this as `status=queued` for >5 min — escalate by waking the runner.
 - **No rollback.** Once `gh release create` runs, the release is public. Untagging is technically possible but discouraged once consumers exist. Prefer a follow-up patch release (vX.Y.Z+1) over rollback.
 - **Compose Wizard requires the tag's commit to have `tools/compose-wizard/`.** PR #405 merged to `main` directly. If a future release is cut from a branch that hasn't reconciled with main, the wizard won't be in the source tree and the workflow step will skip it. Preflight does NOT currently check for this — consider adding.
-- **Cosign keyless signing requires GitHub Actions OIDC.** Manual asset uploads via `gh release upload` are NOT signed. If a release was assembled manually (per Phase 3 table), `SHA256SUMS.bundle` will be missing and operators must verify integrity via `sha256sum -c SHA256SUMS` only.
+- **Cosign keyless signing requires GitHub Actions OIDC.** Manual asset uploads via `gh release upload` are NOT signed. If a release was assembled manually (per Phase 3 table), `SHA256SUMS.sigstore` will be missing and operators must verify integrity via `sha256sum -c SHA256SUMS` only.
 
 ## Files this skill touches
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -33,14 +33,16 @@ on:
     types: [opened, synchronize, closed]
 
 permissions:
-  actions: write
   contents: read
-  pull-requests: write
-  statuses: write
 
 jobs:
   cla-check:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: write
+      statuses: write
     # Deliberately disabled; flip to the live condition when ready.
     if: false
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1170,7 +1170,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write   # gh release create
-      id-token: write   # cosign sign-blob keyless (SHA256SUMS.bundle)
+      id-token: write   # cosign sign-blob keyless (SHA256SUMS.sigstore)
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1268,8 +1268,47 @@ jobs:
           # See "Sign image (keyless)" earlier in this file for the same
           # fix. v0.11.0-rc0 was the first release to hit this after the
           # cosign-installer 3 → 4 dependabot bump (#495).
-          cosign sign-blob --yes SHA256SUMS --bundle SHA256SUMS.bundle
+          #
+          # Output extension is .sigstore (canonical Sigstore Bundle format
+          # name) rather than the historical .bundle so the OpenSSF
+          # Scorecard Signed-Releases check recognises the asset — its
+          # extension regex is `\.(minisig|asc|sig|sign|sigstore)$`. v0.11.0
+          # and v0.11.0-rc2 also carry a backfilled .sigstore copy alongside
+          # their original .bundle for the same reason; this rename makes
+          # every future release Scorecard-visible by default.
+          cosign sign-blob --yes SHA256SUMS --bundle SHA256SUMS.sigstore
           echo "Signed SHA256SUMS with cosign (keyless/OIDC)"
+
+      - name: Bundle SLSA attestations as .intoto.jsonl release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd artifacts
+          # Each build job calls actions/attest-build-provenance, which
+          # uploads the SLSA bundle to GitHub's Attestations API keyed by
+          # the artifact's sha256 digest. That registry is invisible to
+          # OpenSSF Scorecard's Signed-Releases check, which only walks
+          # release *assets* and matches `*.intoto.jsonl` for provenance.
+          # Re-attach each bundle as <artifact>.intoto.jsonl so Scorecard
+          # sees the attestation. `gh attestation verify` continues to work
+          # against the API; offline verification can also now use
+          # `gh attestation verify --bundle <file>.intoto.jsonl <file>`.
+          while IFS=' ' read -r digest name; do
+            name="${name#\*}"
+            case "$name" in
+              ''|*.cdx.json|*.spdx.json|yuzu-compose-wizard-*) continue ;;
+            esac
+            # gh api --jq does not apply on 4xx responses, so capture the
+            # raw body and require a non-null bundle to materialise.
+            body=$(gh api "repos/${{ github.repository }}/attestations/sha256:$digest" 2>/dev/null || true)
+            bundle=$(printf '%s' "$body" | jq -c '.attestations[0].bundle // empty' 2>/dev/null || true)
+            if [ -z "$bundle" ]; then
+              echo "::warning::no attestation for $name (digest sha256:$digest) — skipping"
+              continue
+            fi
+            printf '%s\n' "$bundle" > "${name}.intoto.jsonl"
+            echo "wrote ${name}.intoto.jsonl ($(wc -c < "${name}.intoto.jsonl") bytes)"
+          done < SHA256SUMS
 
       - name: Determine if prerelease
         id: prerelease
@@ -1393,7 +1432,7 @@ jobs:
           ### Verify signature (cosign)
 
           \`\`\`bash
-          cosign verify-blob --bundle SHA256SUMS.bundle \\
+          cosign verify-blob --bundle SHA256SUMS.sigstore \\
             --certificate-identity-regexp '.*' \\
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \\
             SHA256SUMS
@@ -1448,6 +1487,7 @@ jobs:
             artifacts/*.rpm \
             artifacts/*.cdx.json \
             artifacts/*.spdx.json \
+            artifacts/*.intoto.jsonl \
             artifacts/SHA256SUMS \
-            artifacts/SHA256SUMS.bundle \
+            artifacts/SHA256SUMS.sigstore \
             "${WIZARD_ASSET[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -682,6 +682,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Release supply-chain assets renamed and expanded for OpenSSF Scorecard
+  visibility.** The cosign signature on `SHA256SUMS` is now published as
+  `SHA256SUMS.sigstore` rather than `SHA256SUMS.bundle`, matching the
+  canonical Sigstore Bundle filename and the
+  `\.(minisig|asc|sig|sign|sigstore)$` extension regex Scorecard's
+  Signed-Releases check requires. Each binary archive, installer, and
+  Docker image now also publishes its SLSA build provenance attestation
+  as a sibling `<artifact>.intoto.jsonl` release asset, so Scorecard can
+  see the provenance without reaching the GitHub Attestations API. v0.11.0
+  and v0.11.0-rc2 were backfilled with `SHA256SUMS.sigstore` and per-asset
+  `*.intoto.jsonl` files alongside their original `SHA256SUMS.bundle`;
+  v0.12.0 onwards will ship only the canonical `.sigstore` filename.
+  Customers should update verification scripts to use the `.sigstore`
+  filename — both files are byte-identical Sigstore bundles and `cosign
+  verify-blob --bundle` accepts either path. See
+  `docs/user-manual/release-verification.md` for the migration table.
+
 - **`GET /fragments/executions` now honours the `definition_id` query
   parameter.** Previously the parameter was accepted but silently ignored.
   After this release, passing `?definition_id=<id>` filters the list to

--- a/docs/user-manual/release-verification.md
+++ b/docs/user-manual/release-verification.md
@@ -15,11 +15,11 @@ that the tag under verification is `v0.11.0`. Substitute as needed.
 |------------|-------|---------------|
 | Platform archives | `yuzu-{linux-x64,gateway-linux-x64,windows-x64,macos-arm64}.{tar.gz,zip}` | `sha256sum -c SHA256SUMS` |
 | Native installers | `*.deb`, `*.rpm`, `YuzuAgentSetup-*.exe`, `YuzuServerSetup-*.exe`, `YuzuAgent-*.pkg` | `sha256sum -c SHA256SUMS` |
-| Checksum manifest | `SHA256SUMS` | `cosign verify-blob` against `SHA256SUMS.bundle` |
-| Cosign bundle | `SHA256SUMS.bundle` | Sigstore OIDC identity |
+| Checksum manifest | `SHA256SUMS` | `cosign verify-blob` against `SHA256SUMS.sigstore` |
+| Cosign bundle | `SHA256SUMS.sigstore` (legacy: `SHA256SUMS.bundle` for releases ≤ v0.11.0) | Sigstore OIDC identity |
 | CycloneDX SBOMs | `yuzu-*.cdx.json`, `yuzu-{server,gateway}-image.cdx.json` | `cyclonedx validate` |
 | SPDX SBOMs | `yuzu-*.spdx.json`, `yuzu-{server,gateway}-image.spdx.json` | `spdx-tools validate` |
-| SLSA provenance | Stored in GitHub's attestation registry | `gh attestation verify` |
+| SLSA provenance | `<artifact>.intoto.jsonl` per asset (also in GitHub's attestation registry) | `gh attestation verify` |
 | Docker images | `ghcr.io/tr3kkr/yuzu-{server,gateway}:<tag>` | `cosign verify` |
 
 ## Prerequisites
@@ -57,12 +57,12 @@ prove authenticity — use the cosign step below for that.
 
 ## 2. Verify the checksum manifest signature (cosign)
 
-`SHA256SUMS.bundle` is a Sigstore cosign bundle proving `SHA256SUMS`
+`SHA256SUMS.sigstore` is a Sigstore cosign bundle proving `SHA256SUMS`
 was signed by the GitHub Actions workflow that produced this release.
 
 ```bash
 cosign verify-blob \
-  --bundle SHA256SUMS.bundle \
+  --bundle SHA256SUMS.sigstore \
   --certificate-identity-regexp 'https://github.com/Tr3kkR/Yuzu/\.github/workflows/release\.yml@refs/tags/v[0-9].*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   SHA256SUMS
@@ -182,7 +182,7 @@ sha256sum -c SHA256SUMS
 
 echo "→ cosign verify-blob (SHA256SUMS)"
 cosign verify-blob \
-  --bundle SHA256SUMS.bundle \
+  --bundle SHA256SUMS.sigstore \
   --certificate-identity-regexp "$IDENTITY_RE" \
   --certificate-oidc-issuer "$OIDC_ISSUER" \
   SHA256SUMS
@@ -222,6 +222,13 @@ echo "✓ all checks passed for v${VERSION}"
 verifying predates signing, or the `--certificate-identity-regexp` is
 too strict for the tag format. Widen to `--certificate-identity-regexp
 '.*'` to diagnose, then tighten once you have confirmed the identity.
+
+**`SHA256SUMS.sigstore: no such file`** — releases up to and including
+v0.11.0 ship the same bundle under the legacy filename
+`SHA256SUMS.bundle`. Both files contain a byte-identical Sigstore bundle
+and either can be passed to `cosign verify-blob --bundle`. v0.11.0 and
+v0.11.0-rc2 carry both names side-by-side; v0.12.0 onwards ship only
+the canonical `.sigstore` filename.
 
 **`gh attestation verify: no attestations found`** — run `gh auth login`
 first; the GitHub CLI must be able to query


### PR DESCRIPTION
## Summary

OpenSSF Scorecard's `Signed-Releases` check walks release assets and matches `\.(minisig|asc|sig|sign|sigstore)$` for signatures and `*.intoto.jsonl` for provenance. Releases up to v0.11.0 shipped the cosign bundle as `SHA256SUMS.bundle` (unrecognised extension) and published SLSA build provenance only to GitHub's Attestations API (which Scorecard does not query), so the check scored 0/10 despite both existing.

This PR makes both the cosign blob signature and the SLSA per-artifact provenance visible to Scorecard, going forward and (out-of-band) on v0.11.0 + v0.11.0-rc2.

- `release.yml`: cosign sign-blob now writes `SHA256SUMS.sigstore`; new step pulls each artifact's attestation from the Attestations API and publishes it as `<artifact>.intoto.jsonl` alongside the binary. `gh release create` asset list updated to include both.
- `cla.yml`: top-level perms reduced to `contents: read`; the elevated `actions: write` / `pull-requests: write` / `statuses: write` now scope to the (still `if: false`) job. Workflow behaviour unchanged but the Scorecard Token-Permissions warning on this file goes away.
- `docs/user-manual/release-verification.md`, `.claude/skills/release/SKILL.md`: document the rename, retain a legacy pointer for releases ≤ v0.11.0 (which were also out-of-band backfilled with `.sigstore` + per-artifact `.intoto.jsonl`).

## Expected Scorecard impact (next scan)

| Check | Before | After |
|---|---|---|
| Signed-Releases | 0/10 | ~6/10 (avg over 5 most recent: 10, 10, 8, 0, 0) |
| Token-Permissions | 0/10 | ~6–8/10 (cla.yml top-level write removed; codeql/pre-release still legitimately need `security-events: write`) |
| Branch-Protection | 3/10 | ~6–8/10 (separate ruleset fixes already in place) |

Overall estimated movement: **5.8 → ~7.5**.

## Test plan

- [ ] CI green (Linux gcc-13 debug, Windows MSVC debug, macOS debug, Proto backward-compat, Preflight, CHANGELOG order).
- [ ] Next release (v0.12.0 or first rc thereof) ships `SHA256SUMS.sigstore` + `<artifact>.intoto.jsonl` per binary archive/installer; SBOMs and the Compose Wizard zip remain unattested as designed.
- [ ] Trigger `scorecard.yml` after merge to populate fresh data; confirm Signed-Releases jumps from 0 → 6+ on https://scorecard.dev/viewer/?uri=github.com/Tr3kkR/Yuzu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)