### PR TITLE
fix(server): CertReloader shutdown via condition_variable, not 5s polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -753,6 +753,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`CertReloader` shutdown latency drops from up to 5s per teardown to
+  near-zero.** The watcher thread used to sleep in 5-second increments and
+  only check the stop flag between increments, so each `stop()` (and each
+  destructor, since `~CertReloader()` calls `stop()`) blocked for up to
+  one full sleep window. With multiple `[cert-reload][lifecycle]` test
+  cases each paying that cost, the `server unit tests` suite was creeping
+  up to its 120-second meson budget — close enough that PR #734's run on
+  a contended `yuzu-wsl2-linux` runner overran by 4.6s and got SIGTERM'd
+  mid-`CertReloader: destructor stops cleanly`. Replaced the polling
+  sleep with a `std::condition_variable::wait_for` whose predicate the
+  `stop()` path notifies, so shutdown is bounded by `notify_all` + thread
+  join (sub-millisecond) rather than the next 5-second poll. Also
+  silences the `[[deprecated]]` warning on `httplib::SSLServer::ssl_context()`
+  by routing through `tls_context()` with a typed cast — same underlying
+  `SSL_CTX*`, no behaviour change.
+
 - **#618 — users lost across server restarts.** Pre-`auth.db` the user
   list was held in memory, written back to `yuzu-server.cfg` on save,
   but state created via the dashboard between saves was lost on a

--- a/server/core/src/cert_reloader.cpp
+++ b/server/core/src/cert_reloader.cpp
@@ -71,7 +71,11 @@ void CertReloader::start() {
 }
 
 void CertReloader::stop() {
-    stop_requested_.store(true, std::memory_order_release);
+    {
+        std::lock_guard<std::mutex> lk(stop_mu_);
+        stop_requested_.store(true, std::memory_order_release);
+    }
+    stop_cv_.notify_all();
     if (thread_.joinable())
         thread_.join();
 }
@@ -80,16 +84,18 @@ void CertReloader::run_loop() {
     spdlog::info("Certificate reload watcher started (interval={}s, cert={}, key={})",
                  params_.interval.count(), params_.cert_path.string(), params_.key_path.string());
 
-    while (!stop_requested_.load(std::memory_order_acquire)) {
-        // Sleep in 5-second increments for responsive shutdown
-        auto interval_secs = std::max(int64_t{10}, params_.interval.count());
-        auto increments = interval_secs / 5;
-        for (int64_t i = 0; i < increments && !stop_requested_.load(std::memory_order_acquire);
-             ++i) {
-            std::this_thread::sleep_for(std::chrono::seconds{5});
-        }
-        if (stop_requested_.load(std::memory_order_acquire))
+    auto interval_secs = std::max(int64_t{10}, params_.interval.count());
+    while (true) {
+        // wait_for(pred) returns true iff the predicate is true at exit (i.e.
+        // stop was requested). Returns false if the timeout elapsed without
+        // stop, which is our cue to poll the cert files.
+        std::unique_lock<std::mutex> lk(stop_mu_);
+        if (stop_cv_.wait_for(lk, std::chrono::seconds{interval_secs}, [this] {
+                return stop_requested_.load(std::memory_order_acquire);
+            })) {
             break;
+        }
+        lk.unlock();
 
         if (files_changed()) {
             (void)try_reload();
@@ -186,7 +192,10 @@ bool CertReloader::try_reload() {
         return false;
     }
 
-    SSL_CTX* ctx = ssl_server->ssl_context();
+    // tls_context() supersedes ssl_context() in cpp-httplib (the latter is
+    // marked [[deprecated]]). Both return the same underlying SSL_CTX*; the
+    // typed cast keeps the rest of this function unchanged.
+    SSL_CTX* ctx = static_cast<SSL_CTX*>(ssl_server->tls_context());
     if (!ctx) {
         spdlog::error("cert-reload: SSL context is null");
         ++failure_count_;

--- a/server/core/src/cert_reloader.hpp
+++ b/server/core/src/cert_reloader.hpp
@@ -2,7 +2,9 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <filesystem>
+#include <mutex>
 #include <string>
 #include <thread>
 
@@ -63,6 +65,12 @@ private:
     std::filesystem::file_time_type last_key_mtime_{};
     std::thread thread_;
     std::atomic<bool> stop_requested_{false};
+    // stop_cv_ + stop_mu_ make stop() wake the worker immediately rather than
+    // forcing it to wait out a 5-second sleep increment. The 5-second poll
+    // version pushed the server-tests suite over its 120s budget on contended
+    // runners (#flake from PR 734); CV-based wait keeps shutdown < 1ms.
+    std::mutex stop_mu_;
+    std::condition_variable stop_cv_;
     std::atomic<uint64_t> reload_count_{0};
     std::atomic<uint64_t> failure_count_{0};
 };


### PR DESCRIPTION
## Why

PR #734's CI hit a `server unit tests` timeout (124.6s into the 120s meson budget). 16188/16189 assertions were already clean; only the test running at the moment of SIGTERM (`CertReloader: destructor stops cleanly`) recorded a "fatal error condition: SIGTERM" abort. Same suite passed on `dev` 75 minutes earlier off the same base — it's a budget squeeze, not a hang.

## Root cause

`run_loop()` slept in 5-second increments and only checked `stop_requested_` between increments. Every `stop()` — including the destructor path, since `~CertReloader()` calls `stop()` — blocked up to one full sleep window. Two `[cert-reload][lifecycle]` cases each pay that ~5s cost, so the suite has a quiet ~10s floor of cert-reloader teardown that pushes it close to the 120s ceiling.

## Fix

Replace the polling loop with `std::condition_variable::wait_for` whose predicate `stop()` notifies. Shutdown is now bounded by `notify_all` + thread join (sub-millisecond), not the next poll.

Also routes the live SSL_CTX fetch through `httplib::SSLServer::tls_context()` rather than the `[[deprecated]]` `ssl_context()` to silence the compiler warning. Same underlying `SSL_CTX*`, no behaviour change.

## Measurement

Local run on `yuzu-wsl2-linux`-equivalent build:

| Scope | Before | After |
|---|---|---|
| All `[cert-reload]` tests (15 cases, 22 assertions) | ~10s lifecycle floor | **0.735s** end-to-end |

## Test plan

- [ ] Tier-1 fast-path CI green (Linux gcc-13 debug should comfortably finish under the 120s server-tests budget).
- [ ] Existing tests `CertReloader: stop() during sleep` and `CertReloader: destructor stops cleanly` continue to pass — they're now the regression net for shutdown latency.
- [ ] Manual: confirm the cpphttplib `[[deprecated]]` warning is gone from a clean rebuild of `cert_reloader.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)