### PR TITLE
fix(policy): helpful 400 body + worked example when kind: missing (#621)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wrong-kind / missing-kind cases to assert the new helpful content
   (`apiVersion: yuzu.io/v1alpha1` substring + docs link), so the
   improvement is pinned by the test surface rather than relying on a
-  fragile substring match.
+  fragile substring match. Adds a missing-`kind:` test for `create_policy`
+  (governance Gate 7 hardening — was asymmetric with `create_fragment`)
+  and pins the docs link on the `create_fragment` missing-kind branch
+  for the same symmetry reason.
 
 ## [0.12.0] - 2026-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_(no changes since v0.12.0-rc0 — first commit on top of the rc starts a new section here)_
+### Changed
+
+- **Better error message when `POST /api/policy-fragments` (or `/api/policies`)
+  receives YAML without a `kind:` field** (#621). The previous body
+  `kind must be 'PolicyFragment', got ''` left operators stuck because they
+  often sent JSON like `{"kind":"PolicyFragment", "yaml_source":"..."}`
+  expecting `kind` to be a request parameter. The error now includes a
+  full worked YAML example and a link to `docs/user-manual/policy-engine.md`,
+  while keeping the original `kind must be 'PolicyFragment'` (and `'Policy'`)
+  prefix so existing operator scripts that grep on it continue to work.
+  `docs/user-manual/policy-engine.md` gains a worked `curl` example covering
+  both the JSON-envelope and raw-YAML body forms.
+
+### Tests
+
+- `tests/unit/server/test_policy_store.cpp` — extended the existing
+  wrong-kind / missing-kind cases to assert the new helpful content
+  (`apiVersion: yuzu.io/v1alpha1` substring + docs link), so the
+  improvement is pinned by the test surface rather than relying on a
+  fragile substring match.
 
 ## [0.12.0] - 2026-05-03
 

--- a/docs/user-manual/policy-engine.md
+++ b/docs/user-manual/policy-engine.md
@@ -245,15 +245,55 @@ the `Policy:Read` or `Policy:Write` RBAC permission.
 | Method | Path | Description |
 |---|---|---|
 | `GET` | `/api/policy-fragments` | List all fragments. Query params: `name`, `limit`. |
-| `POST` | `/api/policy-fragments` | Create a fragment from YAML. Body: `{"yaml_source": "..."}`. |
+| `POST` | `/api/policy-fragments` | Create a fragment from YAML. Body must be a complete YAML document or a JSON envelope `{"yaml_source": "<full YAML>"}` — see worked example below. |
 | `DELETE` | `/api/policy-fragments/{id}` | Delete a fragment by ID. |
+
+#### Worked example — `POST /api/policy-fragments`
+
+The `kind` is a **YAML field** inside the body, not an HTTP query
+parameter or top-level JSON key. The server checks `kind: PolicyFragment`
+on the parsed YAML; sending `?kind=PolicyFragment` in the URL or
+`{"kind":"PolicyFragment"}` outside `yaml_source` is silently ignored. If
+the YAML is missing the `kind:` line you'll get an HTTP 400 with the full
+expected schema in the error body.
+
+**JSON envelope (recommended for programmatic callers):**
+
+```bash
+curl -X POST http://localhost:8080/api/policy-fragments \
+  -H "Content-Type: application/json" \
+  -b cookie -d '{
+    "yaml_source": "apiVersion: yuzu.io/v1alpha1\nkind: PolicyFragment\nmetadata:\n  name: ssh-disabled\nspec:\n  check:\n    plugin: services\n    action: status\n    parameters: { name: sshd }\n    compliance: \"result.state != \\\"running\\\"\"\n"
+  }'
+```
+
+**Raw YAML body (alternative — content-type other than `application/json`):**
+
+```bash
+curl -X POST http://localhost:8080/api/policy-fragments \
+  -H "Content-Type: application/yaml" \
+  -b cookie --data-binary @- <<'EOF'
+apiVersion: yuzu.io/v1alpha1
+kind: PolicyFragment
+metadata:
+  name: ssh-disabled
+spec:
+  check:
+    plugin: services
+    action: status
+    parameters: { name: sshd }
+    compliance: 'result.state != "running"'
+EOF
+```
+
+Both forms produce a 201 with `{"id": "<fragment-id>", "status": "created"}`.
 
 ### Policies
 
 | Method | Path | Description |
 |---|---|---|
 | `GET` | `/api/policies` | List all policies. Query params: `name`, `fragment_id`, `enabled_only`, `limit`. |
-| `POST` | `/api/policies` | Create a policy from YAML. Body: `{"yaml_source": "..."}`. |
+| `POST` | `/api/policies` | Create a policy from YAML. Body: same shape as `POST /api/policy-fragments` — full YAML in `yaml_source`, with `kind: Policy`. |
 | `GET` | `/api/policies/{id}` | Get policy detail including compliance summary. |
 | `DELETE` | `/api/policies/{id}` | Delete a policy and its compliance data. |
 | `POST` | `/api/policies/{id}/enable` | Enable a disabled policy. |

--- a/server/core/src/policy_store.cpp
+++ b/server/core/src/policy_store.cpp
@@ -456,10 +456,29 @@ PolicyStore::create_fragment(const std::string& yaml_source) {
     if (yaml_source.size() > 1048576)
         return std::unexpected("YAML too large (max 1MB)");
 
-    // Validate kind
+    // Validate kind. Issue #621: the cryptic "got ''" error confused
+    // operators sending JSON like {"kind":"PolicyFragment", "yaml_source":"..."}
+    // — `kind` must be a YAML field inside `yaml_source`, not a top-level
+    // request parameter. Keep the "kind must be 'PolicyFragment'" prefix so
+    // existing operator scripts that grep on it still work, then append a
+    // worked example.
     auto kind = extract_yaml_value(yaml_source, "kind");
     if (kind != "PolicyFragment")
-        return std::unexpected("kind must be 'PolicyFragment', got '" + kind + "'");
+        return std::unexpected(
+            "kind must be 'PolicyFragment', got '" + kind +
+            "'. yaml_source must be a complete YAML document including "
+            "'apiVersion: yuzu.io/v1alpha1' and 'kind: PolicyFragment'. "
+            "Example:\n"
+            "  apiVersion: yuzu.io/v1alpha1\n"
+            "  kind: PolicyFragment\n"
+            "  metadata:\n"
+            "    name: my-fragment\n"
+            "  spec:\n"
+            "    check:\n"
+            "      plugin: <plugin>\n"
+            "      action: <action>\n"
+            "      compliance: <CEL expression>\n"
+            "See docs/user-manual/policy-engine.md.");
 
     // Extract metadata
     auto id_val = extract_yaml_value(yaml_source, "id");
@@ -840,10 +859,26 @@ PolicyStore::create_policy(const std::string& yaml_source) {
     if (yaml_source.size() > 1048576)
         return std::unexpected("YAML too large (max 1MB)");
 
-    // Validate kind
+    // Validate kind. See create_fragment() for the rationale on the
+    // verbose example — same UX issue (#621), different kind.
     auto kind = extract_yaml_value(yaml_source, "kind");
     if (kind != "Policy")
-        return std::unexpected("kind must be 'Policy', got '" + kind + "'");
+        return std::unexpected(
+            "kind must be 'Policy', got '" + kind +
+            "'. yaml_source must be a complete YAML document including "
+            "'apiVersion: yuzu.io/v1alpha1' and 'kind: Policy'. "
+            "Example:\n"
+            "  apiVersion: yuzu.io/v1alpha1\n"
+            "  kind: Policy\n"
+            "  metadata:\n"
+            "    name: my-policy\n"
+            "  spec:\n"
+            "    fragment: <fragment-name-or-id>\n"
+            "    scope: <scope-expression>\n"
+            "    triggers:\n"
+            "      - type: interval\n"
+            "        interval: 3600\n"
+            "See docs/user-manual/policy-engine.md.");
 
     // Extract metadata
     auto id_val = extract_yaml_value(yaml_source, "id");

--- a/tests/unit/server/test_policy_store.cpp
+++ b/tests/unit/server/test_policy_store.cpp
@@ -197,6 +197,12 @@ TEST_CASE("PolicyStore: create fragment with wrong kind", "[policy_store][fragme
     auto result = store.create_fragment("kind: Policy\nname: oops\n");
     REQUIRE(!result.has_value());
     CHECK(result.error().find("kind must be 'PolicyFragment'") != std::string::npos);
+    // Issue #621: error must include a worked example so operators sending
+    // partial YAML (or sending `kind` as a request param) get unstuck without
+    // having to find the docs separately. The prefix above stays stable so
+    // existing scripts that grep on it keep working.
+    CHECK(result.error().find("apiVersion: yuzu.io/v1alpha1") != std::string::npos);
+    CHECK(result.error().find("docs/user-manual/policy-engine.md") != std::string::npos);
 }
 
 TEST_CASE("PolicyStore: create fragment with missing kind", "[policy_store][fragment]") {
@@ -205,6 +211,7 @@ TEST_CASE("PolicyStore: create fragment with missing kind", "[policy_store][frag
     auto result = store.create_fragment("name: no-kind\ndescription: missing kind field\n");
     REQUIRE(!result.has_value());
     CHECK(result.error().find("kind must be 'PolicyFragment'") != std::string::npos);
+    CHECK(result.error().find("apiVersion: yuzu.io/v1alpha1") != std::string::npos);
 }
 
 TEST_CASE("PolicyStore: fragment with check only (no fix, no postCheck)",
@@ -434,6 +441,10 @@ TEST_CASE("PolicyStore: create policy with wrong kind", "[policy_store][policy]"
     auto r = store.create_policy("kind: PolicyFragment\nname: wrong\n");
     REQUIRE(!r.has_value());
     CHECK(r.error().find("kind must be 'Policy'") != std::string::npos);
+    // Issue #621: same UX expectation as create_fragment — operators must
+    // see a worked example in the error body, not just the prefix.
+    CHECK(r.error().find("apiVersion: yuzu.io/v1alpha1") != std::string::npos);
+    CHECK(r.error().find("docs/user-manual/policy-engine.md") != std::string::npos);
 }
 
 TEST_CASE("PolicyStore: create policy with missing fragment", "[policy_store][policy]") {

--- a/tests/unit/server/test_policy_store.cpp
+++ b/tests/unit/server/test_policy_store.cpp
@@ -212,6 +212,10 @@ TEST_CASE("PolicyStore: create fragment with missing kind", "[policy_store][frag
     REQUIRE(!result.has_value());
     CHECK(result.error().find("kind must be 'PolicyFragment'") != std::string::npos);
     CHECK(result.error().find("apiVersion: yuzu.io/v1alpha1") != std::string::npos);
+    // Governance Gate 7 (consistency S2 / QA SHOULD): docs link must be
+    // pinned on this branch too — not just the wrong-kind branch — so the
+    // operator-facing UX is symmetric across both `kind`-failure modes.
+    CHECK(result.error().find("docs/user-manual/policy-engine.md") != std::string::npos);
 }
 
 TEST_CASE("PolicyStore: fragment with check only (no fix, no postCheck)",
@@ -443,6 +447,20 @@ TEST_CASE("PolicyStore: create policy with wrong kind", "[policy_store][policy]"
     CHECK(r.error().find("kind must be 'Policy'") != std::string::npos);
     // Issue #621: same UX expectation as create_fragment — operators must
     // see a worked example in the error body, not just the prefix.
+    CHECK(r.error().find("apiVersion: yuzu.io/v1alpha1") != std::string::npos);
+    CHECK(r.error().find("docs/user-manual/policy-engine.md") != std::string::npos);
+}
+
+TEST_CASE("PolicyStore: create policy with missing kind", "[policy_store][policy]") {
+    PolicyStore store(":memory:");
+
+    // Governance Gate 7 (consistency S2 / QA SHOULD): symmetric coverage
+    // with the create_fragment "missing kind" case above. Without this
+    // test the asymmetry would let a future regression that drops the
+    // worked-example body from create_policy alone slip through CI.
+    auto r = store.create_policy("name: no-kind\ndescription: missing kind field\n");
+    REQUIRE(!r.has_value());
+    CHECK(r.error().find("kind must be 'Policy'") != std::string::npos);
     CHECK(r.error().find("apiVersion: yuzu.io/v1alpha1") != std::string::npos);
     CHECK(r.error().find("docs/user-manual/policy-engine.md") != std::string::npos);
 }


### PR DESCRIPTION
## Summary

Closes **#621**. fjarvis hit \`"kind must be 'PolicyFragment', got ''"\` sending JSON like \`{"kind":"PolicyFragment","yaml_source":"..."}\` and \`?kind=PolicyFragment\` query params, neither of which the route uses — \`kind\` is a YAML field inside \`yaml_source\`. The original error was correct but gave no path forward.

The error now keeps the \`kind must be 'PolicyFragment'\` (and \`'Policy'\`) prefix so existing operator scripts that grep on it keep working, and appends a complete worked example plus a link to \`docs/user-manual/policy-engine.md\`. The doc gains a worked \`curl\` example covering both body forms (JSON-envelope and raw-YAML) and explicitly notes that \`kind\` is a YAML field, not a request parameter.

## Test plan

- [x] \`build-linux/tests/yuzu_server_tests "[policy_store]"\` — 199 assertions, 41 cases, all passing
- [x] \`meson test -C build-linux "changelog order"\` — passes
- [x] Existing wrong-kind / missing-kind tests in \`test_policy_store.cpp\` extended to pin the new helpful content (\`apiVersion: yuzu.io/v1alpha1\` substring + docs link)
- [x] Manual: \`curl -X POST .../api/policy-fragments -d '{"yaml_source":"name: oops"}'\` returns 400 with the new multi-line example

## Out of scope

OpenAPI spec entry for policy-fragment routes — \`rest_api_v1.cpp\`'s hardcoded inline JSON doesn't currently include the policy-engine surface at all, and adding it is a multi-route schema effort that doesn't belong in this UX fix. Will file a follow-up issue.

This is PR 2 of 3 in the A3 ladder — see PR #745 for PR 1 (#620/#622/#624) and a forthcoming issue-close-only commit for #527 (already fixed on dev by f9495a6 + d612051).

🤖 Generated with [Claude Code](https://claude.com/claude-code)