### PR TITLE
test(server): AgentServiceImpl response-path coverage (#117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests
 
+- `tests/unit/server/test_agent_service_impl.cpp` — new file, 9 cases /
+  47 assertions covering `AgentServiceImpl::record_execution_id` and
+  `AgentServiceImpl::process_gateway_response`. Closes the gap explicitly
+  deferred at `tests/unit/server/test_workflow_routes.cpp:820` ("no
+  AgentServiceImpl in ExecHarness") by constructing a real
+  AgentServiceImpl and driving response receipt end-to-end into a real
+  `ResponseStore`. Pins four contracts from #117's response-streaming
+  call-out: (1) `record_execution_id` registers and clears the
+  command_id → execution_id mapping; (2) `process_gateway_response`
+  stamps execution_id on RUNNING streaming rows, terminal SUCCESS rows,
+  terminal FAILURE rows (with `error_detail`), and degrades to empty
+  execution_id for unmapped command_ids; (3) the HF-1 multi-agent
+  fan-out invariant — the terminal branch does NOT erase the mapping,
+  so 4 agents responding to the same `command_id` (with mixed terminal
+  statuses SUCCESS/FAILURE/TIMEOUT) all stamp the same `execution_id`;
+  (4) the `__timing__|...` sentinel takes the early-return branch in
+  the RUNNING handler and does NOT persist a row. The pre-existing
+  `test_workflow_routes.cpp:814` pin exercised the response-store level
+  only; this new file exercises the `process_gateway_response` upstream
+  path that the comment said had to be deferred to UAT. (#117)
 - `scripts/linux-start-UAT.sh` — added regression assertion that `/health`
   and `/api/health` return 200 AND identical JSON bodies, guarding
   against both the #620 regression and a future split of the dual-mount
@@ -91,24 +111,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (governance Gate 7 hardening — was asymmetric with `create_fragment`)
   and pins the docs link on the `create_fragment` missing-kind branch
   for the same symmetry reason.
-- `tests/unit/server/test_agent_service_impl.cpp` — new file, 8 cases /
-  42 assertions covering `AgentServiceImpl::record_execution_id` and
-  `AgentServiceImpl::process_gateway_response`. Closes the gap explicitly
-  deferred at `tests/unit/server/test_workflow_routes.cpp:820` ("no
-  AgentServiceImpl in ExecHarness") by constructing a real
-  AgentServiceImpl and driving response receipt end-to-end into a real
-  `ResponseStore`. Pins three contracts from #117's response-streaming
-  call-out: (1) `record_execution_id` registers and clears the
-  command_id → execution_id mapping; (2) `process_gateway_response`
-  stamps execution_id on RUNNING streaming rows, terminal SUCCESS rows,
-  terminal FAILURE rows (with `error_detail`), and degrades to empty
-  execution_id for unmapped command_ids; (3) the HF-1 multi-agent
-  fan-out invariant — the terminal branch does NOT erase the mapping,
-  so 3 agents responding to the same `command_id` all stamp the same
-  `execution_id`. The pre-existing `test_workflow_routes.cpp:814` pin
-  exercised the response-store level only; this new file exercises the
-  `process_gateway_response` upstream path that the comment said had to
-  be deferred to UAT. (#117)
 
 ## [0.12.0] - 2026-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (governance Gate 7 hardening — was asymmetric with `create_fragment`)
   and pins the docs link on the `create_fragment` missing-kind branch
   for the same symmetry reason.
+- `tests/unit/server/test_agent_service_impl.cpp` — new file, 8 cases /
+  42 assertions covering `AgentServiceImpl::record_execution_id` and
+  `AgentServiceImpl::process_gateway_response`. Closes the gap explicitly
+  deferred at `tests/unit/server/test_workflow_routes.cpp:820` ("no
+  AgentServiceImpl in ExecHarness") by constructing a real
+  AgentServiceImpl and driving response receipt end-to-end into a real
+  `ResponseStore`. Pins three contracts from #117's response-streaming
+  call-out: (1) `record_execution_id` registers and clears the
+  command_id → execution_id mapping; (2) `process_gateway_response`
+  stamps execution_id on RUNNING streaming rows, terminal SUCCESS rows,
+  terminal FAILURE rows (with `error_detail`), and degrades to empty
+  execution_id for unmapped command_ids; (3) the HF-1 multi-agent
+  fan-out invariant — the terminal branch does NOT erase the mapping,
+  so 3 agents responding to the same `command_id` all stamp the same
+  `execution_id`. The pre-existing `test_workflow_routes.cpp:814` pin
+  exercised the response-store level only; this new file exercises the
+  `process_gateway_response` upstream path that the comment said had to
+  be deferred to UAT. (#117)
 
 ## [0.12.0] - 2026-05-03
 

--- a/docs/executions-history-ladder.md
+++ b/docs/executions-history-ladder.md
@@ -43,6 +43,14 @@ first agent's terminal would leave agents 2..N stamping empty
 sweeper is filed as PR 2.x. The accepted bounded leak matches the existing
 `cmd_send_times_` / `cmd_first_seen_` shape under the same `cmd_times_mu_`.
 
+Regression pin: `tests/unit/server/test_agent_service_impl.cpp` (9 cases /
+47 assertions) drives `process_gateway_response` end-to-end into a real
+`ResponseStore` and pins the no-erase rule (HF-1 fan-out across 4 agents
+with mixed terminal statuses), the RUNNING/terminal stamping branches,
+and the `__timing__|...` sentinel early-return. The
+`test_workflow_routes.cpp:814` sibling case covers the response-store
+level only.
+
 ### Server restart caveat
 
 The mapping is in-memory; restart loses it. In-flight commands at restart

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -159,6 +159,7 @@ if build_server
       'unit/server/test_scope_engine.cpp',
       'unit/server/test_web_utils.cpp',
       'unit/server/test_workflow_routes.cpp',
+      'unit/server/test_agent_service_impl.cpp',
       'unit/server/test_analytics_event.cpp',
       'unit/server/test_agent_health_store.cpp',
       'unit/server/test_instruction_store.cpp',

--- a/tests/unit/server/test_agent_service_impl.cpp
+++ b/tests/unit/server/test_agent_service_impl.cpp
@@ -42,7 +42,6 @@
 #include <memory>
 #include <string>
 
-namespace apb = ::yuzu::agent::v1;
 using yuzu::server::ResponseStore;
 using yuzu::server::StoredResponse;
 using yuzu::server::detail::AgentRegistry;
@@ -51,21 +50,31 @@ using yuzu::server::detail::EventBus;
 
 namespace {
 
+namespace apb = ::yuzu::agent::v1;
+
 /// Minimal harness: real AgentServiceImpl wired against in-memory
 /// ResponseStore. analytics/notification/webhook stores stay null so
 /// the side-effect branches in process_gateway_response short-circuit
 /// on their `if (store_)` guards — keeps the test focused on the
 /// execution_id stamping invariant.
+///
+/// MEMBER ORDER LOAD-BEARING: members below are declared in topological
+/// order so that every reference captured by `svc` (and by `registry`)
+/// points at an already-constructed member, AND so that `responses`
+/// destructs AFTER `svc` (it is declared earlier than `svc`, so it
+/// destructs later than `svc`). `svc` holds `response_store_` as a raw
+/// `ResponseStore*` (set in the body); reordering would create a
+/// dangling-pointer hazard at `~svc`. Do not alphabetise.
 struct GatewayResponseHarness {
     yuzu::MetricsRegistry metrics;
     EventBus bus;
     AgentRegistry registry{bus, metrics};
     yuzu::server::auth::AuthManager auth_mgr;
     yuzu::server::auth::AutoApproveEngine auto_approve;
+    ResponseStore responses{":memory:"};
     AgentServiceImpl svc{
         registry, bus, /*require_client_identity=*/false, auth_mgr, auto_approve, metrics,
         /*gateway_mode=*/false};
-    ResponseStore responses{":memory:"};
 
     GatewayResponseHarness() {
         REQUIRE(responses.is_open());
@@ -189,21 +198,62 @@ TEST_CASE("process_gateway_response: terminal branch does NOT erase mapping "
     // The fix at agent_service_impl.cpp:672-674 keeps the mapping live
     // until a future sweeper. This test drives the path the test_workflow_
     // routes pin couldn't reach (it operated on ResponseStore directly).
+    //
+    // Fan out across 4 agents and mix terminal statuses (SUCCESS / FAILURE /
+    // TIMEOUT) to pin two distinct invariants simultaneously: (a) the
+    // mapping survives every terminal-status code path (`else` branch at
+    // agent_service_impl.cpp:656 covers all non-RUNNING statuses uniformly,
+    // a future split that re-introduces an erase on FAILURE-only or
+    // TIMEOUT-only would slip past a SUCCESS-only test); and (b) tail
+    // agents (#4) past the smallest fan-out width still stamp correctly,
+    // closing the off-by-one window where a regression could erase after
+    // exactly N=3 calls.
     GatewayResponseHarness h;
     h.svc.record_execution_id("cmd-fan", "exec-fan");
 
-    for (const auto& agent_id : {"agent-1", "agent-2", "agent-3"}) {
-        auto r = GatewayResponseHarness::make_response("cmd-fan",
-                                                      apb::CommandResponse::SUCCESS);
-        h.svc.process_gateway_response(agent_id, r);
+    struct AgentTerminal {
+        const char* agent;
+        apb::CommandResponse::Status status;
+    };
+    const AgentTerminal terminals[] = {
+        {"agent-1", apb::CommandResponse::SUCCESS},
+        {"agent-2", apb::CommandResponse::FAILURE},
+        {"agent-3", apb::CommandResponse::TIMEOUT},
+        {"agent-4", apb::CommandResponse::SUCCESS},
+    };
+    for (const auto& t : terminals) {
+        auto r = GatewayResponseHarness::make_response("cmd-fan", t.status);
+        h.svc.process_gateway_response(t.agent, r);
     }
 
     auto rows = h.responses.query_by_execution("exec-fan");
-    REQUIRE(rows.size() == 3);
+    REQUIRE(rows.size() == 4);
     for (const auto& row : rows) {
         CHECK(row.execution_id == "exec-fan");
-        CHECK(row.status == static_cast<int>(apb::CommandResponse::SUCCESS));
+        CHECK(row.error_detail.empty()); // SUCCESS path must not invent error_detail
     }
+}
+
+TEST_CASE("process_gateway_response: __timing__ sentinel takes the early-return "
+          "branch and does NOT store",
+          "[agent_service][executions][pr2]") {
+    // The RUNNING branch at agent_service_impl.cpp:599-606 short-circuits
+    // for output starting with "__timing__|" — these are out-of-band
+    // dashboard-stat payloads, not command output. They must NOT appear
+    // in ResponseStore (no execution_id stamp, no instruction row).
+    // Without this pin, a refactor that hoists the store block above the
+    // sentinel guard would silently start persisting timing rows under the
+    // execution_id, which the drawer would then surface as bogus output.
+    GatewayResponseHarness h;
+    h.svc.record_execution_id("cmd-time", "exec-time");
+
+    auto timing = GatewayResponseHarness::make_response("cmd-time",
+                                                       apb::CommandResponse::RUNNING,
+                                                       /*output=*/"__timing__|elapsed=42");
+    h.svc.process_gateway_response("agent-1", timing);
+
+    CHECK(h.responses.query_by_execution("exec-time").empty());
+    CHECK(h.responses.get_by_instruction("cmd-time").empty());
 }
 
 TEST_CASE("process_gateway_response: streaming + terminal both carry execution_id",

--- a/tests/unit/server/test_agent_service_impl.cpp
+++ b/tests/unit/server/test_agent_service_impl.cpp
@@ -1,0 +1,266 @@
+/**
+ * test_agent_service_impl.cpp — coverage for AgentServiceImpl response-path
+ * helpers. Closes the gap explicitly deferred at
+ * test_workflow_routes.cpp:820 ("no AgentServiceImpl in ExecHarness")
+ * by constructing a real AgentServiceImpl and driving response receipt
+ * end-to-end into a real ResponseStore.
+ *
+ * Pins three contracts called out in #117 (response-streaming coverage):
+ *
+ *   1. record_execution_id() registers the command_id → execution_id
+ *      mapping consumed at response receipt; passing an empty
+ *      execution_id removes the entry (the documented "clear" semantics
+ *      from agent_service_impl.cpp:586).
+ *
+ *   2. process_gateway_response() stamps execution_id onto every
+ *      StoredResponse (RUNNING and terminal branches both), so the
+ *      executions detail drawer's `query_by_execution` path sees the
+ *      stream. A response with no recorded mapping degrades cleanly —
+ *      execution_id stays empty rather than crashing or fabricating.
+ *
+ *   3. The HF-1 multi-agent fan-out invariant: the terminal branch
+ *      MUST NOT erase the mapping after the first agent's terminal
+ *      response, otherwise agents 2..N stamp empty execution_id and
+ *      the drawer drops them. This was a real PR-2 hardening regression
+ *      (see agent_service_impl.cpp:672-674); the response-store-level
+ *      pin at test_workflow_routes.cpp:814 only proves the store
+ *      handles two stamped rows — this test proves the upstream path
+ *      actually emits two stamped rows from a single mapping.
+ */
+
+#include "agent_service_impl.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "agent_registry.hpp"
+#include "event_bus.hpp"
+#include "response_store.hpp"
+#include <yuzu/metrics.hpp>
+#include <yuzu/server/auth.hpp>
+#include <yuzu/server/auto_approve.hpp>
+
+#include <memory>
+#include <string>
+
+namespace apb = ::yuzu::agent::v1;
+using yuzu::server::ResponseStore;
+using yuzu::server::StoredResponse;
+using yuzu::server::detail::AgentRegistry;
+using yuzu::server::detail::AgentServiceImpl;
+using yuzu::server::detail::EventBus;
+
+namespace {
+
+/// Minimal harness: real AgentServiceImpl wired against in-memory
+/// ResponseStore. analytics/notification/webhook stores stay null so
+/// the side-effect branches in process_gateway_response short-circuit
+/// on their `if (store_)` guards — keeps the test focused on the
+/// execution_id stamping invariant.
+struct GatewayResponseHarness {
+    yuzu::MetricsRegistry metrics;
+    EventBus bus;
+    AgentRegistry registry{bus, metrics};
+    yuzu::server::auth::AuthManager auth_mgr;
+    yuzu::server::auth::AutoApproveEngine auto_approve;
+    AgentServiceImpl svc{
+        registry, bus, /*require_client_identity=*/false, auth_mgr, auto_approve, metrics,
+        /*gateway_mode=*/false};
+    ResponseStore responses{":memory:"};
+
+    GatewayResponseHarness() {
+        REQUIRE(responses.is_open());
+        svc.set_response_store(&responses);
+    }
+
+    static apb::CommandResponse make_response(const std::string& command_id,
+                                              apb::CommandResponse::Status status,
+                                              const std::string& output = "",
+                                              int exit_code = 0) {
+        apb::CommandResponse r;
+        r.set_command_id(command_id);
+        r.set_status(status);
+        r.set_output(output);
+        r.set_exit_code(exit_code);
+        return r;
+    }
+};
+
+} // namespace
+
+// ── record_execution_id ────────────────────────────────────────────────────
+
+TEST_CASE("record_execution_id: terminal response stamps mapped execution_id",
+          "[agent_service][executions][pr2]") {
+    GatewayResponseHarness h;
+    h.svc.record_execution_id("cmd-A", "exec-42");
+
+    auto resp = GatewayResponseHarness::make_response(
+        "cmd-A", apb::CommandResponse::SUCCESS, /*output=*/"", /*exit_code=*/0);
+    h.svc.process_gateway_response("agent-1", resp);
+
+    auto rows = h.responses.query_by_execution("exec-42");
+    REQUIRE(rows.size() == 1);
+    CHECK(rows[0].execution_id == "exec-42");
+    CHECK(rows[0].agent_id == "agent-1");
+    CHECK(rows[0].instruction_id == "cmd-A");
+    CHECK(rows[0].status == static_cast<int>(apb::CommandResponse::SUCCESS));
+}
+
+TEST_CASE("record_execution_id: empty execution_id removes the mapping",
+          "[agent_service][executions][pr2]") {
+    GatewayResponseHarness h;
+    h.svc.record_execution_id("cmd-A", "exec-42");
+    h.svc.record_execution_id("cmd-A", ""); // documented clear semantics
+
+    auto resp = GatewayResponseHarness::make_response("cmd-A",
+                                                     apb::CommandResponse::SUCCESS);
+    h.svc.process_gateway_response("agent-1", resp);
+
+    auto by_exec = h.responses.query_by_execution("exec-42");
+    CHECK(by_exec.empty()); // mapping cleared → row not tagged
+    auto by_cmd = h.responses.get_by_instruction("cmd-A");
+    REQUIRE(by_cmd.size() == 1);
+    CHECK(by_cmd[0].execution_id.empty());
+}
+
+// ── process_gateway_response: per-status branches ──────────────────────────
+
+TEST_CASE("process_gateway_response: RUNNING streaming row carries execution_id",
+          "[agent_service][executions][pr2]") {
+    // The RUNNING branch lives at agent_service_impl.cpp:597-655 — it both
+    // stores a streaming row and stamps execution_id from the same map.
+    // Pin both halves: the row exists AND it carries the tag.
+    GatewayResponseHarness h;
+    h.svc.record_execution_id("cmd-stream", "exec-stream");
+
+    auto running = GatewayResponseHarness::make_response("cmd-stream",
+                                                        apb::CommandResponse::RUNNING,
+                                                        /*output=*/"row-1");
+    h.svc.process_gateway_response("agent-1", running);
+
+    auto rows = h.responses.query_by_execution("exec-stream");
+    REQUIRE(rows.size() == 1);
+    CHECK(rows[0].status == static_cast<int>(apb::CommandResponse::RUNNING));
+    CHECK(rows[0].output == "row-1");
+}
+
+TEST_CASE("process_gateway_response: FAILURE preserves error_detail and execution_id",
+          "[agent_service][executions][pr2]") {
+    GatewayResponseHarness h;
+    h.svc.record_execution_id("cmd-fail", "exec-fail");
+
+    auto resp = GatewayResponseHarness::make_response("cmd-fail",
+                                                     apb::CommandResponse::FAILURE,
+                                                     /*output=*/"",
+                                                     /*exit_code=*/2);
+    resp.mutable_error()->set_message("plugin returned non-zero");
+    h.svc.process_gateway_response("agent-1", resp);
+
+    auto rows = h.responses.query_by_execution("exec-fail");
+    REQUIRE(rows.size() == 1);
+    CHECK(rows[0].error_detail == "plugin returned non-zero");
+    CHECK(rows[0].execution_id == "exec-fail");
+    CHECK(rows[0].status == static_cast<int>(apb::CommandResponse::FAILURE));
+}
+
+TEST_CASE("process_gateway_response: unmapped command_id stamps empty execution_id",
+          "[agent_service][executions][pr2]") {
+    // Out-of-band dispatch (CLI / direct gRPC) bypasses the dispatch path
+    // that calls record_execution_id. The receipt path must degrade to an
+    // empty execution_id rather than crashing or inventing a value.
+    GatewayResponseHarness h;
+    auto resp = GatewayResponseHarness::make_response("cmd-orphan",
+                                                     apb::CommandResponse::SUCCESS);
+    h.svc.process_gateway_response("agent-1", resp);
+
+    auto by_cmd = h.responses.get_by_instruction("cmd-orphan");
+    REQUIRE(by_cmd.size() == 1);
+    CHECK(by_cmd[0].execution_id.empty());
+}
+
+// ── HF-1 multi-agent fan-out invariant ─────────────────────────────────────
+
+TEST_CASE("process_gateway_response: terminal branch does NOT erase mapping "
+          "(HF-1 multi-agent fan-out invariant)",
+          "[agent_service][executions][pr2][hardening]") {
+    // PR-2 ladder regression. Pre-fix, the terminal branch erased
+    // cmd_execution_ids_ on the FIRST agent's response so agents 2..N
+    // stamped empty execution_id and the executions drawer dropped them.
+    // The fix at agent_service_impl.cpp:672-674 keeps the mapping live
+    // until a future sweeper. This test drives the path the test_workflow_
+    // routes pin couldn't reach (it operated on ResponseStore directly).
+    GatewayResponseHarness h;
+    h.svc.record_execution_id("cmd-fan", "exec-fan");
+
+    for (const auto& agent_id : {"agent-1", "agent-2", "agent-3"}) {
+        auto r = GatewayResponseHarness::make_response("cmd-fan",
+                                                      apb::CommandResponse::SUCCESS);
+        h.svc.process_gateway_response(agent_id, r);
+    }
+
+    auto rows = h.responses.query_by_execution("exec-fan");
+    REQUIRE(rows.size() == 3);
+    for (const auto& row : rows) {
+        CHECK(row.execution_id == "exec-fan");
+        CHECK(row.status == static_cast<int>(apb::CommandResponse::SUCCESS));
+    }
+}
+
+TEST_CASE("process_gateway_response: streaming + terminal both carry execution_id",
+          "[agent_service][executions][pr2]") {
+    // The drawer's per-execution timeline expects both the RUNNING
+    // streaming rows and the final SUCCESS row to be query_by_execution-
+    // visible. Two RUNNING rows then a terminal SUCCESS = 3 rows tagged.
+    GatewayResponseHarness h;
+    h.svc.record_execution_id("cmd-mix", "exec-mix");
+
+    auto r1 = GatewayResponseHarness::make_response("cmd-mix",
+                                                    apb::CommandResponse::RUNNING,
+                                                    /*output=*/"line-1");
+    h.svc.process_gateway_response("agent-1", r1);
+    auto r2 = GatewayResponseHarness::make_response("cmd-mix",
+                                                    apb::CommandResponse::RUNNING,
+                                                    /*output=*/"line-2");
+    h.svc.process_gateway_response("agent-1", r2);
+    auto r3 = GatewayResponseHarness::make_response("cmd-mix",
+                                                    apb::CommandResponse::SUCCESS);
+    h.svc.process_gateway_response("agent-1", r3);
+
+    auto rows = h.responses.query_by_execution("exec-mix");
+    REQUIRE(rows.size() == 3);
+    int running = 0, success = 0;
+    for (const auto& row : rows) {
+        if (row.status == static_cast<int>(apb::CommandResponse::RUNNING)) ++running;
+        if (row.status == static_cast<int>(apb::CommandResponse::SUCCESS)) ++success;
+        CHECK(row.execution_id == "exec-mix");
+    }
+    CHECK(running == 2);
+    CHECK(success == 1);
+}
+
+TEST_CASE("process_gateway_response: re-mapping a command_id updates the stamp",
+          "[agent_service][executions][pr2]") {
+    // Defensive contract: if the dispatch path overwrites a command_id's
+    // mapping (e.g. retry under a new execution row), responses arriving
+    // after the overwrite stamp the new execution_id. Old execution_id
+    // sees only pre-overwrite responses.
+    GatewayResponseHarness h;
+    h.svc.record_execution_id("cmd-re", "exec-old");
+    auto first = GatewayResponseHarness::make_response("cmd-re",
+                                                       apb::CommandResponse::RUNNING,
+                                                       /*output=*/"old");
+    h.svc.process_gateway_response("agent-1", first);
+
+    h.svc.record_execution_id("cmd-re", "exec-new");
+    auto second = GatewayResponseHarness::make_response("cmd-re",
+                                                        apb::CommandResponse::SUCCESS);
+    h.svc.process_gateway_response("agent-1", second);
+
+    auto old_rows = h.responses.query_by_execution("exec-old");
+    REQUIRE(old_rows.size() == 1);
+    CHECK(old_rows[0].status == static_cast<int>(apb::CommandResponse::RUNNING));
+
+    auto new_rows = h.responses.query_by_execution("exec-new");
+    REQUIRE(new_rows.size() == 1);
+    CHECK(new_rows[0].status == static_cast<int>(apb::CommandResponse::SUCCESS));
+}


### PR DESCRIPTION
## Summary

Closes #117 (filed 2026-03-15) by adding regression coverage for the
gap explicitly deferred at `tests/unit/server/test_workflow_routes.cpp:820`
(\"no AgentServiceImpl in ExecHarness\").

New file `tests/unit/server/test_agent_service_impl.cpp` constructs a real
`yuzu::server::detail::AgentServiceImpl` against an in-memory `ResponseStore`
and drives `record_execution_id` + `process_gateway_response` end-to-end.
9 TEST_CASEs / 47 assertions pin four contracts:

1. `record_execution_id` registers and clears the
   `command_id → execution_id` mapping (empty execution_id =
   documented clear semantics from `agent_service_impl.cpp:586`).
2. `process_gateway_response` stamps `execution_id` on RUNNING
   streaming rows, terminal SUCCESS rows, terminal FAILURE rows
   (preserving `error_detail`), and degrades to empty `execution_id`
   for unmapped command_ids (out-of-band CLI / direct-gRPC dispatch).
3. **HF-1 multi-agent fan-out invariant**: the terminal branch does
   NOT erase `cmd_execution_ids_` after the first agent's response.
   Pinned across 4 agents with mixed statuses (SUCCESS / FAILURE /
   TIMEOUT / SUCCESS) — closes the off-by-one regression window AND
   confirms the invariant holds across every non-RUNNING status code
   path uniformly.
4. The `__timing__|...` sentinel takes the early-return branch in
   the RUNNING handler and does NOT persist a row.

The pre-existing pin at `test_workflow_routes.cpp:814` exercised the
`ResponseStore` level only; this PR exercises the upstream
`process_gateway_response` path that the comment said had to be deferred
to a UAT round-trip.

#117 also called out two other coverage areas (Subscribe stream behavior
and enrollment lifecycle), both of which are already covered:
- Subscribe fan-out / register-heartbeat-disconnect lifecycle is
  exercised by the Erlang gateway suites (`gateway/apps/yuzu_gw/test/yuzu_gw_e2e_SUITE.erl`,
  `yuzu_gw_integration_SUITE.erl`).
- Enrollment is covered by `test_auth.cpp` (36 cases),
  `test_approval_manager.cpp` (20), `test_auto_approve.cpp` (19), and
  `test_device_token_store.cpp`.

The remaining unit-testable gap was the executions-correlation path this
PR addresses; the rest is integration-test territory and out of scope
for a pure unit-test PR.

## Commits

- `5e8e460` — initial implementation (8 cases / 42 assertions)
- `2f9b3cc` — governance hardening round (9 cases / 47 assertions)

Hardening addresses convergent findings from `/governance`:
- Harness member-declaration order swap so `~svc` no longer holds a
  dangling raw pointer to a destroyed `ResponseStore` (QE Finding 1 /
  cpp-expert / UP-6); MEMBER ORDER LOAD-BEARING docblock added.
- HF-1 fan-out widened from 3 → 4 agents with mixed terminal statuses
  (UP-1 off-by-one window + happy-path Q3 mixed-status gap).
- New `__timing__` early-return TEST_CASE (happy-path Q6).
- `apb` namespace alias moved into unnamed namespace (cpp-expert NICE).
- CHANGELOG + `docs/executions-history-ladder.md` consistency
  (consistency-auditor / SRE SHOULD / security INFO / compliance INFO-2).

## Test plan

- [x] `meson compile -C build-linux yuzu_server_tests` — clean
- [x] `build-linux/tests/yuzu_server_tests \"[agent_service]\"` — 9/9 pass, 47/47 assertions
- [x] `meson test -C build-linux --suite server` — 1/1 pass, 57.7s
- [x] `python3 tests/test_changelog_order.py` — 13 sections in order
- [x] Full `/governance dev..HEAD` pipeline — Gates 1-7 PASS, 0 BLOCKING, 0 SHOULD

## Governance trail

- Gate 1 — change summary written
- Gate 2 — security-guardian PASS, docs-writer 1 SHOULD-FIX (fixed)
- Gate 3 — quality-engineer SHOULD-FIX (fixed) + NICE, cpp-expert NICE (fixed), build-ci PASS
- Gate 4 — happy-path 3 SHOULDs (2 fixed, 1 deferred as follow-up), unhappy-path full risk register (UP-1/UP-5/UP-6 fixed; rest deferred), consistency-auditor PASS
- Gate 5 — chaos-injector skipped (unhappy-path findings are test-design
  quality, not production-runtime risks suitable for chaos exercise)
- Gate 6 — compliance / sre / enterprise-readiness all PASS
- Gate 7 — re-review on hardening: security PASS, compliance PASS,
  sre PASS, enterprise-readiness PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)