### PR TITLE
chore(ci): add scw-eager-lumiere to runner inventory

### DIFF
--- a/.github/runner-inventory.json
+++ b/.github/runner-inventory.json
@@ -15,6 +15,13 @@
       "labels": ["self-hosted", "Windows", "X64"],
       "role": "Windows MSVC CI jobs — ci.yml windows matrix (release + debug), codeql Windows leg.",
       "installed": "2026-04-14"
+    },
+    {
+      "name": "scw-eager-lumiere",
+      "host": "Scaleway VPS (Ubuntu 24.04, 4 vCPU, 7.7 GB RAM, ~45 GB disk)",
+      "labels": ["self-hosted", "Linux", "X64", "yuzu-cloud-builder"],
+      "role": "Cloud-side Linux capacity sharing the [self-hosted, Linux, X64] label set with yuzu-wsl2-linux. The yuzu-cloud-builder label exists for future opt-in pinning of jobs that should land here specifically. Disk is tighter than the WSL2 box — sanitizer-tests.yml's ≥30 GB preflight will fail-fast if a sanitizer dispatch lands on this runner; that is intentional and the dispatch will retry on yuzu-wsl2-linux.",
+      "installed": "2026-05-04"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds the new self-hosted Linux runner `scw-eager-lumiere` (Scaleway VPS) to `.github/runner-inventory.json`.
- Labels: `[self-hosted, Linux, X64, yuzu-cloud-builder]`. Default Linux/X64 labels kept so the runner shares load with `yuzu-wsl2-linux` on existing `[self-hosted, Linux, X64]` jobs.
- The `yuzu-cloud-builder` label is reserved for future opt-in pinning of jobs that should target this runner specifically.

## Why now

The runner is registered and online; the sentinel currently sees it as drift and will create/update a tracking issue every 30 min until this lands. **Please merge promptly.**

## Caveats (documented in the inventory entry)

- Box has ~20 GB free of 45 GB total. `sanitizer-tests.yml` asserts ≥30 GB free in its preflight, so any sanitizer dispatch that lands on this runner fast-fails at the disk check. That's the intended behavior — the user redispatches on `yuzu-wsl2-linux`.
- Volume resize is a follow-up.
- Toolchain pre-bake (gcc-13, ccache, OTP, rebar3, meson, ninja) is being completed in parallel so the linux matrix doesn't apt-get on every run.

## Test plan

- [x] CI green on this PR (only changes a JSON file with a `paths-ignore` exclusion in ci.yml — no compile)
- [ ] After merge: `gh run list --workflow runner-inventory-sentinel.yml -L 3` shows `success` on next tick
- [ ] After merge: `gh issue list --label runner-inventory-drift --state open` returns empty
- [ ] Trigger a `workflow_dispatch` of a low-risk Linux workflow and confirm `scw-eager-lumiere` can pick up a job (visible in `journalctl -u actions.runner.Tr3kkR-Yuzu.scw-eager-lumiere.service`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)