### PR TITLE
fix(ci): pin OTP 28 in nightly.yml — fixes #860 (nightly-broken)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -73,6 +73,21 @@ jobs:
           pip3 install --user --break-system-packages --require-hashes -r requirements-ci.txt
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
+      # OTP + rebar3 for the gateway custom_target. Without these, this
+      # job inherits whatever Erlang the self-hosted runner has globally,
+      # which on the WSL2 runner has previously been older than the
+      # rebar3 binary on PATH — producing BEAM-loader failures of the
+      # form `op bs_add p x i u x: please re-compile this module with an
+      # Erlang/OTP 28 compiler`. Pin matches ci.yml + release.yml so any
+      # OTP bump moves all three workflows together.
+      - name: Install Erlang/OTP and rebar3
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
+        env:
+          ImageOS: ubuntu24
+        with:
+          otp-version: '28'
+          rebar3-version: '3.24'
+
       - name: Reset ccache stats
         run: ccache -z
 
@@ -154,6 +169,21 @@ jobs:
             pkg-config curl zip unzip tar python3-pip ccache
           pip3 install --user --break-system-packages --require-hashes -r requirements-ci.txt
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # OTP + rebar3 for the gateway custom_target. Without these, this
+      # job inherits whatever Erlang the self-hosted runner has globally,
+      # which on the WSL2 runner has previously been older than the
+      # rebar3 binary on PATH — producing BEAM-loader failures of the
+      # form `op bs_add p x i u x: please re-compile this module with an
+      # Erlang/OTP 28 compiler`. Pin matches ci.yml + release.yml so any
+      # OTP bump moves all three workflows together.
+      - name: Install Erlang/OTP and rebar3
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
+        env:
+          ImageOS: ubuntu24
+        with:
+          otp-version: '28'
+          rebar3-version: '3.24'
 
       - name: Reset ccache stats
         run: ccache -z
@@ -237,6 +267,21 @@ jobs:
           # coverage report).
           pip3 install --user --break-system-packages --require-hashes -r requirements-ci.txt
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # OTP + rebar3 for the gateway custom_target. Without these, this
+      # job inherits whatever Erlang the self-hosted runner has globally,
+      # which on the WSL2 runner has previously been older than the
+      # rebar3 binary on PATH — producing BEAM-loader failures of the
+      # form `op bs_add p x i u x: please re-compile this module with an
+      # Erlang/OTP 28 compiler`. Pin matches ci.yml + release.yml so any
+      # OTP bump moves all three workflows together.
+      - name: Install Erlang/OTP and rebar3
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
+        env:
+          ImageOS: ubuntu24
+        with:
+          otp-version: '28'
+          rebar3-version: '3.24'
 
       - name: Reset ccache stats
         run: ccache -z

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -147,7 +147,14 @@ jobs:
   # ── Sanitizers (TSan) ──────────────────────────────────────────────────
   sanitize-tsan:
     name: "Sanitizers (TSan)"
-    runs-on: [self-hosted, Linux, X64]
+    # Pinned to Shulgi (yuzu-wsl2-linux). Same compute argument as the
+    # ASan job: the TSan triplet (x64-linux-tsan, issue #917) is a forced
+    # cold-cache rebuild every run because per-instrumentation vcpkg
+    # packages can't be safely shared with the standard or ASan triplets.
+    # On scw-eager-lumiere (small Scaleway VM) the from-source dep-tree
+    # rebuild blows the 60-min job timeout; Shulgi (16-core 5950X) clears
+    # the same workload in ~15 min.
+    runs-on: [self-hosted, Linux, X64, yuzu-shulgi]
     timeout-minutes: 60
     env:
       TSAN_OPTIONS: "halt_on_error=1:second_deadlock_stack=1"
@@ -203,32 +210,35 @@ jobs:
           vcpkgDirectory: '${{ github.workspace }}/vcpkg'
           vcpkgGitCommitId: '${{ env.VCPKG_COMMIT }}'
 
-      - name: vcpkg sentinel (x64-linux)
-        run: bash scripts/ci/vcpkg-triplet-sentinel.sh x64-linux
+      - name: vcpkg sentinel (x64-linux-tsan)
+        run: bash scripts/ci/vcpkg-triplet-sentinel.sh x64-linux-tsan
 
-      - name: Install vcpkg packages
+      - name: Install vcpkg packages (TSan-instrumented)
         env:
-          # Shares the matrix linux cache — TSan uses the same x64-linux
-          # triplet so the package zips are bit-identical. Issue #569.
-          VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.tool_cache }}/yuzu-vcpkg-binary-cache-linux
+          # Dedicated per-triplet binary cache. TSan-instrumented
+          # packages can't share the standard x64-linux cache or the
+          # x64-linux-asan cache — different sanitizer flag sets produce
+          # different shadow-memory ABIs. Issue #917 / #569.
+          VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.tool_cache }}/yuzu-vcpkg-binary-cache-tsan
         run: |
           mkdir -p "$VCPKG_DEFAULT_BINARY_CACHE"
           ${{ github.workspace }}/vcpkg/vcpkg install \
-            --triplet x64-linux \
+            --triplet x64-linux-tsan \
+            --overlay-triplets=${{ github.workspace }}/triplets \
             --x-manifest-root=${{ github.workspace }}
 
       - name: Configure (Meson + TSan)
         env:
           CC: ccache gcc-13
           CXX: ccache g++-13
-          PKG_CONFIG_PATH: ${{ github.workspace }}/vcpkg_installed/x64-linux/lib/pkgconfig
+          PKG_CONFIG_PATH: ${{ github.workspace }}/vcpkg_installed/x64-linux-tsan/lib/pkgconfig
         run: |
           reconfig=""
           [[ -d build-linux-tsan/meson-info ]] && reconfig="--reconfigure"
           meson setup $reconfig build-linux-tsan \
             --native-file meson/native/linux-gcc13.ini \
             --buildtype=debug \
-            -Dcmake_prefix_path=${{ github.workspace }}/vcpkg_installed/x64-linux \
+            -Dcmake_prefix_path=${{ github.workspace }}/vcpkg_installed/x64-linux-tsan \
             -Dbuild_tests=true \
             -Db_sanitize=thread
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,7 +36,16 @@ jobs:
   # ── Sanitizers (ASan + UBSan) ──────────────────────────────────────────
   sanitize-asan:
     name: "Sanitizers (ASan+UBSan)"
-    runs-on: [self-hosted, Linux, X64]
+    # Pinned to Shulgi (yuzu-wsl2-linux). The ASan triplet (x64-linux-asan)
+    # is a forced cold-cache rebuild every run because per-instrumentation
+    # vcpkg packages can't be safely shared with the standard triplet — so
+    # the ASan job rebuilds the full dep tree from source on every nightly.
+    # On the small cloud runner (scw-eager-lumiere) that step alone runs
+    # 60+ minutes and routinely blows the 60-min job timeout. Shulgi
+    # (16-core 5950X) clears the same workload in ~15 min. TSan and
+    # Coverage share the warm x64-linux triplet cache so they don't need
+    # pinning and keep the runner pool flexible.
+    runs-on: [self-hosted, Linux, X64, yuzu-shulgi]
     timeout-minutes: 60
     env:
       # detect_odr_violation=0 mirrors ci.yml's matrix linux: gRPC's

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -144,6 +144,17 @@ jobs:
         if: always()
         run: ccache -s
 
+      - name: Upload meson testlog (on failure)
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: meson-testlog-asan
+          path: |
+            build-linux-asan/meson-logs/testlog.txt
+            build-linux-asan/meson-logs/testlog.junit.xml
+          retention-days: 14
+          if-no-files-found: warn
+
   # ── Sanitizers (TSan) ──────────────────────────────────────────────────
   sanitize-tsan:
     name: "Sanitizers (TSan)"
@@ -251,6 +262,17 @@ jobs:
       - name: ccache stats
         if: always()
         run: ccache -s
+
+      - name: Upload meson testlog (on failure)
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: meson-testlog-tsan
+          path: |
+            build-linux-tsan/meson-logs/testlog.txt
+            build-linux-tsan/meson-logs/testlog.junit.xml
+          retention-days: 14
+          if-no-files-found: warn
 
   # ── Coverage (gcov + gcovr) ────────────────────────────────────────────
   coverage:
@@ -385,6 +407,17 @@ jobs:
       - name: ccache stats
         if: always()
         run: ccache -s
+
+      - name: Upload meson testlog (on failure)
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: meson-testlog-coverage
+          path: |
+            build-linux-coverage/meson-logs/testlog.txt
+            build-linux-coverage/meson-logs/testlog.junit.xml
+          retention-days: 14
+          if-no-files-found: warn
 
   # ── Alert on nightly failure ───────────────────────────────────────────
   # Opens or comments on the `nightly-broken` issue if any of the three

--- a/.github/workflows/sanitizer-tests.yml
+++ b/.github/workflows/sanitizer-tests.yml
@@ -50,7 +50,12 @@ jobs:
   asan-ubsan:
     name: "Sanitizers (ASan+UBSan)"
     if: ${{ inputs.suite == 'asan' || inputs.suite == 'both' || inputs.suite == '' }}
-    runs-on: [self-hosted, Linux, X64]
+    # Pinned to Shulgi: x64-linux-asan is a forced cold-cache rebuild and
+    # the small cloud runner can't finish it inside the job timeout. CLAUDE.md
+    # documents this workflow as intended for yuzu-wsl2-linux anyway —
+    # adding the label makes the targeting explicit instead of relying on
+    # whichever Linux X64 runner happens to be free.
+    runs-on: [self-hosted, Linux, X64, yuzu-shulgi]
     timeout-minutes: 75
     env:
       # detect_odr_violation=0 mirrors ci.yml's sanitize-asan job: gRPC's
@@ -173,7 +178,10 @@ jobs:
   tsan:
     name: "Sanitizers (TSan)"
     if: ${{ inputs.suite == 'tsan' || inputs.suite == 'both' || inputs.suite == '' }}
-    runs-on: [self-hosted, Linux, X64]
+    # Pinned to Shulgi for the same reason as asan-ubsan: x64-linux-tsan
+    # is a forced cold-cache rebuild every run (#917). CLAUDE.md documents
+    # this workflow as intended for yuzu-wsl2-linux anyway.
+    runs-on: [self-hosted, Linux, X64, yuzu-shulgi]
     timeout-minutes: 75
     env:
       TSAN_OPTIONS: "halt_on_error=1:second_deadlock_stack=1"
@@ -214,36 +222,38 @@ jobs:
           vcpkgDirectory: '${{ github.workspace }}/vcpkg'
           vcpkgGitCommitId: '${{ env.VCPKG_COMMIT }}'
 
-      - name: vcpkg sentinel (x64-linux)
+      - name: vcpkg sentinel (x64-linux-tsan)
         # Universal cache-key contract — see scripts/ci/vcpkg-triplet-sentinel.sh.
-        run: bash scripts/ci/vcpkg-triplet-sentinel.sh x64-linux
+        run: bash scripts/ci/vcpkg-triplet-sentinel.sh x64-linux-tsan
 
-      - name: Install vcpkg packages
-        # TSan shares the matrix linux cache: TSan instruments the
-        # consumer code, not the vcpkg ports (no x64-linux-tsan
-        # triplet — TSan & ASan are mutually exclusive at the port
-        # level). Sharing yuzu-vcpkg-binary-cache-linux with ci.yml's
-        # matrix Linux + tsan jobs means the dispatched /test --full
-        # path restores the warm cache. Closes the TSan half of #441.
+      - name: Install vcpkg packages (TSan-instrumented)
+        # Dedicated x64-linux-tsan triplet (#917): TSan-instrumented
+        # ports give TSan the visibility it needs into abseil/grpc/openssl
+        # synchronization primitives. Without this, TSan-instrumented
+        # consumer code passes through non-TSan library code and either
+        # misses real races or hard-faults on shadow-memory collisions.
+        # Per-triplet binary cache because TSan-flag compiled packages
+        # can't share zips with the standard or ASan triplets.
         env:
-          VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.tool_cache }}/yuzu-vcpkg-binary-cache-linux
+          VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.tool_cache }}/yuzu-vcpkg-binary-cache-tsan
         run: |
           mkdir -p "$VCPKG_DEFAULT_BINARY_CACHE"
           ${{ github.workspace }}/vcpkg/vcpkg install \
-            --triplet x64-linux \
+            --triplet x64-linux-tsan \
+            --overlay-triplets=${{ github.workspace }}/triplets \
             --x-manifest-root=${{ github.workspace }}
 
       - name: Configure (Meson + TSan)
         env:
           CC: ccache gcc-13
           CXX: ccache g++-13
-          PKG_CONFIG_PATH: ${{ github.workspace }}/vcpkg_installed/x64-linux/lib/pkgconfig
+          PKG_CONFIG_PATH: ${{ github.workspace }}/vcpkg_installed/x64-linux-tsan/lib/pkgconfig
         run: |
           rm -rf build-linux-tsan
           meson setup build-linux-tsan \
             --native-file meson/native/linux-gcc13.ini \
             --buildtype=debug \
-            -Dcmake_prefix_path=${{ github.workspace }}/vcpkg_installed/x64-linux \
+            -Dcmake_prefix_path=${{ github.workspace }}/vcpkg_installed/x64-linux-tsan \
             -Dbuild_tests=true \
             -Db_sanitize=thread
 

--- a/meson.build
+++ b/meson.build
@@ -386,16 +386,18 @@ if _rebar3.found()
   # isolation fix applies unconditionally so the race can't come
   # back if Linux kernel semantics ever change. `test_gateway.py`
   # honors REBAR_BASE_DIR when computing the ebin wipe path.
-  # Timeout matches `gateway ct` (300s). 120s was tight on slower cloud
-  # runners (scw-eager-lumiere) under coverage instrumentation when
-  # parallel meson test execution starves the eunit job of CPU —
-  # eunit reliably finishes in ~30-90s on a fast runner but landed at
-  # 120.03s under nightly's coverage build, killing the suite by SIGTERM.
+  # Timeout 600s — upper-bound safety net for the nightly Coverage and
+  # sanitizer jobs on slower cloud runners (scw-eager-lumiere) where
+  # parallel meson test execution can starve the eunit job of CPU.
+  # Healthy runs finish in ~30-90s on a fast runner and are unaffected
+  # by the upper bound. The previous 120s landed at exactly 120.03s on
+  # nightly Coverage and killed the suite by SIGTERM; gateway eunit is
+  # only reached during nightly anyway, so a generous bound is free.
   test('gateway eunit',
     _python3,
     args: [_gw_test_script, _gw_src, 'eunit'],
     suite: 'gateway',
-    timeout: 300,
+    timeout: 600,
     env: {'REBAR_BASE_DIR': _gw_src / '_build_eunit'},
   )
   test('gateway ct',

--- a/meson.build
+++ b/meson.build
@@ -386,11 +386,16 @@ if _rebar3.found()
   # isolation fix applies unconditionally so the race can't come
   # back if Linux kernel semantics ever change. `test_gateway.py`
   # honors REBAR_BASE_DIR when computing the ebin wipe path.
+  # Timeout matches `gateway ct` (300s). 120s was tight on slower cloud
+  # runners (scw-eager-lumiere) under coverage instrumentation when
+  # parallel meson test execution starves the eunit job of CPU —
+  # eunit reliably finishes in ~30-90s on a fast runner but landed at
+  # 120.03s under nightly's coverage build, killing the suite by SIGTERM.
   test('gateway eunit',
     _python3,
     args: [_gw_test_script, _gw_src, 'eunit'],
     suite: 'gateway',
-    timeout: 120,
+    timeout: 300,
     env: {'REBAR_BASE_DIR': _gw_src / '_build_eunit'},
   )
   test('gateway ct',

--- a/scripts/ci/vcpkg-triplet-sentinel.sh
+++ b/scripts/ci/vcpkg-triplet-sentinel.sh
@@ -71,9 +71,9 @@ fi
 # sha256sum reads every input that exists; missing inputs are skipped (they
 # contribute nothing to the digest). The vcpkg-configuration.json is a hard
 # requirement of the manifest layout for our pinned-baseline mode but the
-# overlay triplet is conditional — only x64-linux-asan / x64-linux-static /
-# x64-windows currently have one. Stock triplets (x64-linux, arm64-osx) do
-# not.
+# overlay triplet is conditional — only x64-linux-asan / x64-linux-tsan /
+# x64-linux-static / x64-windows currently have one. Stock triplets
+# (x64-linux, arm64-osx) do not.
 inputs=(vcpkg.json)
 if [[ -f vcpkg-configuration.json ]]; then
   inputs+=(vcpkg-configuration.json)

--- a/triplets/x64-linux-tsan.cmake
+++ b/triplets/x64-linux-tsan.cmake
@@ -1,0 +1,41 @@
+# x64-linux-tsan triplet — vcpkg builds vendored deps (protobuf, abseil,
+# grpc, openssl, sqlite, etc.) with ThreadSanitizer enabled. The Yuzu
+# sanitize-tsan CI job uses this triplet so the application's TSan
+# instrumentation can observe synchronization primitives inside the
+# dependency code, and abseil's TSan-aware container ops engage
+# (`ABSL_HAVE_THREAD_SANITIZER` is auto-detected by abseil's build when
+# `-fsanitize=thread` is in the compile flags).
+#
+# Without this, TSan-instrumented Yuzu code passes through non-TSan
+# library code paths that hold real locks, and TSan can't observe
+# the happens-before edges. Symptoms: false-positive races, missed
+# real races, or hard SEGV-without-race-report when TSan's shadow
+# memory model collides with a dep's atomic ops it didn't instrument.
+# Issue #917.
+
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+# Sanitiser flags propagate to every compiled C/C++ TU in vendored
+# dependencies. `-fno-omit-frame-pointer` keeps backtraces accurate
+# in race reports; `-g` keeps file:line debug info. Matches what
+# meson `-Db_sanitize=thread` emits for the application binary so
+# the dep tree and app tree are ABI-compatible.
+#
+# UBSan is intentionally **not** built into the deps for the same
+# reason as x64-linux-asan: `-fsanitize=undefined` instruments
+# function-pointer + vptr access in a way that prevents abseil's
+# constexpr address-comparison from being constant-evaluated,
+# breaking the abseil build. The Yuzu application binary still
+# compiles under TSan via meson `-Db_sanitize=thread`; UBSan
+# instrumentation in libs adds nothing here.
+set(VCPKG_C_FLAGS   "-fsanitize=thread -fno-omit-frame-pointer -g")
+set(VCPKG_CXX_FLAGS "-fsanitize=thread -fno-omit-frame-pointer -g")
+set(VCPKG_LINKER_FLAGS "-fsanitize=thread")
+
+# Skip dep debug variants — protobuf/abseil/grpc are already large;
+# a debug-side build would double the binary-cache footprint and the
+# from-source first-run time. Same reasoning as x64-linux-asan.
+set(VCPKG_BUILD_TYPE release)


### PR DESCRIPTION
## Summary

Five-commit CI remediation closing the gateway-build root cause behind `nightly-broken #860` plus the structural follow-ups it exposed. Sequence is:

1. **`033aaf4` — pin OTP 28 in `nightly.yml`** (the actual fix for #860)
   - All three jobs had no `erlef/setup-beam` step; inherited stale OTP/rebar3 from runner host. On `scw-eager-lumiere` the runtime BEAM was older than the rebar3 escript → BEAM-loader failures (`op bs_add p x i u x: please re-compile this module with an Erlang/OTP 28 compiler`).
   - Adds the same setup-beam step `ci.yml` and `release.yml` already use.

2. **`0f73ce7`** (superseded) — eunit timeout 120 → 300 s.
3. **`cd723f6`** — eunit timeout 300 → 600 s. Build unblocking exposed `gateway eunit TIMEOUT 120.03s` on the cloud runner under coverage instrumentation. Per maintainer guidance, gateway eunit only runs during nightly so a generous 10-min upper bound is free.

4. **`0085277` — pin nightly ASan job to Shulgi (`yuzu-shulgi` label)**
   - The `x64-linux-asan` triplet is a forced cold-cache rebuild on every run. On `scw-eager-lumiere` the from-source dep-tree rebuild blows the 60-min timeout. Shulgi's 16-core 5950X clears the same workload in ~15 min.
   - Coverage and TSan share the warm `x64-linux` triplet cache and stay flexible.
   - `yuzu-shulgi` label was added to runner id 30 via `gh api` in the same change window.

5. **`65d372d` — instrument TSan dependencies via `x64-linux-tsan` triplet (closes #917)**
   - Adds `triplets/x64-linux-tsan.cmake` mirroring the ASan triplet pattern.
   - Updates both `nightly.yml` and `sanitizer-tests.yml` TSan jobs: sentinel + vcpkg install + cache scope + meson `cmake_prefix_path` all switched to `x64-linux-tsan`.
   - TSan jobs now also pinned to `yuzu-shulgi` (same compute argument as ASan — instrumented triplet = forced cold-cache rebuild).
   - `sanitizer-tests.yml` ASan job also pinned to `yuzu-shulgi` — CLAUDE.md already documents that workflow as intended for `yuzu-wsl2-linux` and the explicit label removes accidental cloud-runner scheduling.
   - This is the likely structural cause of #910 — TSan SIGSEGV in server unit tests with no race report preceding the abort is the signature of TSan colliding with non-TSan-built abseil/grpc/openssl synchronization primitives.

## Failing run evidence (root cause)

- Run [25594580143](https://github.com/Tr3kkR/Yuzu/actions/runs/25594580143) — TSan failed at gateway custom_target (BEAM-loader).
- Run [25481433665](https://github.com/Tr3kkR/Yuzu/actions/runs/25481433665) — coverage failed.
- Run [25362259432](https://github.com/Tr3kkR/Yuzu/actions/runs/25362259432) — opened #860.

## Validation runs

- Run [25597821480](https://github.com/Tr3kkR/Yuzu/actions/runs/25597821480) on `033aaf4`: confirmed Build phase clean across all three jobs; gateway compile succeeded under setup-beam-installed OTP 28.
- Run [25599471809](https://github.com/Tr3kkR/Yuzu/actions/runs/25599471809) on `cd723f6`: Coverage end-to-end success (0 timeout). Cancelled when `0085277` landed (ASan was stuck on cold-cache vcpkg install on cloud runner — exactly the failure mode that motivated commit 4).
- Run [25601265472](https://github.com/Tr3kkR/Yuzu/actions/runs/25601265472) on `0085277`: ASan job picked up by `yuzu-wsl2-linux` (Shulgi) — label routing confirmed. Still in flight.
- Run [25601447779](https://github.com/Tr3kkR/Yuzu/actions/runs/25601447779) on `65d372d`: full fix-set validation including TSan instrumented deps. Just dispatched.

## Related — tracked separately

- **#910 — TSan: server unit tests SIGSEGV.** Filed before `65d372d` as a pre-existing data race. Now likely a phantom caused by `#917`'s uninstrumented-deps gap; will re-evaluate once `65d372d`'s validation run lands. Closing #910 is gated on observing the SIGSEGV's behaviour with TSan-instrumented deps.

- **Runner OTP 28 host upgrade** (belt-and-braces): workflow-level `setup-beam` pin is sufficient for nightly correctness. Bringing `scw-eager-lumiere` and `yuzu-wsl2-linux` to OTP 28 globally is desirable but requires runner-host privileges out-of-scope for this branch. Commands provided to the maintainer separately.

## Test plan

- [x] Build phase confirmed green across all three jobs on `033aaf4` (BEAM-loader bug eliminated).
- [x] Coverage end-to-end confirmed green on `cd723f6` (eunit timeout adequate).
- [x] ASan job confirmed pinned to Shulgi on `0085277` validation run.
- [ ] TSan job pinned to Shulgi on `65d372d` validation run.
- [ ] TSan instrumentation correctness: with deps now built under `-fsanitize=thread`, server unit tests either reproduce the SIGSEGV with a real race report (Yuzu race → #910 stays valid) or run clean (#910 was a phantom → close).
- [ ] `nightly-broken #860` auto-closes after first green nightly on `main` post-merge.

## Closes

- Closes #917 (TSan dependencies are uninstrumented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)