### PR TITLE
ci(codeql): propagate Erlang PATH to Build step (fix Linux leg)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -252,11 +252,26 @@ jobs:
           # Erlang and doesn't contribute to C++ CodeQL, but the
           # custom_target must succeed or meson compile fails. Linux
           # only — Windows CodeQL leg does not build the gateway.
+          #
+          # `source scripts/ensure-erlang.sh` only mutates PATH in this
+          # step's shell. Subsequent steps (Configure, Build) run in fresh
+          # shells where Erlang is gone again, and the meson `gateway`
+          # custom_target dies with `/usr/bin/env: 'escript': No such
+          # file or directory` (run 25620458000). Echo the bin dirs of
+          # the resolved tools to $GITHUB_PATH so they are prepended for
+          # every subsequent step on the same runner.
           if command -v rebar3 >/dev/null 2>&1; then
             source scripts/ensure-erlang.sh
-            command -v erl >/dev/null || {
+            if command -v erl >/dev/null; then
+              for tool in erl escript rebar3; do
+                bin_dir=$(dirname "$(command -v "$tool" 2>/dev/null)" 2>/dev/null || true)
+                if [[ -n "$bin_dir" && -d "$bin_dir" ]]; then
+                  echo "$bin_dir" >> "$GITHUB_PATH"
+                fi
+              done
+            else
               echo "::warning::ensure-erlang.sh did not resolve erl on PATH"
-            }
+            fi
           else
             echo "rebar3 not installed — gateway target will be skipped"
           fi


### PR DESCRIPTION
## Summary

- Linux CodeQL run [25620458000](https://github.com/Tr3kkR/Yuzu/actions/runs/25620458000) (scheduled, `main@d2d42ee`) failed at the Build step: meson `gateway` custom_target couldn't find `escript`.
- The "Ensure Erlang on PATH" step succeeded but its `source scripts/ensure-erlang.sh` only mutated PATH inside that step's shell. Subsequent steps started in fresh shells where Erlang was gone again.
- Fix: after sourcing, append `dirname` of `erl` / `escript` / `rebar3` to `\$GITHUB_PATH` so every subsequent step in the same job sees them.
- Windows leg is unaffected (the step is `if: matrix.os == 'linux'` and Windows never builds the gateway).
- The Windows half of the same run failed on the vcpkg sentinel step with `WSL_E_LOCAL_SYSTEM_NOT_SUPPORTED` — that one was already fixed on main in #921 (81bea63 → switched the sentinel run to `/usr/bin/bash` and dropped the explicit `shell: bash` so the matrix-level MSYS2 default applies). Not touched here.

## Test plan
- [ ] Re-run CodeQL workflow once this lands on dev → main; expect Linux Build step to succeed at the `.gateway_built` target.
- [ ] Confirm Windows leg still passes (regression check; this PR doesn't touch the Windows codepath).

🤖 Generated with [Claude Code](https://claude.com/claude-code)