### PR TITLE
release: dev → main sync (codeql Erlang PATH fix)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -252,11 +252,26 @@ jobs:
           # Erlang and doesn't contribute to C++ CodeQL, but the
           # custom_target must succeed or meson compile fails. Linux
           # only — Windows CodeQL leg does not build the gateway.
+          #
+          # `source scripts/ensure-erlang.sh` only mutates PATH in this
+          # step's shell. Subsequent steps (Configure, Build) run in fresh
+          # shells where Erlang is gone again, and the meson `gateway`
+          # custom_target dies with `/usr/bin/env: 'escript': No such
+          # file or directory` (run 25620458000). Echo the bin dirs of
+          # the resolved tools to $GITHUB_PATH so they are prepended for
+          # every subsequent step on the same runner.
           if command -v rebar3 >/dev/null 2>&1; then
             source scripts/ensure-erlang.sh
-            command -v erl >/dev/null || {
+            if command -v erl >/dev/null; then
+              for tool in erl escript rebar3; do
+                bin_dir=$(dirname "$(command -v "$tool" 2>/dev/null)" 2>/dev/null || true)
+                if [[ -n "$bin_dir" && -d "$bin_dir" ]]; then
+                  echo "$bin_dir" >> "$GITHUB_PATH"
+                fi
+              done
+            else
               echo "::warning::ensure-erlang.sh did not resolve erl on PATH"
-            }
+            fi
           else
             echo "rebar3 not installed — gateway target will be skipped"
           fi


### PR DESCRIPTION
## Summary

Single-commit sync of #923 from dev to main:

- **#923** `ci(codeql): export Erlang bin dirs to \$GITHUB_PATH so Build step inherits` — fixes Linux leg of the weekly CodeQL run by propagating Erlang's `escript` / `erl` / `rebar3` bin dirs to subsequent steps via `\$GITHUB_PATH` (the prior `source scripts/ensure-erlang.sh` was shell-local, so the Build step started fresh and the meson `gateway` custom_target died with `escript: No such file or directory`).

## Test plan
- [ ] CodeQL workflow next fires green on Linux
- [ ] No regression on Windows leg (already-green; this PR does not touch the Windows codepath)

🤖 Generated with [Claude Code](https://claude.com/claude-code)