### PR TITLE
fix(tests): bump server suite timeout 180s → 600s for ASan headroom

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -234,7 +234,12 @@ if build_server
     # hardening round 1, qe-B2).
     dependencies: [yuzu_server_core_dep, catch2_dep, dependency('openssl', required: true, include_type: 'system')],
   )
-  test('server unit tests', server_test_exe, suite: 'server', timeout: 180)
+  # 600s: the server suite has grown to ~1200 test cases (#1032 added viz-engine
+  # coverage) and ASan instrumentation slows the full run past the previous
+  # 180s cap. TSan with halt_on_error usually exits earlier, but a sanitizer-
+  # instrumented full pass easily hits 4-5 min. A real hang is still bounded
+  # by the 60-min job-level timeout in nightly.yml.
+  test('server unit tests', server_test_exe, suite: 'server', timeout: 600)
 endif
 
 # ── Proto codegen tests ────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

The server unit-test suite grew from ~700 to ~1200 cases after PR #1032 (viz-engine) merged into `dev`. Under ASan instrumentation the full pass now exceeds the previous 180s per-test meson cap, **timing out the nightly's ASan job** ([run 25914787658](https://github.com/Tr3kkR/Yuzu/actions/runs/25914787658), killed at 180.06s while inside `test_workflow_routes` Catch2 fixture).

TSan with `halt_on_error=1` exits earlier so it stayed under the cap, but the cushion was already gone — discovered during the dev-nightly validation for the #1031+#1034 merge.

## What

One-line bump in `tests/meson.build`: `timeout: 180` → `timeout: 600`. Plus a comment explaining the rationale so the next contributor wondering "why is this 600?" has the context.

The dominant cost in the suite is now ASan-instrumented memory allocation across the expanded fixture set, not any single hot test — a surgical workflow-only `--timeout-multiplier` would also work, but the test-list grew so the underlying cap was simply stale.

Real hangs are still bounded by the 60-min job-level timeout in `nightly.yml` and `sanitizer-tests.yml`.

## Test plan

- [ ] Re-dispatch nightly on `dev` after merge; ASan job passes
- [x] No effect on TSan (already passed); no effect on normal CI matrix (uses different timeouts where relevant)