### PR TITLE
ci(codeql): install Erlang via erlef/setup-beam on Linux leg

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,8 +2,18 @@ name: "CodeQL"
 
 # CodeQL C++ + GitHub Actions static analysis across BOTH self-hosted
 # runners, running in parallel:
-#   - yuzu-wsl2-linux (labels: self-hosted/Linux/X64)  — gcc-13 build
+#   - yuzu-wsl2-linux (labels: self-hosted/Linux/X64/yuzu-shulgi) — gcc-13 build
 #   - yuzu-local-windows (labels: self-hosted/Windows/X64) — MSVC build
+#
+# The Linux leg pins `yuzu-shulgi` explicitly so it can't drift to
+# `scw-eager-lumiere` (cloud builder, labels self-hosted/Linux/X64/
+# yuzu-cloud-builder). The cloud builder is sized for nightly Coverage
+# and routinely sits below the 40 GB disk threshold this workflow
+# requires; matching `[self-hosted, Linux, X64]` alone gives GH free
+# reign to assign whichever runner is idle, which produces non-
+# deterministic failures (run 25986790721 hit Scaleway at 23 GB free
+# and died at the disk check before any CodeQL work). Same selector
+# pattern nightly.yml uses for the equivalent meson workload.
 #
 # The two runs are separate matrix legs with `fail-fast: false`, so a
 # quirk on one platform doesn't kill the other. Each leg uploads SARIF
@@ -92,7 +102,10 @@ jobs:
       matrix:
         include:
           - os: linux
-            runner: [self-hosted, Linux, X64]
+            # yuzu-shulgi pin — see header comment. The cloud builder
+            # (scw-eager-lumiere) carries `yuzu-cloud-builder` instead;
+            # this list intentionally excludes it.
+            runner: [self-hosted, Linux, X64, yuzu-shulgi]
             triplet: x64-linux
             vcpkg_bin: vcpkg
             build_dir: build-linux-codeql

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -243,38 +243,37 @@ jobs:
             --triplet ${{ matrix.triplet }} \
             --x-manifest-root="$GITHUB_WORKSPACE"
 
-      - name: Ensure Erlang on PATH (gateway custom_target, linux only)
+      # Install Erlang/OTP + rebar3 for the gateway custom_target. The
+      # meson `gateway` custom_target fires when `find_program('rebar3')`
+      # succeeds at configure time; on the self-hosted Linux runner
+      # rebar3 sits at /home/github-runner/.local/bin/rebar3 so the
+      # custom_target IS scheduled, and the Build step then dies with
+      # `/usr/bin/env: 'escript': No such file or directory` if Erlang
+      # isn't on PATH. Gateway is Erlang and contributes zero TUs to
+      # C++ CodeQL — CodeQL has no Erlang extractor and dialyzer is
+      # the gateway's canonical static-analysis tool (see
+      # `.github/workflows/release.yml` line 296, the `gateway-dialyzer`
+      # skill, and CLAUDE.md "Always run rebar3 dialyzer"). But the
+      # custom_target must succeed or `meson compile` fails the whole
+      # job. Mirror ci.yml's "Install Erlang/OTP and rebar3" step
+      # verbatim — same pinned SHA, same OTP version, same ImageOS
+      # override. Runs reliably on the same yuzu-wsl2-linux runner on
+      # every Tier-2 PR build. Replaces the prior `scripts/ensure-erlang.sh`
+      # +`$GITHUB_PATH` plumbing (PR #923) which could not find Erlang
+      # at all when the runner lacked a kerl/asdf/brew install — the
+      # 2026-05-10 and 2026-05-17 scheduled runs both failed on this
+      # branch. Linux only — Windows uses build_gateway.py's C:\Erlang
+      # junction lookup.
+      - name: Install Erlang/OTP and rebar3 (linux)
         if: matrix.os == 'linux'
-        run: |
-          # The meson `gateway` custom_target fires when rebar3 is
-          # detected. If it is, set up the Erlang toolchain so the
-          # compile step doesn't fail on `.gateway_built`. Gateway is
-          # Erlang and doesn't contribute to C++ CodeQL, but the
-          # custom_target must succeed or meson compile fails. Linux
-          # only — Windows CodeQL leg does not build the gateway.
-          #
-          # `source scripts/ensure-erlang.sh` only mutates PATH in this
-          # step's shell. Subsequent steps (Configure, Build) run in fresh
-          # shells where Erlang is gone again, and the meson `gateway`
-          # custom_target dies with `/usr/bin/env: 'escript': No such
-          # file or directory` (run 25620458000). Echo the bin dirs of
-          # the resolved tools to $GITHUB_PATH so they are prepended for
-          # every subsequent step on the same runner.
-          if command -v rebar3 >/dev/null 2>&1; then
-            source scripts/ensure-erlang.sh
-            if command -v erl >/dev/null; then
-              for tool in erl escript rebar3; do
-                bin_dir=$(dirname "$(command -v "$tool" 2>/dev/null)" 2>/dev/null || true)
-                if [[ -n "$bin_dir" && -d "$bin_dir" ]]; then
-                  echo "$bin_dir" >> "$GITHUB_PATH"
-                fi
-              done
-            else
-              echo "::warning::ensure-erlang.sh did not resolve erl on PATH"
-            fi
-          else
-            echo "rebar3 not installed — gateway target will be skipped"
-          fi
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
+        env:
+          # erlef/setup-beam can't auto-detect the self-hosted runner OS;
+          # the explicit ImageOS hint matches ci.yml:230.
+          ImageOS: ubuntu24
+        with:
+          otp-version: '28'
+          rebar3-version: '3.24'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3


### PR DESCRIPTION
## Summary
- The Linux CodeQL scheduled scan has failed on the past two Sundays (2026-05-10 run 25620458000, 2026-05-17 run 25982097954) at `[320/338] Generating gateway` with `/usr/bin/env: 'escript': No such file or directory`.
- Root cause: meson's `find_program('rebar3')` succeeds at configure time (rebar3 is at `~/.local/bin/rebar3` on yuzu-wsl2-linux), so the `gateway` custom_target is scheduled — but the existing `scripts/ensure-erlang.sh` + `\$GITHUB_PATH` plumbing from #923 can only find Erlang installed via kerl/asdf/brew/MSYS2, none of which exist on the runner. It emits `[ensure-erlang] Erlang/OTP not found` and the Build step then dies on `escript`.
- Replace with `erlef/setup-beam@fc68ffb` v1.24.0 + `ImageOS: ubuntu24` — the exact pattern `ci.yml:228` has been using reliably on the same runner for every Tier-2 PR. The action installs OTP 28 + rebar3 3.24 and writes the bin dirs to `\$GITHUB_PATH` so the Build step inherits them.

**Note on CodeQL + Erlang**: CodeQL has no Erlang extractor (supported list: C/C++, C#, Go, Java, Kotlin, JS, TS, Python, Ruby, Rust, Swift, Actions). The gateway's canonical static-analysis tool is dialyzer (run in `release.yml:296` and via the `gateway-dialyzer` skill). This change only restores the gateway custom_target so `meson compile` finishes the C++ tracer pass — gateway code is invisible to the C++ CodeQL database either way.

Windows leg untouched — `scripts/build_gateway.py` already finds escript via the `C:\Erlang` junction on the Windows self-hosted runner (this PR's "before" Windows leg was succeeding).

## Test plan
- [x] `workflow_dispatch` triggered on this branch: https://github.com/Tr3kkR/Yuzu/actions/runs/25986790721
- [ ] Linux leg passes through the Build step (no `escript` failure on `.gateway_built`)
- [ ] CodeQL SARIF uploaded for `c-cpp-linux` and `c-cpp-windows` categories
- [ ] No regression in Windows leg