### PR TITLE
chore(auth): W1.x device-token debt — internal_error, prng_failure casing, audit-detail trust boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **#1056 — `DeviceTokenValidateError::internal_error` distinguishes a
+  store-internal fault from a clean miss.** A `sqlite3_prepare_v2`
+  failure in `DeviceTokenStore::validate_token` was previously
+  mislabelled `not_found`, polluting the not-found signal and misleading
+  forensics. It now maps to a dedicated `internal_error` variant. The
+  public wire response is unchanged — it still collapses to the same
+  `401`/`UNAUTHENTICATED` as every other variant (no `500` differential
+  to probe); only the operator-facing audit detail and the
+  `yuzu_device_token_rejected_total{variant=...}` label change.
+
+- **#1057 — `SecureRandomError::PrngFailure` renamed to `prng_failure`.**
+  Aligns the enumerator with the snake_case convention used by the
+  sibling auth error enums (`DeviceTokenValidateError` et al.). Internal
+  symbol only; the audit-emitted `"prng_failure"` reason string was
+  already snake_case, so there is no wire or audit-log change.
+
+- **#1060 — `rejection_detail` renamed to
+  `rejection_audit_detail_for_storage`.** Names the trust boundary at
+  every call site: the returned string carries `bound_device_id` /
+  `bound_principal_id` and must be written only to the audit store,
+  never echoed onto a public surface. Internal helper only (no runtime
+  behavior change).
+
 - **#1088 — `McpServer::DispatchFn` signature gained trailing
   `execution_id` parameter.** Internal ABI on the `McpServer` class
   (header `server/core/src/mcp_server.hpp`). The typedef now matches

--- a/server/core/src/device_token_rejection.hpp
+++ b/server/core/src/device_token_rejection.hpp
@@ -8,8 +8,8 @@
 /// HTTP/gRPC response MUST go through `make_public_rejection()` (HTTP) or
 /// `make_grpc_rejection_status()` (gRPC) and MUST NOT vary the wire shape
 /// by variant. The typed `DeviceTokenValidateError` is visible ONLY in
-/// operator-facing surfaces: audit rows (`rejection_detail()` /
-/// `rejection_event_action()`) and Prometheus counters
+/// operator-facing surfaces: audit rows (`rejection_audit_detail_for_storage()`
+/// / `rejection_event_action()`) and Prometheus counters
 /// (`rejection_metric_name()`).
 ///
 /// **Why collapse?** Without this, an attacker holding a stolen valid
@@ -97,6 +97,8 @@ inline std::string_view rejection_variant_name(DeviceTokenValidateError e) noexc
         return "unbound_legacy";
     case DeviceTokenValidateError::binding_mismatch:
         return "binding_mismatch";
+    case DeviceTokenValidateError::internal_error:
+        return "internal_error";
     }
     return "unknown";
 }
@@ -105,7 +107,17 @@ inline std::string_view rejection_variant_name(DeviceTokenValidateError e) noexc
 /// for `binding_mismatch` (#1053 audit-completeness goal) so an auditor
 /// can reconstruct "agent X tried to use a token bound to agent Y
 /// (issued by principal Z)" without joining additional tables.
-inline std::string rejection_detail(const RejectedToken& r, std::string_view presenting_agent_id) {
+///
+/// **Trust boundary (#1060).** The `_for_storage` suffix is deliberate: the
+/// returned string carries `bound_device_id` / `bound_principal_id`, which
+/// are operator-only. The result MUST be written ONLY to the audit store —
+/// never echoed onto a REST/dashboard "recent rejections" surface, or it
+/// leaks token-binding context to an attacker holding a stolen token. Naming
+/// the boundary at every call site is the compile-time-cheap guard against a
+/// future caller surfacing it on a public response. See the `make_public_*`
+/// helpers for the only sanctioned wire path.
+inline std::string rejection_audit_detail_for_storage(const RejectedToken& r,
+                                                      std::string_view presenting_agent_id) {
     std::string detail{rejection_variant_name(r.error)};
     if (!presenting_agent_id.empty())
         detail.append(": presenter=").append(presenting_agent_id);

--- a/server/core/src/device_token_rejection.hpp
+++ b/server/core/src/device_token_rejection.hpp
@@ -143,9 +143,11 @@ inline std::string rejection_audit_detail_for_storage(const RejectedToken& r,
 /// * `revoked` — replayed-revoked-token attempt. Investigate the
 ///   originating IP.
 ///
-/// `not_found` / `expired` / `invalid_input` are bucketed together as
-/// low-signal `yuzu_device_token_rejected_total{variant=...}` so SRE
-/// can still see them without flooding the high-signal counters.
+/// `not_found` / `expired` / `invalid_input` / `internal_error` are
+/// bucketed together as low-signal `yuzu_device_token_rejected_total{variant=...}`
+/// so SRE can still see them without flooding the high-signal counters.
+/// (`internal_error` is a store-internal fault, not a client miss — when the
+/// store is wired it should graduate to its own paging counter; see #1054.)
 inline std::string_view rejection_metric_name(DeviceTokenValidateError e) noexcept {
     switch (e) {
     case DeviceTokenValidateError::binding_mismatch:

--- a/server/core/src/device_token_store.cpp
+++ b/server/core/src/device_token_store.cpp
@@ -229,8 +229,11 @@ DeviceTokenStore::validate_token(const std::string& raw_token,
                            "created_at, expires_at, last_used_at, revoked "
                            "FROM device_auth_tokens WHERE token_hash = ?;",
                            -1, &s, nullptr) != SQLITE_OK) {
+        // #1056: a prepare failure is a store-internal fault, not a clean
+        // miss. Labelling it not_found would pollute the not_found signal and
+        // mislead forensics. It still collapses to the same wire response.
         RejectedToken r;
-        r.error = DeviceTokenValidateError::not_found;
+        r.error = DeviceTokenValidateError::internal_error;
         return std::unexpected(std::move(r));
     }
     sqlite3_bind_text(s, 1, hashed.c_str(), -1, SQLITE_TRANSIENT);

--- a/server/core/src/device_token_store.hpp
+++ b/server/core/src/device_token_store.hpp
@@ -57,6 +57,14 @@ enum class DeviceTokenValidateError {
     /// but the agent presenting the token does not match `device_id` (#824
     /// stolen-token impersonation).
     binding_mismatch,
+    /// A store-internal failure prevented validation from reaching a verdict
+    /// (e.g. `sqlite3_prepare_v2` failed). Distinct from `not_found` so an
+    /// internal fault does not pollute the not-found signal or mislead
+    /// forensics into reading a clean miss (#1056). Collapses to the same
+    /// 401/UNAUTHENTICATED wire response as every other variant — an
+    /// internal fault MUST NOT surface as a 500 differential an attacker
+    /// could probe.
+    internal_error,
 };
 
 /// Rich rejection context returned from `validate_token` on failure
@@ -71,6 +79,7 @@ enum class DeviceTokenValidateError {
 /// |--------------------|----------|-----------------|--------------------|
 /// | invalid_input      | empty    | empty           | empty              |
 /// | not_found          | empty    | empty           | empty              |
+/// | internal_error     | empty    | empty           | empty              |
 /// | revoked            | set      | set             | set                |
 /// | expired            | set      | set             | set                |
 /// | unbound_legacy     | set      | empty           | set                |

--- a/server/core/src/enrollment_token_rejection.hpp
+++ b/server/core/src/enrollment_token_rejection.hpp
@@ -8,8 +8,11 @@
 /// every gRPC handler that maps an `EnrollmentTokenError` to a wire
 /// response MUST collapse to one opaque message ("invalid, expired, or
 /// exhausted enrollment token"). Operator-facing variance lives ONLY in
-/// audit rows (`rejection_detail`) and Prometheus counters
-/// (`rejection_metric_name`).
+/// audit rows (variant via `enrollment_rejection_variant_name`, assembled at
+/// the call site — there is no `_for_storage` detail helper here because
+/// enrollment rejections carry no bound-device context to guard, unlike the
+/// device-token sibling's `rejection_audit_detail_for_storage`) and
+/// Prometheus counters (`enrollment_rejection_metric_name`).
 ///
 /// **Why collapse the enrollment-token surface.** Same threat model as
 /// device tokens: a presenter who can discriminate `not_found` from

--- a/server/core/src/secure_random.cpp
+++ b/server/core/src/secure_random.cpp
@@ -50,7 +50,7 @@ std::expected<void, SecureRandomError> fill_random(std::span<std::uint8_t> out) 
     // creating a fresh token) is not also forced to fail.
     if (g_force_failure) {
         g_force_failure = false;
-        return std::unexpected(SecureRandomError::PrngFailure);
+        return std::unexpected(SecureRandomError::prng_failure);
     }
 
 #ifdef _WIN32
@@ -66,7 +66,7 @@ std::expected<void, SecureRandomError> fill_random(std::span<std::uint8_t> out) 
         if (rc != 0 /* STATUS_SUCCESS */) {
             spdlog::error("secure_random: BCryptGenRandom failed, NTSTATUS=0x{:08x}",
                           static_cast<unsigned>(rc));
-            return std::unexpected(SecureRandomError::PrngFailure);
+            return std::unexpected(SecureRandomError::prng_failure);
         }
         p += step;
         remaining -= step;
@@ -78,12 +78,12 @@ std::expected<void, SecureRandomError> fill_random(std::span<std::uint8_t> out) 
     // failure — never fall back to weak entropy.
     if (out.size() > static_cast<std::size_t>(std::numeric_limits<int>::max())) {
         spdlog::error("secure_random: requested {} bytes exceeds RAND_bytes int limit", out.size());
-        return std::unexpected(SecureRandomError::PrngFailure);
+        return std::unexpected(SecureRandomError::prng_failure);
     }
     const int rc = RAND_bytes(out.data(), static_cast<int>(out.size()));
     if (rc != 1) {
         spdlog::error("secure_random: RAND_bytes returned {} (entropy unavailable)", rc);
-        return std::unexpected(SecureRandomError::PrngFailure);
+        return std::unexpected(SecureRandomError::prng_failure);
     }
     return {};
 #endif

--- a/server/core/src/secure_random.hpp
+++ b/server/core/src/secure_random.hpp
@@ -36,7 +36,7 @@ enum class SecureRandomError {
     /// exhaustion in an early-boot or restricted-FD container. On Windows
     /// it indicates BCrypt's provider returned non-success. Either way the
     /// server has no business issuing a token until the next call succeeds.
-    PrngFailure,
+    prng_failure,
 };
 
 /// Fill `out` with cryptographically-secure random bytes. Empty `out` is a
@@ -53,7 +53,7 @@ fill_random(std::span<std::uint8_t> out) noexcept;
 namespace test_hooks {
 
 /// Force the next `fill_random` / `random_hex` call on the current thread to
-/// return `PrngFailure` without touching the underlying CSPRNG, then auto-clear.
+/// return `prng_failure` without touching the underlying CSPRNG, then auto-clear.
 /// Test-only: lets governance Gate 2 F-002 verify that token-create handlers
 /// emit a `failure` audit row when entropy is unavailable, without faking
 /// an entropy-exhaustion environment. Thread-local so concurrent test cases

--- a/server/core/src/server.cpp
+++ b/server/core/src/server.cpp
@@ -266,7 +266,7 @@ public:
                           "Audit events that failed to persist (sqlite3_step != DONE)", "counter");
         // PR W1.1 sre-1 (gov Gate 6, sre): CSPRNG-failure paging signal.
         // Increments in the token-create handlers (api_token, device_token)
-        // when `secure_random::fill_random` returns PrngFailure (entropy
+        // when `secure_random::fill_random` returns prng_failure (entropy
         // exhaustion). Operators wire a Prometheus rule like
         //   rate(yuzu_secure_random_failure_total[5m]) > 0
         // to page on-call short of grepping audit logs.
@@ -298,7 +298,7 @@ public:
                           "Replay attempt against a revoked device token", "counter");
         metrics_.describe("yuzu_device_token_rejected_total",
                           "Low-signal device-token validation rejections (not_found, "
-                          "expired, invalid_input), labelled by variant",
+                          "expired, invalid_input, internal_error), labelled by variant",
                           "counter");
         // W1.4 / #827: enrollment-token race-loss counter. Fires when two
         // agents concurrently presented the same one-time enrollment token

--- a/tests/unit/server/test_device_token_rejection.cpp
+++ b/tests/unit/server/test_device_token_rejection.cpp
@@ -14,7 +14,7 @@
  *      `binding_mismatch` from `not_found` to confirm token existence.
  *
  *   2. **Audit/metric expansion (#1053).** The operator-visible side —
- *      `rejection_detail()` and `rejection_metric_name()` — MUST
+ *      `rejection_audit_detail_for_storage()` and `rejection_metric_name()` — MUST
  *      discriminate by variant so SRE can alert on a `binding_mismatch`
  *      spike and an auditor can reconstruct attempted impersonations
  *      ("presenter=X bound=Y bound_principal=Z").
@@ -50,6 +50,7 @@ RejectedToken make_rejected(DeviceTokenValidateError v) {
     switch (v) {
     case DeviceTokenValidateError::invalid_input:
     case DeviceTokenValidateError::not_found:
+    case DeviceTokenValidateError::internal_error:
         // no row context — fields stay empty
         break;
     case DeviceTokenValidateError::revoked:
@@ -72,6 +73,7 @@ const std::vector<DeviceTokenValidateError> kAllVariants = {
     DeviceTokenValidateError::invalid_input,  DeviceTokenValidateError::not_found,
     DeviceTokenValidateError::revoked,        DeviceTokenValidateError::expired,
     DeviceTokenValidateError::unbound_legacy, DeviceTokenValidateError::binding_mismatch,
+    DeviceTokenValidateError::internal_error,
 };
 
 } // namespace
@@ -165,7 +167,7 @@ TEST_CASE("device_token_rejection: audit detail discriminates by variant",
     std::set<std::string> detail_set;
     for (auto v : kAllVariants) {
         auto rt = make_rejected(v);
-        auto detail = rejection_detail(rt, "device-B");
+        auto detail = rejection_audit_detail_for_storage(rt, "device-B");
         REQUIRE_FALSE(detail.empty());
         CHECK(detail.find(std::string(rejection_variant_name(v))) != std::string::npos);
         detail_set.insert(detail);
@@ -180,7 +182,7 @@ TEST_CASE("device_token_rejection: binding_mismatch audit detail names presenter
     // The #1053 acceptance case: auditor sees the full impersonation
     // attempt without joining additional tables.
     auto rt = make_rejected(DeviceTokenValidateError::binding_mismatch);
-    auto detail = rejection_detail(rt, "device-B");
+    auto detail = rejection_audit_detail_for_storage(rt, "device-B");
     CHECK(detail.find("binding_mismatch") != std::string::npos);
     CHECK(detail.find("presenter=device-B") != std::string::npos);
     CHECK(detail.find("bound=device-A") != std::string::npos);
@@ -193,7 +195,7 @@ TEST_CASE("device_token_rejection: unbound_legacy audit detail omits bound_devic
     // Per RejectedToken doc — unbound_legacy MUST NOT carry a fabricated
     // bound_device_id. The legacy row has no binding by construction.
     auto rt = make_rejected(DeviceTokenValidateError::unbound_legacy);
-    auto detail = rejection_detail(rt, "device-Z");
+    auto detail = rejection_audit_detail_for_storage(rt, "device-Z");
     CHECK(detail.find("unbound_legacy") != std::string::npos);
     CHECK(detail.find("presenter=device-Z") != std::string::npos);
     CHECK(detail.find("bound_principal=admin") != std::string::npos);
@@ -207,7 +209,7 @@ TEST_CASE("device_token_rejection: not_found audit detail carries no row context
     // not_found is the only rejection without a row — must not fabricate
     // token_id / bound_* fields.
     auto rt = make_rejected(DeviceTokenValidateError::not_found);
-    auto detail = rejection_detail(rt, "device-Z");
+    auto detail = rejection_audit_detail_for_storage(rt, "device-Z");
     CHECK(detail.find("not_found") != std::string::npos);
     CHECK(detail.find("presenter=device-Z") != std::string::npos);
     CHECK(detail.find("token_id=") == std::string::npos);
@@ -232,6 +234,8 @@ TEST_CASE("device_token_rejection: Prometheus metric names are stable + variant-
     CHECK(rejection_metric_name(DeviceTokenValidateError::expired) ==
           "yuzu_device_token_rejected_total");
     CHECK(rejection_metric_name(DeviceTokenValidateError::invalid_input) ==
+          "yuzu_device_token_rejected_total");
+    CHECK(rejection_metric_name(DeviceTokenValidateError::internal_error) ==
           "yuzu_device_token_rejected_total");
 }
 

--- a/tests/unit/server/test_device_token_rejection.cpp
+++ b/tests/unit/server/test_device_token_rejection.cpp
@@ -138,6 +138,7 @@ TEST_CASE("device_token_rejection: gRPC status uniformly UNAUTHENTICATED",
     CHECK(msg.find("expired") == std::string::npos);
     CHECK(msg.find("unbound_legacy") == std::string::npos);
     CHECK(msg.find("binding_mismatch") == std::string::npos);
+    CHECK(msg.find("internal_error") == std::string::npos);
     CHECK(msg.find("device-A") == std::string::npos);
     CHECK(msg.find("admin") == std::string::npos);
 }
@@ -211,6 +212,19 @@ TEST_CASE("device_token_rejection: not_found audit detail carries no row context
     auto rt = make_rejected(DeviceTokenValidateError::not_found);
     auto detail = rejection_audit_detail_for_storage(rt, "device-Z");
     CHECK(detail.find("not_found") != std::string::npos);
+    CHECK(detail.find("presenter=device-Z") != std::string::npos);
+    CHECK(detail.find("token_id=") == std::string::npos);
+    CHECK(detail.find(" bound=") == std::string::npos);
+    CHECK(detail.find("bound_principal=") == std::string::npos);
+}
+
+TEST_CASE("device_token_rejection: internal_error audit detail carries no row context",
+          "[device_token][audit][issue1056]") {
+    // internal_error (a store-internal fault, e.g. sqlite3_prepare_v2 failure)
+    // has no row — like not_found it MUST NOT fabricate token_id / bound_* fields.
+    auto rt = make_rejected(DeviceTokenValidateError::internal_error);
+    auto detail = rejection_audit_detail_for_storage(rt, "device-Z");
+    CHECK(detail.find("internal_error") != std::string::npos);
     CHECK(detail.find("presenter=device-Z") != std::string::npos);
     CHECK(detail.find("token_id=") == std::string::npos);
     CHECK(detail.find(" bound=") == std::string::npos);

--- a/tests/unit/server/test_rest_api_tokens.cpp
+++ b/tests/unit/server/test_rest_api_tokens.cpp
@@ -302,7 +302,7 @@ TEST_CASE("REST DELETE /api/v1/tokens: unknown token id returns 404 with no audi
 // `csprng_unavailable` marker. The hooks lean on
 // `yuzu::server::test_hooks::force_next_failure_for_this_thread()` — a
 // thread-local, one-shot override that makes the very next
-// `fill_random` / `random_hex` call return PrngFailure without faking
+// `fill_random` / `random_hex` call return prng_failure without faking
 // an entropy-starved process. SOC 2 CC7.2/CC7.3 rationale: security-
 // relevant failure conditions for token issuance must be auditable.
 // ──────────────────────────────────────────────────────────────────────────
@@ -314,7 +314,7 @@ TEST_CASE("REST POST /api/v1/tokens: CSPRNG failure emits failure audit (F-002)"
     h.session_role = auth::Role::user;
 
     // Force the next fill_random call (inside ApiTokenStore::generate_raw_token)
-    // to return PrngFailure. This is the only path that produces the CSPRNG
+    // to return prng_failure. This is the only path that produces the CSPRNG
     // error without sabotaging the OS RNG, and it auto-clears so any
     // subsequent calls in the harness teardown are unaffected.
     yuzu::server::test_hooks::force_next_failure_for_this_thread();

--- a/tests/unit/server/test_secure_random.cpp
+++ b/tests/unit/server/test_secure_random.cpp
@@ -79,7 +79,7 @@ TEST_CASE("secure_random: 1000 consecutive 16-byte hex tokens are all unique", "
 // On POSIX, fill_random rejects buffers larger than INT_MAX because
 // RAND_bytes takes int. Windows splits into ULONG-sized chunks instead, so
 // this guard does not apply there.
-TEST_CASE("secure_random: oversized request returns PrngFailure on POSIX", "[csprng][error]") {
+TEST_CASE("secure_random: oversized request returns prng_failure on POSIX", "[csprng][error]") {
     // We cannot actually allocate INT_MAX+1 bytes — synthesise a fake span
     // whose .size() exceeds the cap. The pointer is never dereferenced
     // because fill_random's size check fires first.
@@ -88,6 +88,6 @@ TEST_CASE("secure_random: oversized request returns PrngFailure on POSIX", "[csp
     std::span<std::uint8_t> oversized{&dummy, huge};
     auto rc = fill_random(oversized);
     REQUIRE_FALSE(rc.has_value());
-    CHECK(rc.error() == SecureRandomError::PrngFailure);
+    CHECK(rc.error() == SecureRandomError::prng_failure);
 }
 #endif


### PR DESCRIPTION
Same-repo re-submission of the W1.x device-token debt cleanup so the self-hosted CI matrix (Linux/Windows/Proto) actually runs — **supersedes the fork PR #1114**, which carries the full `/governance` agent-by-agent trail.

## What
Caller-independent cleanup from the W1.x token-binding ladder (the device-token validation feature is still unwired scaffolding — `validate_token` has no production caller):

| Issue | Change |
|---|---|
| **#1056** | Add `DeviceTokenValidateError::internal_error` so a `sqlite3_prepare_v2` failure is no longer mislabelled `not_found`. Collapses to the same 401/UNAUTHENTICATED wire response (no 500 differential). |
| **#1057** | Rename `SecureRandomError::PrngFailure` → `prng_failure` (snake_case enum-casing convention). |
| **#1060** | Rename `rejection_detail` → `rejection_audit_detail_for_storage` to flag the operator-only trust boundary at every call site. |

2 commits: the change + a governance Gate-7 hardening round (`9097e0a`) folding SHOULD findings (stale enrollment comment, gRPC-exclusion test, dedicated `internal_error` audit-detail test).

## Governance
Full pipeline run (Gates 2–7) on #1114 — **PASS, no CRITICAL/HIGH/BLOCKING**. `#1052`/`#1053` confirmed already-shipped (closed); `#1054`/`#1055`/`#1061` deferred to the store-wiring feature.

## Verification
Full `meson compile` clean; `meson test` 5/5 suites green (vcpkg-pinned baseline `4b77da7`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)