### PR TITLE
chore(governance): add CODEOWNERS — @fjarvis owns the auth surface

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# CODEOWNERS — GitHub auto-requests review from the listed owners when a PR
+# touches a matching path. Owners must have write access to the repo, or the
+# entry is silently ignored. The LAST matching pattern wins, so if a broad
+# catch-all is ever added, keep these auth rules below it.
+
+# Auth / identity control plane — owner @fjarvis
+/server/core/src/auth*                       @fjarvis
+/server/core/src/rbac_*                      @fjarvis
+/server/core/src/oidc_*                      @fjarvis
+/server/core/src/api_token_*                 @fjarvis
+/server/core/src/device_token_*              @fjarvis
+/server/core/src/enrollment_*                @fjarvis
+/server/core/src/secure_random.*             @fjarvis
+/server/core/include/yuzu/server/auth.hpp    @fjarvis
+/docs/auth-architecture.md                   @fjarvis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Governance — `CODEOWNERS` added.** `@fjarvis` is the code owner for the
+  auth/identity surface (`auth*`, `rbac_*`, `oidc_*`, `api_token_*`,
+  `device_token_*`, `enrollment_*`, `secure_random.*`, `auth.hpp`,
+  `docs/auth-architecture.md`); GitHub auto-requests his review on matching
+  PRs. Advisory for now — `require_code_owner_review` is off on the dev/main
+  rulesets.
+
 - **#1056 — `DeviceTokenValidateError::internal_error` distinguishes a
   store-internal fault from a clean miss.** A `sqlite3_prepare_v2`
   failure in `DeviceTokenStore::validate_token` was previously


### PR DESCRIPTION
## What
Adds `.github/CODEOWNERS` making **@fjarvis** the code owner for the auth / identity surface: `auth*`, `rbac_*`, `oidc_*`, `api_token_*`, `device_token_*`, `enrollment_*`, `secure_random.*`, `server/core/include/yuzu/server/auth.hpp`, and `docs/auth-architecture.md`.

## Why
@fjarvis is the active contributor on the auth/session surface and now holds write access, so the entries are honored — he'll be auto-requested on matching PRs.

## Note
The `Protect Dev` / `Protect Main` rulesets currently set `require_code_owner_review = false`, so this is **auto-request only** until that flag is flipped. Enable it to make auth-PR code-owner approval mandatory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)