### PR TITLE
ci(cla): activate CLA Assistant (flip `if: false`)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -9,22 +9,21 @@ name: CLA Assistant
 # pull request and require every commit author to sign the CLA before merge.
 #
 # ─────────────────────────────────────────────────────────────────────────
-#  DISABLED UNTIL CLA_REPO_ACCESS_TOKEN IS PROVISIONED.
+#  ACTIVE on Tr3kkR/Yuzu (activated 2026-05-21).
 # ─────────────────────────────────────────────────────────────────────────
-# To activate:
-#   1. Create a GitHub Personal Access Token (classic) with `repo` scope
-#      on an account that can write to this repository.
-#   2. Add it as repository secret `CLA_REPO_ACCESS_TOKEN`.
-#   3. Change the workflow-level `if:` guard below from `false` to
-#      `github.repository == 'Tr3kkR/Yuzu'`.
-#   4. Optionally create a separate private repo to store signatures
-#      (recommended) and update `path-to-document` / `remote-repository-name`.
+# Provisioning (in place):
+#   - Secret `CLA_REPO_ACCESS_TOKEN`: classic PAT (`repo` scope) able to
+#     write the signatures store.
+#   - Signatures store: private repo `Tr3kkR/Yuzu-cla-signatures`, branch
+#     `main`, file `signatures/cla.json` (auto-created on first signature).
+#   - Guard: runs only on the canonical repo; forks of Yuzu are skipped.
 #
-# Until those steps are completed, this workflow is a no-op. Merging PRs
-# without a signed CLA in the pre-activation window locks those
-# contributions into AGPL only (the Project Steward cannot relicense them
-# under the commercial license). See CONTRIBUTING.md for how contributors
-# should sign manually in the meantime.
+# To make the CLA *block* merges (not just comment), add this job's status
+# context to the `Protect Dev` / `Protect Main` rulesets' required checks.
+#
+# NOTE: any external contribution merged BEFORE activation was not covered by
+# a signed CLA, so it is AGPL-only and cannot be relicensed commercially.
+# See CONTRIBUTING.md.
 
 on:
   issue_comment:
@@ -43,8 +42,8 @@ jobs:
       contents: read
       pull-requests: write
       statuses: write
-    # Deliberately disabled; flip to the live condition when ready.
-    if: false
+    # Live on the canonical repo only; forks of Yuzu skip the CLA gate.
+    if: github.repository == 'Tr3kkR/Yuzu'
     steps:
       - name: CLA Assistant
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CI / governance — CLA Assistant activated on `Tr3kkR/Yuzu`.** The
+  `.github/workflows/cla.yml` gate is live: external contributors must sign
+  the Contributor License Agreement before merge (signatures stored in the
+  private `Tr3kkR/Yuzu-cla-signatures` repo; forks of Yuzu skip the gate).
+  Protects the AGPL + commercial dual-license chain — unsigned external
+  contributions can only ship under AGPL.
+
 - **Governance — `CODEOWNERS` added.** `@fjarvis` is the code owner for the
   auth/identity surface (`auth*`, `rbac_*`, `oidc_*`, `api_token_*`,
   `device_token_*`, `enrollment_*`, `secure_random.*`, `auth.hpp`,


### PR DESCRIPTION
## What
Activates the CLA Assistant workflow: flips the `cla-check` job guard from `if: false` to `if: github.repository == 'Tr3kkR/Yuzu'` (forks skip the gate), and refreshes the now-stale "DISABLED" header comment. Adds a CHANGELOG entry.

## Why
Both prerequisites are now in place:
- Repo secret `CLA_REPO_ACCESS_TOKEN` (classic PAT, `repo` scope)
- Private signatures store `Tr3kkR/Yuzu-cla-signatures` (branch `main`, `signatures/cla.json`)

Yuzu dual-licenses (AGPL + commercial); external contributions need a signed CLA to be relicensable. Until now the gate was a no-op (`if: false`), so external PRs (e.g. #1123 from a first-time contributor) could merge AGPL-only.

## After merge
- The bot goes live on the next `pull_request_target` / `issue_comment` event; external authors get the sign prompt.
- **Follow-up:** grab the exact status-context name from the first live run and add it to the `Protect Dev` / `Protect Main` rulesets' required checks so the CLA actually **blocks** merge (it currently only comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)