### PR TITLE
ci(docs-lint): always run so the required CHANGELOG-order check reports

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,25 +1,20 @@
 name: Docs Lint
 
-# Lightweight hygiene checks for documentation and the changelog. Runs on
-# markdown-only changes (which ci.yml deliberately skips via paths-ignore).
-# Keep this workflow fast and dependency-light — no build, no vcpkg, no caches.
+# Lightweight hygiene checks for the changelog (and docs). The `changelog-order`
+# job publishes the **required** "CHANGELOG order" status check, so this
+# workflow must run on EVERY pull request to main/dev. A `paths:` filter here
+# was the bug: a PR that didn't touch CHANGELOG.md never reported the required
+# check and got wedged forever on a status that never arrived (the
+# path-filtered-required-check trap). The job is fast and dependency-light — no
+# build, no vcpkg, no caches — so running it unconditionally is cheap.
 on:
-  # push fires only on mainline branches; feature/fix branches with an open
-  # PR run docs lint exactly once via pull_request. Mirrors ci.yml.
+  # No paths filter: the required CHANGELOG-order status must report on every
+  # PR. push fires only on mainline branches so a feature/fix branch with an
+  # open PR runs docs lint exactly once via pull_request.
   push:
     branches: [main, dev]
-    paths:
-      - 'CHANGELOG.md'
-      - 'docs/**'
-      - 'tests/test_changelog_order.py'
-      - '.github/workflows/docs-lint.yml'
   pull_request:
     branches: [main, dev]
-    paths:
-      - 'CHANGELOG.md'
-      - 'docs/**'
-      - 'tests/test_changelog_order.py'
-      - '.github/workflows/docs-lint.yml'
   workflow_dispatch:
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CI — `CHANGELOG order` check no longer wedges meta PRs.** Removed the
+  `paths:` filter from `docs-lint.yml` so the **required** "CHANGELOG order"
+  status reports on every PR to `main`/`dev`. Previously the filter meant a PR
+  that didn't touch `CHANGELOG.md` (CODEOWNERS, CI, pure-code, etc.) never
+  produced the required check and was blocked forever on a status that never
+  arrived. The job is a ~5s file-order lint, so running it unconditionally is
+  cheap.
+
 - **CI / governance — CLA Assistant activated on `Tr3kkR/Yuzu`.** The
   `.github/workflows/cla.yml` gate is live: external contributors must sign
   the Contributor License Agreement before merge (signatures stored in the


### PR DESCRIPTION
## What
Removes the `paths:` filter from `docs-lint.yml` so the `changelog-order` job — which publishes the **required** "CHANGELOG order" status — runs on every PR to `main`/`dev`.

## Why
Because "CHANGELOG order" is a required check in the `Protect Dev`/`Protect Main` rulesets, any PR that didn't touch `CHANGELOG.md`/`docs/**` (CODEOWNERS #1124, CI #1125, pure-code PRs) never produced the check and was wedged forever on a status that never arrived — the classic path-filtered-required-check trap. The "every PR touches CHANGELOG.md" convention had been masking it.

The job is a ~5s, dependency-light file-order lint (no build/vcpkg/caches), so running it unconditionally is cheap and removes the trap for every future meta PR.

## Follow-up (not in this PR)
Mirror trap in the other direction: `ci.yml` uses `paths-ignore: docs/**, *.md, …`, so a **docs-only** PR skips the build matrix and would be blocked on the required `Linux/Windows/macOS/Proto` checks. That's a CI-cost tradeoff — flagging for a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)