### PR TITLE
chore(deps): pin erlang/ubuntu base-image major lines (decline #1139, #1140)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,23 @@ updates:
       - "docker"
     cooldown:
       default-days: 7
+    # Base-image major lines are pinned and bumped deliberately, not by
+    # auto-PR — a base bump is a coordinated migration, not a one-line diff.
+    #   erlang: tag is the bare major (`28`), so 28.x point releases arrive
+    #     as digest updates and still flow; we only block the major. OTP 29
+    #     is a lockstep change across release.yml (otp-version),
+    #     ensure-erlang.sh, every gateway Dockerfile + the chiselled image,
+    #     and a clean dialyzer/eunit pass (declined #1139).
+    #   ubuntu: tag is major.minor (`24.04`), so 24.10 (interim) would arrive
+    #     as a *minor* bump — block major AND minor to stay on the 24.04 LTS.
+    #     Digest refreshes of 24.04 still flow and keep it patched. Next hop
+    #     is the 26.04 LTS (already used by the chiselled images), done by
+    #     hand (declined #1140).
+    ignore:
+      - dependency-name: "erlang"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "ubuntu"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   # Python tooling consumed by CI (meson, and whatever else lands in
   # requirements-ci.txt). vcpkg and rebar3 are covered by dedicated


### PR DESCRIPTION
Adds dependabot `ignore` rules so the **OTP 29** (#1139) and **Ubuntu 25.10** (#1140) base-image bumps stop being re-proposed. Both are deliberate, coordinated migrations — not one-line auto-PRs.

## Rules
```yaml
ignore:
  - dependency-name: "erlang"
    update-types: ["version-update:semver-major"]                                   # stay on 28.x
  - dependency-name: "ubuntu"
    update-types: ["version-update:semver-major", "version-update:semver-minor"]    # stay on 24.04 LTS
```

## Why these specific scopes
- **erlang** — tag is the bare major (`28`), so 28.x point releases arrive as **digest** updates and still flow; only the major (29) is blocked. Moving to OTP 29 is a lockstep change across `release.yml` (`otp-version`), `ensure-erlang.sh`, every gateway Dockerfile + the chiselled image, with a clean `rebar3 dialyzer`/eunit pass — per the CLAUDE.md "bump them together" rule.
- **ubuntu** — tag is major.minor (`24.04`), so `24.10` (interim) would arrive as a *minor* bump. Blocking **major + minor** keeps CI/sanitizer images on the **24.04 LTS**; digest refreshes of `24.04` still flow and keep it patched. Next hop is the **26.04 LTS** (already used by the chiselled images), done by hand.

## Note on timing
Dependabot reads config from the **default branch (`main`)**, so this rule only takes effect after the dev→main reconcile. #1139 and #1140 are being closed now with `@dependabot ignore this major version` so they don't reopen in the interim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)