### PR TITLE
docs(changelog): roll [Unreleased] → [0.12.0] GA (v0.12.0 release prep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-05-25
+
 ### Breaking Changes
 
 - **Gateway requires `YUZU_GW_COOKIE` before upgrade (#659).** The Erlang gateway
@@ -1943,7 +1945,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and pins the docs link on the `create_fragment` missing-kind branch
   for the same symmetry reason.
 
-## [0.12.0] - 2026-05-03
+## [0.12.0-rc0] - 2026-05-03
 
 ### Breaking
 


### PR DESCRIPTION
Release prep for **v0.12.0 GA**. Rolls the CHANGELOG so the GA release notes are complete.

- `## [Unreleased]` → `## [0.12.0] - 2026-05-25` (the GA section — all post-rc0 work, ~1.8k lines / 61 commits since rc0).
- Prior `## [0.12.0] - 2026-05-03` → `## [0.12.0-rc0]` (it was the rc0 snapshot; relabelled so the dates/versions stay honest and reverse-chronological).
- Fresh empty `## [Unreleased]` on top for 0.13.0 work.

Verified: `release.yml`'s extraction awk now emits the full GA changelog; `release-preflight` check #3/#4 still match `## [0.12.0]`; header order stays reverse-chronological (`CHANGELOG order` check). Content-only change.

Merging this keeps `dev`↔`main` reconciled for the GA promotion (no divergence trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)