### PR TITLE
fix(release): scope chisel-publish concurrency group per matrix image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1232,10 +1232,16 @@ jobs:
     # workflow-level concurrency is cancel-in-progress:false (a real
     # release must run to completion); this narrower group trades that
     # for runner-slot liveness on the demo-image path specifically — SRE
-    # flagged the starvation risk. Group is keyed on github.ref (not
-    # ref+sha) so a re-push of the same tag is treated as a supersede.
+    # flagged the starvation risk. Group is keyed on github.ref + the
+    # matrix image so a re-push of the same tag is treated as a
+    # supersede PER IMAGE — without `${{ matrix.image }}`, the three
+    # matrix legs (server/gateway/agent) share a single group and
+    # GitHub cancels two of them at scheduling time. Observed on
+    # v0.12.0 release run 26413256206 where server-chisel and
+    # agent-chisel were cancelled at 1s runtime, leaving gateway-chisel
+    # as the only published variant.
     concurrency:
-      group: chisel-publish-${{ github.ref }}
+      group: chisel-publish-${{ github.ref }}-${{ matrix.image }}
       cancel-in-progress: true
     # Generous timeout: the server/agent chisel images compile all of
     # vcpkg (gRPC/abseil/protobuf/openssl) from source, and the arm64 leg


### PR DESCRIPTION
## Problem

In `release.yml`, the `docker-publish-chisel` job has:

```yaml
concurrency:
  group: chisel-publish-${{ github.ref }}
  cancel-in-progress: true
```

The job uses a matrix over `image: [server, gateway, agent]`. Because the concurrency group doesn't include `${{ matrix.image }}`, all three matrix legs share a single group, and GitHub cancels two of them at scheduling time with `cancel-in-progress: true`.

## Observed

On v0.12.0 release run [26413256206](https://github.com/Tr3kkR/Yuzu/actions/runs/26413256206):

```
Publish server-chisel image:  cancelled  (1s runtime)
Publish gateway-chisel image: queued → success
Publish agent-chisel image:   cancelled  (1s runtime)
```

Only gateway-chisel published. `yuzu-server-chisel:0.12.0` and `yuzu-agent-chisel:0.12.0` need backfilling.

The non-chisel `docker-publish` job (server/gateway only, no concurrency block) was unaffected. The GA itself (`Create Release`, agent-bundle) completed cleanly — chisel publishes are out-of-band.

## Fix

Append `${{ matrix.image }}` to the concurrency group key:

```yaml
group: chisel-publish-${{ github.ref }}-${{ matrix.image }}
```

Each matrix leg now gets its own group. Re-pushing the same tag still supersedes per image (original design intent preserved).

## Backfill plan

After this merges + main FF, the missing `yuzu-server-chisel:0.12.0` and `yuzu-agent-chisel:0.12.0` will be backfilled via re-tagged release run (already-published artifacts on GH release are idempotent; image pushes are idempotent on same content hash).

## Test

`yamllint` clean. Comment block updated with root-cause notes for future readers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)