### PR TITLE
fix(release): make Create Release idempotent on re-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1885,22 +1885,35 @@ jobs:
             WIZARD_ASSET+=(artifacts/yuzu-compose-wizard-*.zip)
           fi
 
-          gh release create "${GITHUB_REF_NAME}" \
-            --title "Yuzu ${GITHUB_REF_NAME}" \
-            --notes-file release-notes.md \
-            ${PRERELEASE_FLAG} \
-            artifacts/yuzu-linux-x64.tar.gz \
-            artifacts/yuzu-gateway-linux-x64.tar.gz \
-            artifacts/yuzu-windows-x64.zip \
-            artifacts/YuzuAgentSetup-*.exe \
-            artifacts/YuzuServerSetup-*.exe \
-            artifacts/YuzuAgent-*.pkg \
-            artifacts/yuzu-macos-arm64.tar.gz \
-            artifacts/*.deb \
-            artifacts/*.rpm \
-            artifacts/*.cdx.json \
-            artifacts/*.spdx.json \
-            artifacts/*.intoto.jsonl \
-            artifacts/SHA256SUMS \
-            artifacts/SHA256SUMS.sigstore \
-            "${WIZARD_ASSET[@]}"
+          # Idempotent on re-tag: if the release already exists (e.g.
+          # operator deleted + recreated the tag to backfill a CI bug
+          # like the chisel-publish concurrency miss in run 26413256206),
+          # skip the create+upload so the dependent docker-publish-*
+          # jobs can still run cleanly without "release already exists"
+          # blowing up Create Release. Asset re-upload would require
+          # --clobber per-file and risks signature drift on already-
+          # published artifacts; the safer behavior is leave the
+          # published release untouched.
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            echo "::notice::Release ${GITHUB_REF_NAME} already exists; skipping create+upload (assets already published, signatures preserved)"
+          else
+            gh release create "${GITHUB_REF_NAME}" \
+              --title "Yuzu ${GITHUB_REF_NAME}" \
+              --notes-file release-notes.md \
+              ${PRERELEASE_FLAG} \
+              artifacts/yuzu-linux-x64.tar.gz \
+              artifacts/yuzu-gateway-linux-x64.tar.gz \
+              artifacts/yuzu-windows-x64.zip \
+              artifacts/YuzuAgentSetup-*.exe \
+              artifacts/YuzuServerSetup-*.exe \
+              artifacts/YuzuAgent-*.pkg \
+              artifacts/yuzu-macos-arm64.tar.gz \
+              artifacts/*.deb \
+              artifacts/*.rpm \
+              artifacts/*.cdx.json \
+              artifacts/*.spdx.json \
+              artifacts/*.intoto.jsonl \
+              artifacts/SHA256SUMS \
+              artifacts/SHA256SUMS.sigstore \
+              "${WIZARD_ASSET[@]}"
+          fi


### PR DESCRIPTION
## Problem

`gh release create` in the release job hard-fails with "release already exists" if a tag is re-pushed. This cascades to the dependent `docker-publish-agent-bundle` job (which `needs: [release]`) being skipped.

Operator cannot recover from a CI bug on an already-published release without bumping the version.

## Concrete need

v0.12.0 release run [26413256206](https://github.com/Tr3kkR/Yuzu/actions/runs/26413256206) shipped the GA cleanly (41 assets, signed), but two of three chisel publishes were cancelled by a separate concurrency-group bug (fixed in #1178). To backfill the missing chisel images, we need to re-tag v0.12.0 — which requires the release job to tolerate the existing release.

## Fix

Wrap `gh release create` in an existence check:

```bash
if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
  echo "::notice::Release ${GITHUB_REF_NAME} already exists; skipping create+upload (assets already published, signatures preserved)"
else
  gh release create "${GITHUB_REF_NAME}" \
    --title "Yuzu ${GITHUB_REF_NAME}" \
    ...
fi
```

## Why "skip" vs "--clobber"

`gh release create --clobber` would re-upload all assets, regenerating `SHA256SUMS.sigstore` and invalidating the existing cosign attestations on `.deb`/`.rpm`/SBOM files. The safer behavior is to leave the published release untouched and let downstream jobs (chisel publishes, agent-bundle) re-fire idempotently.

## Verification

- First-release behavior (no existing release) is unchanged — the `else` branch runs the original command verbatim.
- Re-tag behavior: skip emits an annotated notice, exit 0, dependent jobs proceed.
- No change to upstream `build-*` or `docker-publish-*` jobs.

## After this merges

Operator workflow for backfill:
1. Merge this + main FF
2. Delete v0.12.0 tag, recreate at new main → CI re-runs
3. Create Release skips cleanly → docker-publish-chisel succeeds with PR #1178's concurrency fix → 5/6 GHCR images backfilled in one cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)