### PR TITLE
fix(ci): use GHCR_PAT instead of GITHUB_TOKEN for GHCR docker logins

### DIFF
--- a/.github/workflows/ci-runner-image.yml
+++ b/.github/workflows/ci-runner-image.yml
@@ -37,8 +37,12 @@ jobs:
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # GHCR_PAT (write:packages-only PAT owned by Tr3kkR) instead
+          # of GITHUB_TOKEN so we can push to GHCR packages whose
+          # Actions-access policy isn't pinned to this repo. Falls
+          # back to GITHUB_TOKEN for fork PRs without secret access.
+          username: Tr3kkR
+          password: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -75,8 +79,12 @@ jobs:
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # GHCR_PAT (write:packages-only PAT owned by Tr3kkR) instead
+          # of GITHUB_TOKEN so we can push to GHCR packages whose
+          # Actions-access policy isn't pinned to this repo. Falls
+          # back to GITHUB_TOKEN for fork PRs without secret access.
+          username: Tr3kkR
+          password: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -124,8 +124,12 @@ jobs:
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # GHCR_PAT (write:packages-only PAT owned by Tr3kkR) instead
+          # of GITHUB_TOKEN so we can push to GHCR packages whose
+          # Actions-access policy isn't pinned to this repo. Falls
+          # back to GITHUB_TOKEN for fork PRs without secret access.
+          username: Tr3kkR
+          password: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Pull release images
         env:
@@ -598,8 +602,12 @@ jobs:
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # GHCR_PAT (write:packages-only PAT owned by Tr3kkR) instead
+          # of GITHUB_TOKEN so we can push to GHCR packages whose
+          # Actions-access policy isn't pinned to this repo. Falls
+          # back to GITHUB_TOKEN for fork PRs without secret access.
+          username: Tr3kkR
+          password: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}
 
       # Scope: Trivy is used here ONLY for vulnerability scanning of
       # published container images. SBOM generation is NOT done here —
@@ -662,8 +670,12 @@ jobs:
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # GHCR_PAT (write:packages-only PAT owned by Tr3kkR) instead
+          # of GITHUB_TOKEN so we can push to GHCR packages whose
+          # Actions-access policy isn't pinned to this repo. Falls
+          # back to GITHUB_TOKEN for fork PRs without secret access.
+          username: Tr3kkR
+          password: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Start stack
         env:
@@ -817,8 +829,12 @@ jobs:
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # GHCR_PAT (write:packages-only PAT owned by Tr3kkR) instead
+          # of GITHUB_TOKEN so we can push to GHCR packages whose
+          # Actions-access policy isn't pinned to this repo. Falls
+          # back to GITHUB_TOKEN for fork PRs without secret access.
+          username: Tr3kkR
+          password: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Start previous release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1074,8 +1074,15 @@ jobs:
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # GHCR_PAT (write:packages-only PAT owned by Tr3kkR) instead
+          # of GITHUB_TOKEN so we can push to GHCR packages whose
+          # Actions-access policy isn't pinned to this repo (e.g.
+          # yuzu-agent-bundle-chisel, originally created via local
+          # PAT push). Falls back to GITHUB_TOKEN for fork PRs that
+          # don't have access to the secret. Username pinned to the
+          # PAT owner ('Tr3kkR') since github.actor varies per actor.
+          username: Tr3kkR
+          password: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Compute image tags and labels
         id: meta
@@ -1303,8 +1310,15 @@ jobs:
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # GHCR_PAT (write:packages-only PAT owned by Tr3kkR) instead
+          # of GITHUB_TOKEN so we can push to GHCR packages whose
+          # Actions-access policy isn't pinned to this repo (e.g.
+          # yuzu-agent-bundle-chisel, originally created via local
+          # PAT push). Falls back to GITHUB_TOKEN for fork PRs that
+          # don't have access to the secret. Username pinned to the
+          # PAT owner ('Tr3kkR') since github.actor varies per actor.
+          username: Tr3kkR
+          password: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Compute image tags and labels
         id: meta
@@ -1486,8 +1500,15 @@ jobs:
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # GHCR_PAT (write:packages-only PAT owned by Tr3kkR) instead
+          # of GITHUB_TOKEN so we can push to GHCR packages whose
+          # Actions-access policy isn't pinned to this repo (e.g.
+          # yuzu-agent-bundle-chisel, originally created via local
+          # PAT push). Falls back to GITHUB_TOKEN for fork PRs that
+          # don't have access to the secret. Username pinned to the
+          # PAT owner ('Tr3kkR') since github.actor varies per actor.
+          username: Tr3kkR
+          password: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1


### PR DESCRIPTION
## Problem

v0.12.0 release run [26413256206](https://github.com/Tr3kkR/Yuzu/actions/runs/26413256206) failed on `Publish agent-bundle image` with:

```
ERROR: failed to push ghcr.io/tr3kkr/yuzu-agent-bundle-chisel:0.12.0:
HEAD request to .../blobs/sha256:... 403 Forbidden
```

`GITHUB_TOKEN` only has write access to GHCR packages **linked to the originating repository**. The `yuzu-agent-bundle-chisel` package was first created via a local PAT push (during the feat/chiselled-demo-env spike), so its Actions-access policy isn't auto-linked to Tr3kkR/Yuzu — CI's `GITHUB_TOKEN` has no role on it.

This will recur for **any GHCR package whose first push didn't come from CI** — every spike, backfill, or new image namespace bootstrapped locally.

## Fix

Replace `GITHUB_TOKEN` with a personal access token (`GHCR_PAT`, scope `write:packages` only) for the 8 GHCR `docker/login-action` steps:

- `release.yml` × 3 (server/gateway/agent image publishes)
- `pre-release.yml` × 4 (RC publishes)
- `ci-runner-image.yml` × 2 (self-hosted runner image)

Pattern:
```yaml
username: Tr3kkR  # PAT owner; github.actor varies per actor
password: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}
```

## Scope rationale

`GHCR_PAT` is `write:packages` only — **minimal blast radius**. All other GITHUB_TOKEN usages (gh CLI in non-docker steps, OIDC attestations) are unchanged because the PAT doesn't carry those scopes.

## Repo secret

`GHCR_PAT` added 2026-05-26 11:18:33Z (verified scope: `write:packages`).

## After merge

After main FF, the v0.12.0 backfill can proceed via re-tag (PR #1178 + #1179 already merged) — this time the agent-bundle job will also succeed with the PAT-based login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)