### PR TITLE
fix(agent): validate plugin names at load time (#822)

### DIFF
--- a/agents/core/include/yuzu/agent/plugin_loader.hpp
+++ b/agents/core/include/yuzu/agent/plugin_loader.hpp
@@ -3,6 +3,7 @@
 #include <yuzu/plugin.h>
 
 #include <array>
+#include <cstddef>
 #include <expected>
 #include <filesystem>
 #include <memory>
@@ -35,6 +36,20 @@ inline constexpr std::array<std::string_view, 3> kReservedPluginNames{
 /// (e.g. agent metrics) can match on this prefix to count rejections by
 /// category without re-parsing free-form text.
 inline constexpr std::string_view kReservedNameReason = "reserved plugin name";
+
+/// Maximum length of a plugin's self-declared name. Names are operator-visible
+/// identifiers used in logs, Prometheus label values, and the command-dispatch
+/// match; bounding them keeps log lines and label cardinality sane and stops a
+/// plugin from declaring a pathological multi-kilobyte name.
+inline constexpr std::size_t kMaxPluginNameLen = 64;
+
+/// Stable, fixed reason string recorded verbatim in LoadError::reason when a
+/// plugin is rejected because its declared name is empty, over-length, or
+/// contains a byte outside the identifier set [A-Za-z0-9_]. Unlike
+/// kReservedNameReason this carries no variable suffix — the offending name is
+/// deliberately NOT echoed, because a crafted name may carry newline or control
+/// bytes that would forge log lines / corrupt the error channel. See #822.
+inline constexpr std::string_view kInvalidNameReason = "invalid plugin name";
 
 /// Stable reason prefixes for code-signing rejections. The metric label
 /// derives from the prefix so operators can alert distinctly on
@@ -84,6 +99,45 @@ verify_plugin_signature(const std::filesystem::path& plugin_path,
     }
     return false;
 }
+
+/// True if `name` is a well-formed plugin identifier: non-empty, at most
+/// kMaxPluginNameLen bytes, and composed solely of ASCII alphanumerics and the
+/// underscore. The character test is written out by hand rather than using
+/// std::isalnum — that function is locale-sensitive (so the verdict could
+/// differ between hosts) and is undefined behaviour for negative `char` values
+/// (high-bit bytes). This is constexpr and locale-independent, so the result is
+/// identical on every platform.
+///
+/// The loader enforces this on a plugin's self-declared name BEFORE any
+/// reserved-name or dispatch comparison so a crafted name (NUL-truncation,
+/// embedded control bytes, path/pipe/newline characters) can never diverge
+/// between the std::string_view security check here and a downstream C-string
+/// consumer of descriptor->name. Reserved names (e.g. "__guard__") are
+/// themselves valid identifiers — they pass this check and are then rejected
+/// by is_reserved_plugin_name. See #822.
+[[nodiscard]] constexpr bool is_valid_plugin_name(std::string_view name) noexcept {
+    if (name.empty() || name.size() > kMaxPluginNameLen) {
+        return false;
+    }
+    for (const char c : name) {
+        const bool ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                        (c >= '0' && c <= '9') || c == '_';
+        if (!ok) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Compile-time pins for the is_valid_plugin_name contract (#822). Reserved
+// names are themselves valid identifiers (they reach the reserved-name check
+// and are rejected there, not here); empty, charset-violating, and embedded-NUL
+// names are rejected.
+static_assert(is_valid_plugin_name("__guard__"));
+static_assert(is_valid_plugin_name("example_42"));
+static_assert(!is_valid_plugin_name(""));
+static_assert(!is_valid_plugin_name("bad name"));
+static_assert(!is_valid_plugin_name(std::string_view{"nul\0byte", 8}));
 
 /// SHA-256 hash a file on disk. Returns lowercase hex or empty on failure.
 [[nodiscard]] std::string sha256_file(const std::filesystem::path& path);

--- a/agents/core/src/agent.cpp
+++ b/agents/core/src/agent.cpp
@@ -644,6 +644,11 @@ public:
             std::string_view reason = "load_failed";
             if (err.reason.starts_with(yuzu::agent::kReservedNameReason)) {
                 reason = "reserved_name";
+            } else if (err.reason.starts_with(yuzu::agent::kInvalidNameReason)) {
+                // #822: a plugin declared a malformed name (empty, over-length,
+                // or outside [A-Za-z0-9_]) — distinct from a reserved-name
+                // attempt so operators can alert on crafted-name loads.
+                reason = "invalid_name";
             } else if (err.reason.starts_with(yuzu::agent::kSignatureMissingReason)) {
                 reason = "signature_missing";
             } else if (err.reason.starts_with(yuzu::agent::kSignatureUntrustedReason)) {

--- a/agents/core/src/plugin_loader.cpp
+++ b/agents/core/src/plugin_loader.cpp
@@ -778,7 +778,27 @@ PluginLoader::scan(const std::filesystem::path& plugin_dir,
         auto loaded = PluginHandle::load(entry.path());
 #endif
         if (loaded) {
-            const std::string_view plugin_name{loaded->descriptor()->name};
+            // The descriptor name is plugin-self-declared and crosses the C ABI
+            // as a bare `const char*`. Validate it before constructing a
+            // std::string_view from it — the string_view(const char*) ctor calls
+            // strlen, which is UB on a null pointer that a malformed C plugin
+            // could set — and before any reserved-name / dispatch comparison, so
+            // a crafted name cannot diverge between this security check and a
+            // downstream C-string consumer of descriptor->name (#822).
+            const char* raw_name = loaded->descriptor()->name;
+            if (raw_name == nullptr || !is_valid_plugin_name(raw_name)) {
+                // Do NOT echo raw_name: it may carry NUL/control/newline bytes
+                // that would forge log lines or corrupt the error channel. The
+                // on-disk entry path is operator-controlled and safe to log.
+                spdlog::error("Plugin {} declares an invalid name — rejecting (a "
+                              "plugin name must be a non-empty [A-Za-z0-9_] "
+                              "identifier of at most {} bytes)",
+                              entry.path().string(), kMaxPluginNameLen);
+                result.errors.push_back(
+                    LoadError{entry.path().string(), std::string{kInvalidNameReason}});
+                continue;
+            }
+            const std::string_view plugin_name{raw_name};
             if (is_reserved_plugin_name(plugin_name)) {
                 // #453: prevent a compromised plugin author from shadowing
                 // the Guardian (__guard__) or other reserved dispatch names.

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -53,6 +53,17 @@ reserved_name_fixture_plugin = shared_library(
   install: false,
 )
 
+# ── Test fixture: plugin with a malformed name (#822) ────────────────────────
+# Declares a name outside the [A-Za-z0-9_] identifier set; test_plugin_loader.cpp
+# scans against it to verify the invalid-name rejection path.
+invalid_name_fixture_plugin = shared_library(
+  'invalid_name_fixture_plugin',
+  files('unit/fixtures/invalid_name_plugin.cpp'),
+  name_prefix: '',
+  dependencies: [yuzu_sdk_dep, yuzu_agent_core_dep],
+  install: false,
+)
+
 # ── Agent unit tests ──────────────────────────────────────────────────────────
 #
 # Proto-dep choice is platform-conditional (#572 + Windows MSVC follow-up):
@@ -107,16 +118,16 @@ agent_test_exe = executable(
     include_directories('../agents/plugins/vuln_scan/src'),  # cve_rules.hpp
   ],
   dependencies: [yuzu_agent_core_dep, yuzu_sdk_dep, agent_test_proto_dep, nlohmann_dep, catch2_dep, agent_test_openssl_dep],
-  # Ensure the fixture plugin is built before the test runs so the lookup
-  # inside test_plugin_loader.cpp finds it under MESON_BUILD_ROOT/tests/.
-  link_depends: reserved_name_fixture_plugin,
+  # Ensure the fixture plugins are built before the test runs so the lookups
+  # inside test_plugin_loader.cpp find them under MESON_BUILD_ROOT/tests/.
+  link_depends: [reserved_name_fixture_plugin, invalid_name_fixture_plugin],
 )
 test(
   'agent unit tests',
   agent_test_exe,
   suite: 'agent',
   timeout: 240,
-  depends: reserved_name_fixture_plugin,
+  depends: [reserved_name_fixture_plugin, invalid_name_fixture_plugin],
 )
 
 # ── TAR plugin unit tests ────────────────────────────────────────────────────

--- a/tests/unit/fixtures/invalid_name_plugin.cpp
+++ b/tests/unit/fixtures/invalid_name_plugin.cpp
@@ -1,0 +1,28 @@
+// Fixture plugin for #822 — deliberately declares a malformed plugin name
+// (contains a space, which is outside the [A-Za-z0-9_] identifier set) so
+// PluginLoader::scan can be exercised against the invalid-name rejection path.
+// Not shipped; linked only when -Dbuild_tests=true.
+
+#include <yuzu/plugin.hpp>
+
+#include <string_view>
+
+class InvalidNameFixturePlugin final : public yuzu::Plugin {
+public:
+    std::string_view name() const noexcept override { return "bad name"; }
+    std::string_view version() const noexcept override { return "0.0.0-test"; }
+    std::string_view description() const noexcept override {
+        return "Fixture — must be rejected by plugin loader (#822)";
+    }
+
+    const char* const* actions() const noexcept override {
+        static const char* acts[] = {nullptr};
+        return acts;
+    }
+
+    yuzu::Result<void> init(yuzu::PluginContext&) override { return {}; }
+    void shutdown(yuzu::PluginContext&) noexcept override {}
+    int execute(yuzu::CommandContext&, std::string_view, yuzu::Params) override { return 0; }
+};
+
+YUZU_PLUGIN_EXPORT(InvalidNameFixturePlugin)

--- a/tests/unit/test_plugin_loader.cpp
+++ b/tests/unit/test_plugin_loader.cpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <random>
 #include <string>
+#include <string_view>
 #include <system_error>
 
 namespace fs = std::filesystem;
@@ -37,12 +38,13 @@ constexpr const char* kPluginExt = ".dylib";
 constexpr const char* kPluginExt = ".so";
 #endif
 
-// Locate the reserved-name fixture plugin built by tests/meson.build
-// (`reserved_name_fixture_plugin`). Returns empty path if not found —
+// Locate a fixture plugin shared library (`<base_name><ext>`) built by
+// tests/meson.build — e.g. "reserved_name_fixture_plugin" (#453) or
+// "invalid_name_fixture_plugin" (#822). Returns empty path if not found —
 // tests that require the fixture should SKIP rather than FAIL to keep
 // cross-compile / restricted-CI scenarios quiet.
-fs::path find_reserved_fixture_plugin() {
-    const std::string lib_name = std::string{"reserved_name_fixture_plugin"} + kPluginExt;
+fs::path find_fixture_plugin(std::string_view base_name) {
+    const std::string lib_name = std::string{base_name} + kPluginExt;
 
     std::vector<fs::path> candidates;
     if (auto* build_root = std::getenv("MESON_BUILD_ROOT")) {
@@ -305,6 +307,58 @@ TEST_CASE("kReservedPluginNames covers guardian, system, update",
     REQUIRE(yuzu::agent::kReservedPluginNames[2] == "__update__");
 }
 
+// ── #822 plugin-name validation ──────────────────────────────────────────────
+
+TEST_CASE("is_valid_plugin_name accepts well-formed identifiers",
+          "[plugin_loader][name_validation]") {
+    using yuzu::agent::is_valid_plugin_name;
+
+    REQUIRE(is_valid_plugin_name("example"));
+    REQUIRE(is_valid_plugin_name("inventory_scan"));
+    REQUIRE(is_valid_plugin_name("plugin42"));
+    REQUIRE(is_valid_plugin_name("_leading_underscore"));
+    REQUIRE(is_valid_plugin_name("CamelCase"));
+    REQUIRE(is_valid_plugin_name("ALLCAPS"));
+
+    // Reserved names are themselves valid identifiers — the charset check
+    // passes them through; is_reserved_plugin_name is what rejects them.
+    REQUIRE(is_valid_plugin_name("__guard__"));
+    REQUIRE(is_valid_plugin_name("__system__"));
+    REQUIRE(is_valid_plugin_name("__update__"));
+
+    // Exactly at the length bound is allowed.
+    REQUIRE(is_valid_plugin_name(std::string(yuzu::agent::kMaxPluginNameLen, 'a')));
+}
+
+TEST_CASE("is_valid_plugin_name rejects malformed names",
+          "[plugin_loader][name_validation]") {
+    using yuzu::agent::is_valid_plugin_name;
+
+    // Empty / over-length.
+    REQUIRE_FALSE(is_valid_plugin_name(""));
+    REQUIRE_FALSE(is_valid_plugin_name(std::string(yuzu::agent::kMaxPluginNameLen + 1, 'a')));
+
+    // Characters outside [A-Za-z0-9_].
+    REQUIRE_FALSE(is_valid_plugin_name("has space"));
+    REQUIRE_FALSE(is_valid_plugin_name("has-hyphen"));
+    REQUIRE_FALSE(is_valid_plugin_name("has.dot"));
+    REQUIRE_FALSE(is_valid_plugin_name("path/separator"));
+    REQUIRE_FALSE(is_valid_plugin_name("pipe|delimited")); // server splits output on '|'
+    REQUIRE_FALSE(is_valid_plugin_name("bang!"));
+
+    // Control / embedded bytes that would diverge a std::string_view check
+    // from a downstream C-string consumer, or forge a log line (#822). The NUL
+    // case is sized explicitly so the view spans past the embedded NUL.
+    REQUIRE_FALSE(is_valid_plugin_name(std::string_view{"nul\0byte", 8}));
+    REQUIRE_FALSE(is_valid_plugin_name("line\nfeed"));
+    REQUIRE_FALSE(is_valid_plugin_name("tab\tstop"));
+
+    // Non-ASCII high bytes (negative char on signed-char platforms — the
+    // hand-rolled range test must reject these without invoking isalnum UB).
+    REQUIRE_FALSE(is_valid_plugin_name("emoji\xF0\x9F\x98\x80"));
+    REQUIRE_FALSE(is_valid_plugin_name(std::string_view{"\xFF\xFE", 2}));
+}
+
 // ── Code-signing tests (#80) ─────────────────────────────────────────────────
 
 TEST_CASE("verify_plugin_signature accepts a valid CMS signature", "[plugin_loader][signing]") {
@@ -426,7 +480,7 @@ TEST_CASE("PluginLoader::scan with require_signature on rejects unsigned plugin 
 
 TEST_CASE("PluginLoader rejects a plugin declaring a reserved name",
           "[plugin_loader][reserved_name]") {
-    auto fixture = find_reserved_fixture_plugin();
+    auto fixture = find_fixture_plugin("reserved_name_fixture_plugin");
     if (fixture.empty()) {
         WARN("reserved_name_fixture_plugin not found — skipping behavioral scan test");
         SUCCEED();
@@ -462,6 +516,40 @@ TEST_CASE("PluginLoader rejects a plugin declaring a reserved name",
     REQUIRE(err.path == staged.string());
     REQUIRE(err.reason.starts_with(yuzu::agent::kReservedNameReason));
     REQUIRE(err.reason.find("__guard__") != std::string::npos);
+
+    fs::remove_all(tmp);
+}
+
+TEST_CASE("PluginLoader rejects a plugin declaring an invalid name",
+          "[plugin_loader][name_validation]") {
+    auto fixture = find_fixture_plugin("invalid_name_fixture_plugin");
+    if (fixture.empty()) {
+        WARN("invalid_name_fixture_plugin not found — skipping behavioral scan test");
+        SUCCEED();
+        return;
+    }
+
+    // Scan an isolated copy so the result reflects only this fixture (mirrors
+    // the reserved-name behavioral test above).
+    auto tmp = yuzu::test::unique_temp_path("yuzu_test_invalid_name_plugin_");
+    fs::create_directories(tmp);
+    auto staged = tmp / fixture.filename();
+    std::error_code ec;
+    fs::copy_file(fixture, staged, fs::copy_options::overwrite_existing, ec);
+    REQUIRE_FALSE(ec);
+
+    auto result = yuzu::agent::PluginLoader::scan(tmp);
+
+    // A malformed name must not yield a loaded plugin...
+    REQUIRE(result.loaded.empty());
+    // ...and must surface as a single error tagged with the stable reason so
+    // the agent metric can categorise it. The reason is exactly kInvalidNameReason
+    // with no suffix — the raw (attacker-controlled) name is deliberately not
+    // echoed (#822).
+    REQUIRE(result.errors.size() == 1);
+    const auto& err = result.errors.front();
+    REQUIRE(err.path == staged.string());
+    REQUIRE(err.reason == yuzu::agent::kInvalidNameReason);
 
     fs::remove_all(tmp);
 }


### PR DESCRIPTION
Closes #822.

## What

`PluginLoader::scan()` accepted a plugin's self-declared `descriptor->name` without checking it, then built a `std::string_view` from the bare `const char*` for the reserved-name (`__guard__`) guard. Two problems:

1. **`strlen(nullptr)` UB** — a malformed C plugin could set `name = nullptr`; the `std::string_view(const char*)` ctor calls `strlen`, which is UB on a null pointer. (The pre-existing `load()` null guards cover the descriptor pointer and ABI field, but not `name`.)
2. **Check/consumer divergence (the #822 finding)** — a crafted name (embedded NUL, control/newline bytes, path/pipe characters) could diverge between the `string_view` security check and a downstream C-string consumer, and was echoed into logs.

## How

- **`is_valid_plugin_name(std::string_view)`** (`plugin_loader.hpp`): non-empty, `<= kMaxPluginNameLen` (64), and solely `[A-Za-z0-9_]`. Hand-rolled range checks rather than `std::isalnum` — that function is locale-sensitive (non-deterministic across hosts) and UB for negative `char` values. `constexpr` + `static_assert`s pin the contract at compile time.
- **`scan()`** now guards `nullptr` and rejects invalid names with the fixed `kInvalidNameReason` **before** the reserved-name check. The offending name is **deliberately not echoed** into the log/error (log-injection guard). Reserved names are valid identifiers, so they pass this check and are still rejected by `is_reserved_plugin_name` — the #453 path is unchanged.
- **Metric**: the new rejection is categorised as `yuzu_agent_plugin_rejected_total{reason="invalid_name"}` (distinct from `reserved_name` / generic `load_failed`) so operators can alert on crafted-name load attempts.
- The agent-side `__guard__` dispatch intercept needs no change — it compares a NUL-clean protobuf `std::string`, not the descriptor `const char*`.

All shipped plugin names are clean lowercase identifiers (longest ~15 chars), so nothing we ship is rejected.

## Tests

- Exhaustive predicate unit tests: accepts identifiers incl. reserved names and the exact 64-byte bound; rejects empty / over-length / space / hyphen / dot / slash / pipe / bang / embedded-NUL (explicitly-sized view) / newline / tab / non-ASCII high bytes.
- `scan()` behavioral test driving a new `invalid_name_fixture_plugin` shared library end-to-end (asserts not-loaded + exactly one error == `kInvalidNameReason`, no echoed name).
- Full `--suite agent` green on macOS (Apple Clang). `[plugin_loader]` = 383 assertions / 17 cases.

## Governance

Reviewed by `cpp-expert`, `cpp-safety`, `security-guardian`:
- **cpp-safety: APPROVE** — confirmed the nullptr short-circuit removes the real `strlen(nullptr)` UB, signed-char handling correct, off-by-one bound correct, no dangling `string_view`, test fixtures well-formed.
- **cpp-expert: APPROVE** — no CRITICAL/HIGH/MEDIUM; hand-rolled charset is the right call; includes/portability/naming conform.
- **security-guardian: 1 blocking MEDIUM (Finding #1)** — the new rejection had no dedicated metric bucket. **Addressed in this PR** (the `invalid_name` branch above).

## Follow-ups filed from governance

- #1193 — (MEDIUM, pre-existing) `plugin_loader.cpp:537` (`PluginHandle::load`) logs raw `name`/`version`/`sdk_version` at info **before** `scan()` validates → log-injection. Same defect class as #822.
- #1194 — (LOW–MEDIUM) `version`/`description` still cross the gRPC wire (`PluginInfo`) and into the dashboard/config map unvalidated and unbounded; non-UTF-8 values can fail server serialization/parse. Natural completion of #822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)