### PR TITLE
fix(dashboard): keep agent/scope panel visible on narrow viewports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   intersected with the policy's own scope; new `yuzu_server_policy_verdicts_total`
   / `yuzu_server_policy_eval_errors_total` metrics.
 
+### Fixed
+
+- **Dashboard scope panel now visible at narrow viewports (≤1280px).** A global
+  responsive rule in `server/core/static/yuzu.css` was hiding the right-hand
+  agent/device selector panel (`.scope`) on any browser window 1280px wide or
+  narrower — a common laptop resolution — making connected agents invisible
+  until the operator widened the window past ~1400px. The rule was inherited
+  from an unrelated `.main-grid` layout. Now only the optional history rail is
+  hidden at that breakpoint; the scope panel reflows to a two-column layout and
+  stays fully accessible. The 1281–1440px band also received grid hardening
+  (`minmax(0,1fr)` middle track + `min-width:0`) so the instruction bar's
+  minimum content size can no longer push the panel off-screen.
+
 ### Tests
 
 - `tests/unit/server/test_policy_evaluator.cpp` — 10 cases for the new

--- a/server/core/src/dashboard_ui.cpp
+++ b/server/core/src/dashboard_ui.cpp
@@ -31,17 +31,25 @@ extern const char* const kDashboardIndexHtml =
     .dashboard-grid {
       display: grid; flex: 1; min-height: 0;
       grid-template-rows: auto 1fr auto;
-      grid-template-columns: 220px 1fr 260px;
+      grid-template-columns: 220px minmax(0, 1fr) 260px;
       grid-template-areas:
         "history instrbar  scope"
         "history results   scope"
         "history footer    scope";
     }
+    /* Grid items default to min-width:auto (= min-content). The instr-bar's
+       nowrap content has a ~920px min-content, which pins the whole grid at
+       ~1400px and pushes the right-hand scope (agent list) column off-screen
+       under body{overflow:hidden} on narrower windows. min-width:0 lets the
+       middle track actually compress so the scope column stays visible.
+       (Responsive breakpoints — hiding the history rail and reflowing to two
+       columns on narrow viewports — live in static/yuzu.css.) */
+    .dashboard-grid > * { min-width: 0; }
 
     /* ── Instruction Bar ─────────────────────────────────────── */
     .instr-bar {
       grid-area: instrbar;
-      display: flex; align-items: center; gap: 0.75rem;
+      display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;
       padding: 0.75rem 1rem;
       border-bottom: 1px solid var(--border);
       background: var(--surface);

--- a/server/core/static/yuzu.css
+++ b/server/core/static/yuzu.css
@@ -397,7 +397,19 @@ body { font-family: var(--font-sans); background: var(--bg); color: var(--fg); l
 }
 @media (max-width: 1280px) {
   .main-grid { grid-template-columns: 1fr !important; }
-  .history, .scope { display: none !important; }
+  /* Keep the agent/scope panel visible on narrow screens — it is how the
+     operator targets devices, so hiding it breaks the dashboard. Collapse
+     only the optional history rail and reflow the dashboard to two columns
+     so the scope panel is never clipped. (Was: hid .history AND .scope,
+     which made agents disappear on any window <=1280px.) */
+  .history { display: none !important; }
+  .dashboard-grid {
+    grid-template-columns: minmax(0, 1fr) 220px !important;
+    grid-template-areas:
+      "instrbar scope"
+      "results  scope"
+      "footer   scope" !important;
+  }
 }
 
 /* YAML split-panel editor */


### PR DESCRIPTION
## Summary

The dashboard's right-hand **Scope** panel (the agent/device selector) disappeared on any browser window ≤1280px wide, making connected agents invisible until the user widened the window past ~1400px.

## Root cause

A global responsive rule in `server/core/static/yuzu.css`:

```css
@media (max-width: 1280px) { .history, .scope { display: none !important; } }
```

was written for a different page's `.main-grid` layout, but its blunt `.scope` hide also caught the dashboard's agent panel, with no fallback. The `!important` also masked any attempt to fix it from the compiled-in dashboard CSS.

## Fix

- **`yuzu.css`**: at ≤1280px, hide only the optional `.history` rail and reflow `.dashboard-grid` to two columns so the agent/scope panel stays visible and is never clipped.
- **`dashboard_ui.cpp`** (inline CSS only): harden the base grid against `body{overflow:hidden}` clipping in the 1281–1440px band — `minmax(0,1fr)` middle track, `min-width:0` on grid children (defeats the instruction bar's ~920px min-content that otherwise pins the grid wider than the viewport), and `flex-wrap` on the instruction bar.

No C++ logic, REST, proto, store, auth, or ABI changes. CHANGELOG `### Fixed` entry added.

## Verification

- **Layout width sweep** (headless browser, 800/1100/1280/1281/1440/1600px): `.scope` is `display:flex` and fully on-screen at every width; 2 agents render.
- **C++ unit suites** (server + tar, `build-windows`): 2/2 OK, 0 fail.
- **Dashboard puppeteer test** (`tests/puppeteer/dashboard-help-test.mjs`): PASS (login + help=164 rows + command execution).

## Governance

Right-sized pipeline run (CSS-only diff): Gate 2 `security-guardian` + `docs-writer`, Gate 4 `consistency-auditor` + `happy-path` — **all clean, no BLOCKING findings**. C++ domain agents, chaos, and ops gates skipped per the runbook's small-scope allowance (no C++ logic / control / observability surface). consistency-auditor noted two **pre-existing** warts for a follow-up (dead `.main-grid` rule, vestigial `.scope`/`.history` width values) — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)