### PR TITLE
chore(codeowners): assign System Guardian files to @FortitudeEtc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,16 @@
 /server/core/src/secure_random.*             @fjarvis
 /server/core/include/yuzu/server/auth.hpp    @fjarvis
 /docs/auth-architecture.md                   @fjarvis
+
+# System Guardian / Guaranteed State — owner @FortitudeEtc
+# Desired-state enforcement subsystem; design in docs/yuzu-guardian-design-v1.1.md.
+# (Excludes .claude/agents/security-guardian.md — that's the governance reviewer, not this feature.)
+/agents/core/src/guardian_*                          @FortitudeEtc
+/agents/core/include/yuzu/agent/guardian_*           @FortitudeEtc
+/server/core/src/guaranteed_state*                   @FortitudeEtc
+/proto/yuzu/guardian/                                @FortitudeEtc
+/docs/yuzu-guardian-*                                @FortitudeEtc
+/docs/user-manual/guaranteed-state.md                @FortitudeEtc
+/tests/unit/test_guardian_*                          @FortitudeEtc
+/tests/unit/server/test_guaranteed_state*            @FortitudeEtc
+/tests/unit/server/test_rest_guaranteed*             @FortitudeEtc


### PR DESCRIPTION
## What

Adds a CODEOWNERS block giving **@FortitudeEtc** ownership of the System Guardian / Guaranteed-State subsystem, so he is auto-requested for review on any PR touching it.

Covered (10 files, verified by glob against the tree):

| Area | Pattern |
|---|---|
| Agent engine | `/agents/core/src/guardian_*`, `/agents/core/include/yuzu/agent/guardian_*` |
| Server store | `/server/core/src/guaranteed_state*` |
| Proto | `/proto/yuzu/guardian/` (whole package dir) |
| Docs | `/docs/yuzu-guardian-*`, `/docs/user-manual/guaranteed-state.md` |
| Tests | `/tests/unit/test_guardian_*`, `/tests/unit/server/test_guaranteed_state*`, `/tests/unit/server/test_rest_guaranteed*` |

Prefix globs follow the existing `auth*`/`rbac_*` house style so future Guardian files are covered automatically.

## Deliberately excluded

`.claude/agents/security-guardian.md` — that's the `/governance` security **reviewer** agent, not the Guaranteed-State product feature. Owning it would mis-route reviews of the governance prompt.

## Notes

- @FortitudeEtc has **write** access, so the entry is honored (CODEOWNERS silently ignores owners without write).
- New patterns don't overlap @fjarvis's auth block, so the "last match wins" ordering is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)