### PR TITLE
docs(auth): reconcile MFA step-up site inventory with shipped code (#1199 follow-up)

### DIFF
--- a/docs/auth-mfa-design.md
+++ b/docs/auth-mfa-design.md
@@ -1,7 +1,7 @@
 # MFA (TOTP) — Yuzu design reference
 
 Status: **PR 1 + PR 2 of 3 shipped (v0.13+)** — self-service enrollment,
-login challenge, recovery codes (PR 1) and step-up on 10 high-risk
+login challenge, recovery codes (PR 1) and step-up on 11 high-risk
 REST + Settings surfaces (PR 2). PR 3 adds OIDC `amr` short-circuit and
 enforcement modes (`admin-only` / `required`).
 
@@ -249,8 +249,18 @@ Browser                    Server (POST /api/v1/sessions)    AuthDB
 
 Step-up sites (from the discovery pass): user delete + role change in
 Settings; token create/revoke, session revoke, Guardian rule create /
-update / push, software-package create + deployment execute, file
-retrieval upload in REST API v1. Eleven sites total.
+update / delete / push, software-package create + deployment execute in
+REST API v1. Eleven sites total.
+
+`POST /api/v1/file-retrieval` was in the original discovery list but is
+**not** a step-up site. It is agent-originated push-back — the only
+caller is the agent's `content_dist` plugin uploading a file it
+retrieved on the operator's behalf, not a browser operator acting on a
+session cookie. Step-up evaluates a session's `mfa_verified_at` against
+a local `users`-row enrollment; an agent upload has neither, so the gate
+has nothing to evaluate. Guardian rule **delete** took its place in the
+high-risk set during PR 2 governance (removing a remediation rule is as
+destructive as updating one), keeping the count at eleven.
 
 ---
 


### PR DESCRIPTION
## What

Resolves the one open `SHOULD` item from @Tr3kkR's #1199 approval review: `docs/auth-mfa-design.md` listed `POST /api/v1/file-retrieval` as one of the eleven MFA step-up sites, but the shipped code does not gate it. Code and design doc disagreed on the security contract.

The **doc** was stale, not the code — the merged #1199 CHANGELOG already carried the correct list. This is a doc-only reconciliation, no behaviour change.

## Why file-retrieval is correctly *not* a step-up site

It's **agent-originated push-back**: the only caller is the agent's `content_dist` plugin (`agents/plugins/content_dist/src/content_dist_plugin.cpp:695`) uploading a file it retrieved on the operator's behalf — not a browser operator acting on a session cookie. Step-up evaluates a session's `mfa_verified_at` against a local `users`-row enrollment; an agent upload has neither, so the gate has nothing to evaluate. Guardian rule **delete** took its place in the high-risk set during PR2 governance.

## Changes (all in `docs/auth-mfa-design.md`)

- Remove `file-retrieval` from the step-up inventory; add an explicit rationale paragraph so the exclusion is documented, not silent.
- Add Guardian rule **delete** (gated in code since PR2 Gate 4, missing from the doc).
- Fix the intro "10 high-risk surfaces" → "11", matching the "Eleven sites total" inventory line.

The eleven now reconcile exactly with the registered handlers: Settings user-delete + role-change; REST token create/revoke, session revoke, Guardian rule create/update/delete/push, software-package create + deployment execute.

## Out of scope (filed separately, not fixed here)

While tracing this I noticed `/api/v1/file-retrieval` looks like a **half-wired stub**: the agent posts multipart form-data (`file`/`sha256`/`original_path`, no `agent_id`, no auth header) while the server handler parses JSON expecting `agent_id`+`size` and never actually writes the file. That's an independent correctness/auth issue, not part of this MFA doc reconciliation — flagging for a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)