### PR TITLE
docs: correct stale triage-label claim in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,7 +278,7 @@ GitHub issues at `github.com/Tr3kkR/Yuzu` via the `gh` CLI. See `docs/agents/iss
 
 ### Triage labels
 
-Canonical defaults (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`); only `wontfix` exists in the repo's label set today. See `docs/agents/triage-labels.md`.
+Canonical defaults (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) — all five now exist in the repo's label set, alongside a broader categorization set (`bug`, `security`, `P0`/`P1`/`P2`, `enhancement`, `documentation`, `reliability`, workstream-* and phase-* tags, etc.). See `docs/agents/triage-labels.md`.
 
 ### Domain docs
 


### PR DESCRIPTION
## What

CLAUDE.md's Triage labels section said *"only `wontfix` exists in the repo's label set today."* That's stale — verified all five canonical triage labels now exist (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`), and the repo carries a broader categorization set (58 labels total: `bug`, `security`, `P0`/`P1`/`P2`, `enhancement`, `documentation`, `reliability`, `workstream-*`, `phase-*`, …).

One-line correction so a future session doesn't skip a label that's actually available. `docs/agents/triage-labels.md` was already accurate and is unchanged.

Noticed while filing #1214 (a `bug`/`security`/`P2` issue — labels the old note implied didn't exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)