### PR TITLE
fix(scope-walking): close policy fromResultSet scalar bypass + harden YAML scanner (#1221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,6 +264,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Scope-walking PR-E follow-ups — policy `fromResultSet:` bypass + YAML scanner
+  hardening (#1221).** Two robustness gaps from the #1215 review, both fail-closed
+  before this change: (1) a **scalar** policy scope (`scope: from_result_set:rs_x`)
+  slipped past the policy `fromResultSet` rejection — `extract_yaml_value` returned
+  it non-empty, skipping the mapping-form check — and was stored verbatim;
+  `PolicyStore::create_policy` now rejects the `from_result_set:` atom in either the
+  scalar or mapping form. (2) `yaml_scan::extract_yaml_value` is now comment-aware
+  (it skips keys inside whole-line and inline `#` comments, matching `yaml_has_key`),
+  so a commented `# fromResultSet:` decoy can no longer be picked up; `yaml_scan.hpp`
+  gains an isolate-via-`extract_yaml_section`-first security contract for the
+  now-authorization-load-bearing scanners. No behaviour change for valid content.
+
 - **`scope.selector:` policies now lower to a real scope (PR-E).** A Policy whose
   `spec.scope:` opened a `selector:` mapping was previously read by the scalar
   extractor as empty and silently stored no scope. It now lowers via the `scope_yaml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,8 +272,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `PolicyStore::create_policy` now rejects the `from_result_set:` atom in either the
   scalar or mapping form. (2) `yaml_scan::extract_yaml_value` is now comment-aware
   (it skips keys inside whole-line and inline `#` comments, matching `yaml_has_key`),
-  so a commented `# fromResultSet:` decoy can no longer be picked up; `yaml_scan.hpp`
-  gains an isolate-via-`extract_yaml_section`-first security contract for the
+  so a commented `# fromResultSet:` decoy can no longer be picked up; and
+  `extract_yaml_section` now anchors on line-leading keys instead of an unanchored
+  `find()`, so a `scope:` substring inside a description/value no longer mis-anchors
+  the section walk and silently drops the whole block (which, for a policy, would
+  fail **open** to a fleet-wide match). `yaml_scan.hpp` gains an
+  isolate-via-`extract_yaml_section`-first security contract for the
   now-authorization-load-bearing scanners. No behaviour change for valid content.
 
 - **`scope.selector:` policies now lower to a real scope (PR-E).** A Policy whose

--- a/server/core/src/policy_store.cpp
+++ b/server/core/src/policy_store.cpp
@@ -673,6 +673,17 @@ PolicyStore::create_policy(const std::string& yaml_source) {
         return std::unexpected(
             "inline flow-mapping scope is not supported; use the block form "
             "(scope: <newline> indented selector:/fromResultSet:)");
+    // PR-E2: result sets are not yet valid in a continuously-evaluated policy (a
+    // result set's ~1h TTL does not match a policy that re-evaluates forever), in
+    // EITHER form. The mapping form is rejected in the scope.empty() branch below
+    // via parse_scope_block; this catches the SCALAR form (`scope: from_result_set:rs_x`)
+    // that branch would otherwise skip because extract_yaml_value returns it
+    // non-empty — closing the policy fromResultSet bypass (#1221 MEDIUM-1).
+    if (scope.find("from_result_set:") != std::string::npos)
+        return std::unexpected(
+            "spec.scope.fromResultSet is not yet supported for policies (follow-up "
+            "PR-E2): a result set's 1h TTL does not match a continuously-evaluated "
+            "policy. Use a selector or a scope expression.");
     if (scope.empty()) {
         auto sb = parse_scope_block(yaml_source);
         if (sb.has_from_result_set)

--- a/server/core/src/yaml_scan.cpp
+++ b/server/core/src/yaml_scan.cpp
@@ -227,7 +227,24 @@ std::string extract_yaml_section(const std::string& yaml, const std::string& dot
         remaining = (dot == std::string::npos) ? "" : remaining.substr(dot + 1);
 
         auto search = segment + ":";
-        auto pos = current.find(search);
+        // Anchor to a real key: the match must be the first non-whitespace token
+        // on its line, not a `segment:` substring sitting inside a value, a
+        // description, or a comment. Unanchored find() previously mis-anchored on
+        // such a substring, mis-computed key_indent, and returned an empty block —
+        // silently dropping the whole section (for a policy that means the scope
+        // predicate vanishes and it matches the entire fleet: fail-OPEN).
+        // (#1221 MEDIUM-2 / #1215 adversarial H-2.)
+        size_t pos = std::string::npos;
+        for (size_t p = current.find(search); p != std::string::npos;
+             p = current.find(search, p + 1)) {
+            auto ls = current.rfind('\n', p);
+            size_t lb = (ls == std::string::npos) ? 0 : ls + 1;
+            auto fnw = current.find_first_not_of(" \t", lb);
+            if (fnw == p) { // `segment:` is the line's first non-whitespace token
+                pos = p;
+                break;
+            }
+        }
         if (pos == std::string::npos)
             return {};
 

--- a/server/core/src/yaml_scan.cpp
+++ b/server/core/src/yaml_scan.cpp
@@ -14,6 +14,27 @@ std::string extract_yaml_value(const std::string& yaml, const std::string& key) 
             pos = yaml.find(search, pos + 1);
             continue;
         }
+        // Reject a match that sits inside a YAML comment: either a whole-line
+        // comment (first non-whitespace char is '#') or text after an inline '#'
+        // comment marker earlier on the line. A '#' counts as a marker only at
+        // line start or when preceded by whitespace (YAML requires a space before
+        // an inline comment), so `foo#bar` in a value is not treated as one. This
+        // mirrors yaml_has_key's comment-awareness so a commented key like
+        // `# fromResultSet: rs_x` is never mistaken for a real one (#1221 MEDIUM-2).
+        auto line_begin = yaml.rfind('\n', pos);
+        line_begin = (line_begin == std::string::npos) ? 0 : line_begin + 1;
+        bool in_comment = false;
+        for (auto k = line_begin; k < pos; ++k) {
+            if (yaml[k] == '#' &&
+                (k == line_begin || yaml[k - 1] == ' ' || yaml[k - 1] == '\t')) {
+                in_comment = true;
+                break;
+            }
+        }
+        if (in_comment) {
+            pos = yaml.find(search, pos + 1);
+            continue;
+        }
         auto vstart = pos + search.size();
         // Skip whitespace after colon
         while (vstart < yaml.size() && (yaml[vstart] == ' ' || yaml[vstart] == '\t'))

--- a/server/core/src/yaml_scan.hpp
+++ b/server/core/src/yaml_scan.hpp
@@ -22,9 +22,20 @@ namespace yuzu::server::yaml_scan {
 //
 // NOT a general-purpose YAML parser. Sufficient for yuzu.io/v1alpha1 DSL.
 //
+// SECURITY CONTRACT (#1215 review / #1221 MEDIUM-2): these scanners are now
+// load-bearing for authorization decisions (scope_yaml lowers a `scope:` block
+// that gates which devices a command targets). `extract_yaml_value` and
+// `extract_yaml_section` locate a key by substring (`find(key + ":")`), so a key
+// that is a superstring of another, or the same key under a sibling section, can
+// be matched if you scan the WHOLE document. Any new security-relevant lookup
+// MUST first isolate the owning block with `extract_yaml_section(<dotted.path>)`
+// and scan within that, the way `scope_yaml::parse_scope_block` does. Raw
+// whole-document `extract_yaml_value` is for non-authorization fields only.
+//
 // History: these four functions lived in policy_store.cpp's anonymous namespace
 // until PR-E (scope-walking YAML DSL) needed them in a second translation unit.
-// Behaviour is preserved verbatim from that move; `yaml_has_key` is new.
+// `yaml_has_key` is new; `extract_yaml_value` gained comment-awareness in the
+// #1215 follow-up (it now skips keys inside `#` comments, matching yaml_has_key).
 
 /// Extract a scalar value for `key`. Returns empty when the key is absent or
 /// opens a mapping/sequence (so callers can use emptiness to mean "not a

--- a/tests/unit/server/test_policy_store.cpp
+++ b/tests/unit/server/test_policy_store.cpp
@@ -364,6 +364,43 @@ scope:
     CHECK(result.error().find("fromResultSet") != std::string::npos);
 }
 
+TEST_CASE("PolicyStore: scalar scope.fromResultSet is also rejected (#1221 MEDIUM-1)",
+          "[policy_store][policy][scope]") {
+    PolicyStore store(":memory:");
+    auto frag = store.create_fragment(kFullFragment);
+    REQUIRE(frag.has_value());
+
+    // The mapping form above is rejected via parse_scope_block. The SCALAR form
+    // (`scope: from_result_set:rs_abc`) makes extract_yaml_value non-empty, which
+    // pre-fix skipped the `scope.empty()` branch and stored the ref verbatim —
+    // bypassing the policy ban (fail-closed at eval, but a latent live path for
+    // PR-E2). It must be rejected at create with the same fromResultSet error.
+    std::string yaml = R"(
+apiVersion: yuzu.io/v1alpha1
+kind: Policy
+displayName: Scalar RS Policy
+fragment: )" + frag.value() +
+                       R"(
+scope: from_result_set:rs_abc
+)";
+    auto result = store.create_policy(yaml);
+    REQUIRE_FALSE(result.has_value());
+    CHECK(result.error().find("fromResultSet") != std::string::npos);
+
+    // The same ref composed into a larger scalar expression is likewise rejected.
+    std::string yaml2 = R"(
+apiVersion: yuzu.io/v1alpha1
+kind: Policy
+displayName: Composed RS Policy
+fragment: )" + frag.value() +
+                        R"(
+scope: ostype == "windows" AND from_result_set:rs_abc
+)";
+    auto result2 = store.create_policy(yaml2);
+    REQUIRE_FALSE(result2.has_value());
+    CHECK(result2.error().find("fromResultSet") != std::string::npos);
+}
+
 TEST_CASE("PolicyStore: inline flow-mapping scope is rejected (UP-6)",
           "[policy_store][policy][scope]") {
     PolicyStore store(":memory:");

--- a/tests/unit/server/test_yaml_scan.cpp
+++ b/tests/unit/server/test_yaml_scan.cpp
@@ -69,6 +69,24 @@ TEST_CASE("yaml_scan: yaml_has_key skips comments and is not fooled by substring
     CHECK(yaml_has_key("mode: static\n", "mode"));
 }
 
+TEST_CASE("yaml_scan: extract_yaml_value skips keys inside comments (#1221 MEDIUM-2)",
+          "[yaml_scan]") {
+    // A whole-line commented key must not be returned, even though its 'key:'
+    // token is preceded by whitespace (the old anchor check alone passed it).
+    CHECK(extract_yaml_value("  # fromResultSet: rs_evil\n", "fromResultSet").empty());
+    // A real key AFTER a commented decoy line wins; the decoy is skipped, not
+    // returned (regression guard for the policy scalar-scope footgun).
+    CHECK(extract_yaml_value("  # fromResultSet: rs_evil\n  fromResultSet: rs_real\n",
+                             "fromResultSet") == "rs_real");
+    // An inline trailing comment that mentions a key-like token is not a key.
+    CHECK(extract_yaml_value("selector:    # fromResultSet: rs_evil\n  platform: x\n",
+                             "fromResultSet")
+              .empty());
+    // A '#' inside the value (no preceding whitespace) is NOT a comment marker —
+    // a legitimate value containing '#' is still returned intact.
+    CHECK(extract_yaml_value("channel: prod#1\n", "channel") == "prod#1");
+}
+
 TEST_CASE("yaml_scan: a key inside a quoted value does not leak into a sibling section",
           "[yaml_scan]") {
     // Adversarial: 'fromResultSet' appears inside a description value, NOT as a

--- a/tests/unit/server/test_yaml_scan.cpp
+++ b/tests/unit/server/test_yaml_scan.cpp
@@ -87,6 +87,40 @@ TEST_CASE("yaml_scan: extract_yaml_value skips keys inside comments (#1221 MEDIU
     CHECK(extract_yaml_value("channel: prod#1\n", "channel") == "prod#1");
 }
 
+TEST_CASE("yaml_scan: extract_yaml_section anchors to line-leading keys (#1215 H-2)",
+          "[yaml_scan]") {
+    // A `scope:` substring inside a description value must NOT mis-anchor the
+    // section walk. Pre-fix, find() matched the substring, mis-computed the
+    // indent, and returned an empty block — dropping the real scope (fail-OPEN
+    // for policies). The real `scope:` block must still be returned intact.
+    std::string yaml = "spec:\n"
+                       "  description: \"see scope: foo for details\"\n"
+                       "  scope:\n"
+                       "    fromResultSet: rs_x\n";
+    auto scope = extract_yaml_section(yaml, "spec.scope");
+    CHECK(extract_yaml_value(scope, "fromResultSet") == "rs_x");
+    // A commented section header must not be anchored to either.
+    std::string yaml2 = "# scope: {fromResultSet: rs_evil}\n"
+                        "spec:\n"
+                        "  scope:\n"
+                        "    fromResultSet: rs_real\n";
+    auto scope2 = extract_yaml_section(yaml2, "spec.scope");
+    CHECK(extract_yaml_value(scope2, "fromResultSet") == "rs_real");
+}
+
+TEST_CASE("yaml_scan: a commented inline-mapping scope: line is not extracted (#1215 H-1)",
+          "[yaml_scan]") {
+    // validate_definition_scope reads extract_yaml_value(yaml, "scope") to detect
+    // the inline flow-mapping form. A *commented* `# scope: {...}` line must not
+    // be picked up, or a legitimate definition keeping sample YAML in a comment
+    // is falsely rejected. The real mapping scope: opens a block → returns empty.
+    std::string yaml = "# scope: {fromResultSet: rs_evil}\n"
+                       "spec:\n"
+                       "  scope:\n"
+                       "    fromResultSet: rs_abc\n";
+    CHECK(extract_yaml_value(yaml, "scope").empty());
+}
+
 TEST_CASE("yaml_scan: a key inside a quoted value does not leak into a sibling section",
           "[yaml_scan]") {
     // Adversarial: 'fromResultSet' appears inside a description value, NOT as a


### PR DESCRIPTION
## Summary

Follow-up to the #1215 review, implementing the two **MEDIUM** findings tracked in #1221. Both were **fail-closed before this change** — neither was an exploitable hole — but both are validation/robustness gaps that become live risks as the scope-walking ladder continues (PR-E2 onward).

> **Stacking:** this branch is based on `feat/scope-walking` (#1215) because the fixes touch files that PR introduces (`yaml_scan.*`, the policy scope path). Base is set to `feat/scope-walking` so the diff shows **only this commit**. Once #1215 rebase-merges to `dev`, GitHub will retarget this PR to `dev`; I'll rebase onto `dev` then for a clean merge.

## What changed

**MEDIUM-1 — policy scalar-scope `from_result_set:` bypass** (`policy_store.cpp`)
`PolicyStore::create_policy` rejected `fromResultSet` only in the *mapping* form. A **scalar** `scope: from_result_set:rs_x` made `extract_yaml_value("scope")` return non-empty, so the `if (scope.empty())` branch holding the rejection was skipped and the ref was stored verbatim — bypassing the documented "policies can't use result sets (yet)" rule. Fail-closed at evaluation today (`PolicyEvaluator` calls the 3-arg `evaluate_scope` → `rs_store=nullptr`/`principal=""` → 0 devices), but it becomes a live, never-intended path the moment PR-E2 threads a principal into policy evaluation. Now the `from_result_set:` atom is rejected in **either** form, before the empty-block branch.

**MEDIUM-2 — hand-rolled YAML scanner is now authorization-load-bearing** (`yaml_scan.{cpp,hpp}`)
`extract_yaml_value` was not comment-aware (unlike the new `yaml_has_key`), so a commented `# fromResultSet: rs_x` line could be picked up (the token's preceding char is a space, satisfying the weak anchor). It now skips keys inside whole-line **and** inline `#` comments (a `#` counts as a marker only at line start or after whitespace, so `foo#bar` in a value is untouched). Added a **security contract** to `yaml_scan.hpp`: the scanners locate keys by substring, so any new authorization-relevant lookup MUST first isolate the owning block via `extract_yaml_section(<dotted.path>)` — the way `parse_scope_block` does.

## Tests

- `test_policy_store.cpp` — scalar `scope: from_result_set:rs_abc` and a composed `ostype == "windows" AND from_result_set:rs_abc` are both rejected at create.
- `test_yaml_scan.cpp` — whole-line comment skip, decoy-comment-then-real-key, inline trailing comment, and a value legitimately containing `#` (`prod#1`) returned intact.
- **Full server suite green** (1996 cases, 23,325 assertions); `[yaml_scan]`/`[policy_store][scope]`/`[scope][dsl]` all pass; CHANGELOG order check passes.

## Not in this PR

The LOW findings from #1221 (un-audited `/api/scope/estimate` preview, legacy-policy migration warning, audit-row dedup) remain tracked there as separate follow-ups.

Addresses #1221 — implements MEDIUM-1 and MEDIUM-2; the LOWs stay open there. cc @Tr3kkR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
