### PR TITLE
feat(docs-site): add Instructions & DSL manual section (#1259)

### DIFF
--- a/site/src/nav.mjs
+++ b/site/src/nav.mjs
@@ -23,6 +23,14 @@ export const NAV = [
     ],
   },
   {
+    heading: 'Instructions & DSL',
+    entries: [
+      { file: 'Instruction-Engine', slug: 'instruction-engine', title: 'Instruction Engine' },
+      { file: 'user-manual/instructions', slug: 'instructions', title: 'Instructions' },
+      { file: 'yaml-dsl-spec', slug: 'yaml-dsl', title: 'YAML DSL' },
+    ],
+  },
+  {
     heading: 'Targeting',
     entries: [
       { file: 'user-manual/scope-engine', slug: 'scope-engine', title: 'Scope Engine' },


### PR DESCRIPTION
Closes #1259.

Adds the **Instructions & DSL** reading-room section to the docs site.

## What
- `site/src/nav.mjs`: new section with **Instruction Engine** (`Instruction-Engine`), **Instructions** (`user-manual/instructions`), **YAML DSL** (`yaml-dsl-spec`).

## Diagrams
No source normalization was needed: the diagrams in these docs are **tree-style** (left-anchored `└──`, no frame edges) and carry no retired arrows (`►`). The frame-line alignment linter scans all three (now **9 docs**) and stays green.

## Verification
- `npm run check:diagrams` → green (9 docs)
- `npm run build` → green (12 pages; `/manual/instruction-engine/`, `/manual/instructions/`, `/manual/yaml-dsl/`)
- Cross-doc links rewrite to site routes; **no dangling `.md`**
- Pages reviewed in preview

Part of epic #1248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
