### PR TITLE
feat(docs-site): add Targeting manual section + retire scope-walking arrows (#1260)

### DIFF
--- a/docs/scope-walking-design.md
+++ b/docs/scope-walking-design.md
@@ -225,7 +225,7 @@ Persistent left-rail panel showing the current operator's result sets, ranked by
 ```
 [★] windows-chrome-suspects     2,798 devices  17m  pinned
 [ ] all-windows-fleet           4,011 devices   2h
-[ ] tar-chrome-procs           ▶ tar query     8m
+[ ] tar-chrome-procs           (tar query)     8m
 ```
 
 Each chip has:
@@ -237,7 +237,7 @@ Each chip has:
 Above every query frame, a horizontal breadcrumb of the active result set's lineage:
 
 ```
-__all__ ─▶ all-windows-fleet ─▶ windows-chrome ─▶ windows-chrome-suspects
+__all__ ─→ all-windows-fleet ─→ windows-chrome ─→ windows-chrome-suspects
                                                               ▲
                                               (active scope — refines next query)
 ```

--- a/site/src/nav.mjs
+++ b/site/src/nav.mjs
@@ -26,6 +26,10 @@ export const NAV = [
     heading: 'Targeting',
     entries: [
       { file: 'user-manual/scope-engine', slug: 'scope-engine', title: 'Scope Engine' },
+      { file: 'scope-walking-design', slug: 'scope-walking', title: 'Scope Walking' },
+      { file: 'asset-tagging-guide', slug: 'asset-tagging', title: 'Asset Tagging' },
+      { file: 'user-manual/management-groups', slug: 'management-groups', title: 'Management Groups' },
+      { file: 'user-manual/device-management', slug: 'device-management', title: 'Device Management' },
     ],
   },
   {


### PR DESCRIPTION
Closes #1260.

Adds the **Targeting** reading-room section and performs the first real source-diagram normalization.

## What
- `site/src/nav.mjs`: Targeting gains **Scope Walking**, **Asset Tagging**, **Management Groups**, **Device Management** (Scope Engine already present).
- `docs/scope-walking-design.md`: retire the 4 `▶` glyphs the alignment linter rejects once the doc is on the site:
  - breadcrumb `─▶` → `─→` (same 2-cell width — the `▲` pointer and caption stay aligned)
  - sidebar `▶ tar query` → `(tar query)` (same 11-cell width — columns stay aligned)

  No framed diagram needed re-alignment (the one box block is a left-anchored tree, exempt). This also improves the doc's GitHub rendering.

## Verification
- `npm run check:diagrams` → green (**10 docs**; scope-walking-design now scanned and clean)
- `npm run build` → green (13 pages)
- Cross-doc links rewrite to site routes; **no dangling `.md`**
- Page reviewed in preview

Note: touches `docs/scope-walking-design.md`, which has CODEOWNERS — minimal glyph-only change. Part of epic #1248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
