### PR TITLE
feat(docs-site): add Policy & Guardian manual section (#1261)

### DIFF
--- a/docs/user-manual/guaranteed-state.md
+++ b/docs/user-manual/guaranteed-state.md
@@ -220,7 +220,7 @@ curl -H "Authorization: Bearer $YUZU_TOKEN" \
 
 ## Retention
 
-Guardian events are pruned on a rolling window. The default is 30 days. Override with `--guardian-event-retention-days` at server start (or set `YUZU_GUARDIAN_EVENT_RETENTION_DAYS`), or via `PUT /api/v1/config/guardian_event_retention_days` at runtime. See the [Retention Settings](server-administration.md#retention-settings) table in the server administration guide.
+Guardian events are pruned on a rolling window. The default is 30 days. Override with `--guardian-event-retention-days` at server start (or set `YUZU_GUARDIAN_EVENT_RETENTION_DAYS`), or via `PUT /api/v1/config/guardian_event_retention_days` at runtime. See the [Retention Settings](server-admin.md#retention-settings) table in the server administration guide.
 
 ## Observability
 

--- a/docs/yuzu-guardian-design-v1.1.md
+++ b/docs/yuzu-guardian-design-v1.1.md
@@ -49,19 +49,19 @@ Not all detections are the same. A firewall rule change happens instantaneously 
 The guard types below are Windows-specific. See Section 15 for Linux equivalents and Section 19 for macOS equivalents. The two-category model (event guards vs condition guards) is identical across all platforms.
 
 ```
-Guards
-├── Event Guards (real-time, kernel-backed user-mode APIs)
-│   ├── Registry Guard       RegNotifyChangeKeyValue          ~0ms latency   [implemented]
-│   ├── File Guard           ReadDirectoryChangesW            ~0ms latency   [implemented]
-│   ├── ETW Guard            OpenTrace / ProcessTrace          ~1-5ms latency
-│   ├── WFP Guard            FwpmFilterSubscribeChanges0       ~0ms latency
-│   └── SCM Guard            NotifyServiceStatusChange         ~0ms latency
-│
-└── Condition Guards (periodic evaluation on a schedule)
-    ├── Process Guard         ToolHelp32 snapshot + ETW hybrid  configurable interval
-    ├── Software Guard        Registry Uninstall keys + WMI     configurable interval
-    ├── Compliance Guard      Event Log query + WMI query       configurable interval
-    └── WMI Guard             Arbitrary WMI query evaluation    configurable interval
+ Guards
+ ├── Event Guards (real-time, kernel-backed user-mode APIs)
+ │   ├── Registry Guard       RegNotifyChangeKeyValue          ~0ms latency   [implemented]
+ │   ├── File Guard           ReadDirectoryChangesW            ~0ms latency   [implemented]
+ │   ├── ETW Guard            OpenTrace / ProcessTrace          ~1-5ms latency
+ │   ├── WFP Guard            FwpmFilterSubscribeChanges0       ~0ms latency
+ │   └── SCM Guard            NotifyServiceStatusChange         ~0ms latency
+ │
+ └── Condition Guards (periodic evaluation on a schedule)
+     ├── Process Guard         ToolHelp32 snapshot + ETW hybrid  configurable interval
+     ├── Software Guard        Registry Uninstall keys + WMI     configurable interval
+     ├── Compliance Guard      Event Log query + WMI query       configurable interval
+     └── WMI Guard             Arbitrary WMI query evaluation    configurable interval
 ```
 
 **Event guards** block on kernel wait handles and fire within microseconds of a change. They are appropriate for configuration settings that can change at any moment and must be immediately reverted.
@@ -81,65 +81,65 @@ Guards
 ### 3.1 Agent-side component hierarchy
 
 ```
-Yuzu Agent
-├── Plugin Host (existing — 44 plugins, C ABI)
-├── Trigger Engine (existing — interval, file, evtlog triggers)
-├── Comms / gRPC (existing — bidirectional stream)
-├── KV Storage (existing — SQLite, reused for policy cache)
-│
-└── Yuzu Guardian (NEW)
-    │
-    ├── Policy Cache
-    │   ├── SQLite table in existing KV store
-    │   ├── Versioned rules with HMAC signatures
-    │   └── Full offline operation — no network dependency
-    │
-    ├── Guard Manager
-    │   ├── Instantiates guards based on active policy rules
-    │   ├── Routes guard events to the State Evaluator
-    │   ├── Manages guard lifecycle (start/stop/restart)
-    │   │
-    │   ├── Event Guards (real-time)
-    │   │   ├── Registry Guard
-    │   │   ├── ETW Guard
-    │   │   ├── WFP Guard
-    │   │   └── SCM Guard
-    │   │
-    │   ├── Condition Guards (periodic)
-    │   │   ├── Process Guard (hybrid: ETW + periodic poll)
-    │   │   ├── Software Guard
-    │   │   ├── Compliance Guard
-    │   │   └── WMI Guard
-    │   │
-    │   └── Reconciliation Guard (periodic full-state check, safety net)
-    │
-    ├── State Evaluator
-    │   ├── Compares detected state against policy assertion
-    │   ├── Returns: compliant | drift | exempt
-    │   └── Assertion type registry (extensible)
-    │
-    ├── Remediation Engine
-    │   ├── Executes corrective action (in-process, no server round-trip)
-    │   ├── Delegates failure handling to Resilience Strategy
-    │   └── Re-entrancy protection (suppresses self-triggered events)
-    │
-    ├── Resilience Strategy (per-rule configurable)
-    │   ├── Persist — immediate, sub-ms, never gives up (default)
-    │   ├── Backoff — exponential delay, never gives up
-    │   ├── Bounded — give up after N cycles, then keep detecting + alert
-    │   ├── Escalation — forward design (post-MVP): A → B → C → terminal
-    │   └── Race Detector — sliding window drift rate tracking
-    │
-    └── Audit Journal
-        ├── Local SQLite journal (sequential IDs, HMAC integrity)
-        ├── Async writes (fire-and-forget from guard threads)
-        └── Batch sync to server when online
+ Yuzu Agent
+ ├── Plugin Host (existing — 44 plugins, C ABI)
+ ├── Trigger Engine (existing — interval, file, evtlog triggers)
+ ├── Comms / gRPC (existing — bidirectional stream)
+ ├── KV Storage (existing — SQLite, reused for policy cache)
+ │
+ └── Yuzu Guardian (NEW)
+     │
+     ├── Policy Cache
+     │   ├── SQLite table in existing KV store
+     │   ├── Versioned rules with HMAC signatures
+     │   └── Full offline operation — no network dependency
+     │
+     ├── Guard Manager
+     │   ├── Instantiates guards based on active policy rules
+     │   ├── Routes guard events to the State Evaluator
+     │   ├── Manages guard lifecycle (start/stop/restart)
+     │   │
+     │   ├── Event Guards (real-time)
+     │   │   ├── Registry Guard
+     │   │   ├── ETW Guard
+     │   │   ├── WFP Guard
+     │   │   └── SCM Guard
+     │   │
+     │   ├── Condition Guards (periodic)
+     │   │   ├── Process Guard (hybrid: ETW + periodic poll)
+     │   │   ├── Software Guard
+     │   │   ├── Compliance Guard
+     │   │   └── WMI Guard
+     │   │
+     │   └── Reconciliation Guard (periodic full-state check, safety net)
+     │
+     ├── State Evaluator
+     │   ├── Compares detected state against policy assertion
+     │   ├── Returns: compliant | drift | exempt
+     │   └── Assertion type registry (extensible)
+     │
+     ├── Remediation Engine
+     │   ├── Executes corrective action (in-process, no server round-trip)
+     │   ├── Delegates failure handling to Resilience Strategy
+     │   └── Re-entrancy protection (suppresses self-triggered events)
+     │
+     ├── Resilience Strategy (per-rule configurable)
+     │   ├── Persist — immediate, sub-ms, never gives up (default)
+     │   ├── Backoff — exponential delay, never gives up
+     │   ├── Bounded — give up after N cycles, then keep detecting + alert
+     │   ├── Escalation — forward design (post-MVP): A → B → C → terminal
+     │   └── Race Detector — sliding window drift rate tracking
+     │
+     └── Audit Journal
+         ├── Local SQLite journal (sequential IDs, HMAC integrity)
+         ├── Async writes (fire-and-forget from guard threads)
+         └── Batch sync to server when online
 ```
 
 ### 3.2 Data flow
 
 ```
-Server ──push──▶ Policy Cache (local SQLite)
+Server ──push──→ Policy Cache (local SQLite)
                       │
               Guard Manager reads active rules,
               starts appropriate guards
@@ -151,12 +151,12 @@ Server ──push──▶ Policy Cache (local SQLite)
               │                │
               └───────┬────────┘
                       │
-              Guard fires ──▶ State Evaluator
+              Guard fires ──→ State Evaluator
                                     │
                               Compare actual vs desired
                                     │
-                              ┌─ Compliant ──▶ no-op
-                              └─ Drift ──▶ Remediation Engine
+                              ┌─ Compliant ──→ no-op
+                              └─ Drift ──→ Remediation Engine
                                                │
                                          Execute corrective action
                                          Write audit event (async)
@@ -166,29 +166,29 @@ Server ──push──▶ Policy Cache (local SQLite)
 ### 3.3 Server-side additions
 
 ```
-Yuzu Server (existing)
-│
-├── Guaranteed State Store (NEW — SQLite table)
-│   ├── Rule CRUD (yaml_source + denormalised columns)
-│   └── Fleet compliance state aggregation
-│
-├── REST API v1 additions (NEW endpoints)
-│   ├── /api/v1/guaranteed-state/rules          CRUD
-│   ├── /api/v1/guaranteed-state/push           Distribute to agents
-│   ├── /api/v1/guaranteed-state/status         Fleet compliance
-│   ├── /api/v1/guaranteed-state/events         Drift/remediation events
-│   └── /api/v1/guaranteed-state/alerts         Active alerts
-│
-├── Dashboard additions (NEW page)
-│   ├── /guaranteed-state                       Main page
-│   ├── /guaranteed-state/rules/:id             Rule detail
-│   ├── /guaranteed-state/alerts                Alert timeline
-│   └── HTMX fragments for all interactive elements
-│
-└── MCP tool additions
-    ├── get_guaranteed_state_status              Fleet compliance
-    ├── list_guaranteed_state_rules              Rule listing
-    └── get_guaranteed_state_alerts              Active alerts
+ Yuzu Server (existing)
+ │
+ ├── Guaranteed State Store (NEW — SQLite table)
+ │   ├── Rule CRUD (yaml_source + denormalised columns)
+ │   └── Fleet compliance state aggregation
+ │
+ ├── REST API v1 additions (NEW endpoints)
+ │   ├── /api/v1/guaranteed-state/rules          CRUD
+ │   ├── /api/v1/guaranteed-state/push           Distribute to agents
+ │   ├── /api/v1/guaranteed-state/status         Fleet compliance
+ │   ├── /api/v1/guaranteed-state/events         Drift/remediation events
+ │   └── /api/v1/guaranteed-state/alerts         Active alerts
+ │
+ ├── Dashboard additions (NEW page)
+ │   ├── /guaranteed-state                       Main page
+ │   ├── /guaranteed-state/rules/:id             Rule detail
+ │   ├── /guaranteed-state/alerts                Alert timeline
+ │   └── HTMX fragments for all interactive elements
+ │
+ └── MCP tool additions
+     ├── get_guaranteed_state_status              Fleet compliance
+     ├── list_guaranteed_state_rules              Rule listing
+     └── get_guaranteed_state_alerts              Active alerts
 ```
 
 ---
@@ -204,7 +204,7 @@ Kernel + HAL init
 Session Manager (smss.exe)
 Service Control Manager starts
     │
-    ├── Yuzu Agent service starts ──────▶ Phase 1: start_local()
+    ├── Yuzu Agent service starts ──────→ Phase 1: start_local()
     │   (SERVICE_AUTO_START)                  │
     │                                        ├── Open SQLite KV store
     │                                        ├── Load policy cache
@@ -214,13 +214,13 @@ Service Control Manager starts
     │
     ├── Network stack initialises
     │
-Winlogon shows login screen ───────────▶ Phase 2: sync_with_server()
+Winlogon shows login screen ───────────→ Phase 2: sync_with_server()
     │                                        │
     │                                        ├── Connect gRPC
     │                                        ├── Fetch policy updates
     │                                        └── Flush audit journal
     │
-User logs in ──────────────────────────▶ Already enforcing for ~30s+
+User logs in ──────────────────────────→ Already enforcing for ~30s+
 ```
 
 **Phase 1 — Local enforcement (no network required):**
@@ -1255,37 +1255,37 @@ The dashboard uses the existing HTMX paradigm (server-rendered HTML fragments).
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐
-│  Guaranteed State                                     [+ New Rule]│
+│  Guaranteed State                                    [+ New Rule]│
 ├──────────────────────────────────────────────────────────────────┤
-│  Platform: [All ▼]  [W] 148 agents  [L] 30 agents  [M] 20 agents│
+│  Platform: [All ▼]  [W] 148 agents  [L] 30 agents  [M] 20 agents │
 ├──────────────────────────────────────────────────────────────────┤
-│  ┌──────┐  ┌─────────┐  ┌───────┐  ┌──────┐  ┌──────────────┐  │
-│  │  42  │  │   39    │  │   2   │  │   1  │  │ ████████░ 93%│  │
-│  │ Rules│  │Compliant│  │Drifted│  │Errors│  │  Fleet comp. │  │
-│  └──────┘  └─────────┘  └───────┘  └──────┘  └──────────────┘  │
+│  ┌──────┐  ┌─────────┐  ┌───────┐  ┌──────┐  ┌──────────────┐    │
+│  │  42  │  │   39    │  │   2   │  │   1  │  │ ████████░ 93%│    │
+│  │ Rules│  │Compliant│  │Drifted│  │Errors│  │  Fleet comp. │    │
+│  └──────┘  └─────────┘  └───────┘  └──────┘  └──────────────┘    │
 ├────────────────────────────┬─────────────────────────────────────┤
 │  Rules                     │  Recent events                      │
 │  ┌───────────────────────┐ │  ┌────────────────────────────────┐ │
-│  │ ● block-smb-445   [W] │ │  │ 10:42  DRIFT REMEDIATED       │ │
-│  │   Compliant · 148/148 │ │  │ block-smb-445 on DESKTOP-A3F  │ │
-│  │   [event] HIGH        │ │  │ Port 445 opened → blocked 2ms │ │
+│  │ ● block-smb-445   [W] │ │  │ 10:42  DRIFT REMEDIATED        │ │
+│  │   Compliant · 148/148 │ │  │ block-smb-445 on DESKTOP-A3F   │ │
+│  │   [event] HIGH        │ │  │ Port 445 opened → blocked 2ms  │ │
 │  ├───────────────────────┤ │  ├────────────────────────────────┤ │
-│  │ ● edr-agent-running[W]│ │  │ 10:41  DRIFT DETECTED         │ │
-│  │   Compliant · 148/148 │ │  │ av-scan-7d on LAPTOP-B92      │ │
+│  │ ● edr-agent-running[W]│ │  │ 10:41  DRIFT DETECTED          │ │
+│  │   Compliant · 148/148 │ │  │ av-scan-7d on LAPTOP-B92       │ │
 │  │   [hybrid] CRITICAL   │ │  │ Last scan 9d ago → triggered   │ │
 │  ├───────────────────────┤ │  ├────────────────────────────────┤ │
-│  │ ◐ ssh-no-root-login[L]│ │  │ 10:38  COMPLIANT              │ │
-│  │   2 drifted · 28/30   │ │  │ edr-agent-running on SRV-DC01 │ │
+│  │ ◐ ssh-no-root-login[L]│ │  │ 10:38  COMPLIANT               │ │
+│  │   2 drifted · 28/30   │ │  │ edr-agent-running on SRV-DC01  │ │
 │  │   [event] HIGH        │ │  │ CSFalconService.exe running ✓  │ │
 │  ├───────────────────────┤ │  ├────────────────────────────────┤ │
-│  │ ● macos-alf-on    [M] │ │  │ 10:35  RESILIENCE ESCALATED   │ │
-│  │   Compliant · 20/20   │ │  │ block-smb-445 on DESKTOP-K7M  │ │
+│  │ ● macos-alf-on    [M] │ │  │ 10:35  RESILIENCE ESCALATED    │ │
+│  │   Compliant · 20/20   │ │  │ block-smb-445 on DESKTOP-K7M   │ │
 │  │   [event] HIGH        │ │  │ firewall-api → registry-write  │ │
 │  └───────────────────────┘ │  └────────────────────────────────┘ │
 │                            │                                     │
 │  Legend:                   │  [Show all events →]                │
-│  ● Compliant  ◐ Drifted   │                                     │
-│  ◉ Alert      ○ Disabled  │                                     │
+│  ● Compliant  ◐ Drifted    │                                     │
+│  ◉ Alert      ○ Disabled   │                                     │
 ├────────────────────────────┴─────────────────────────────────────┤
 │  Push policies     Scope: [________________________]  [Push Now] │
 ├──────────────────────────────────────────────────────────────────┤
@@ -1307,10 +1307,10 @@ The dashboard uses the existing HTMX paradigm (server-rendered HTML fragments).
 │  Description: Ensure SMB port 445 is blocked for inbound traffic │
 │  Severity: HIGH    Mode: Enforce    OS: Windows                  │
 │  Scope: tag:production-workstations AND NOT tag:file-servers     │
-│  Tags: security, network, cis-benchmark-5.2.1                   │
+│  Tags: security, network, cis-benchmark-5.2.1                    │
 │  Guards: Registry (primary), ETW (primary), Reconciliation       │
 │  Assertion: firewall-port-blocked (TCP/445/inbound)              │
-│  Resilience: Escalation (firewall-api → registry → wfp-api)     │
+│  Resilience: Escalation (firewall-api → registry → wfp-api)      │
 ├──────────────────────────────────────────────────────────────────┤
 │  Agent compliance                           148 compliant / 148  │
 │  ┌────────────┬───────────┬────────────┬────────┬──────────────┐ │
@@ -2052,20 +2052,20 @@ ReadOnlyPaths=/proc/sys /sys/fs/selinux
 The two-phase init works identically on Linux:
 
 ```
-systemd starts ──────────────────────▶ Phase 1: start_local()
+systemd starts ──────────────────────→ Phase 1: start_local()
     │                                       │
     ├── yuzu-agent.service starts           ├── Open SQLite
     │   (After=local-fs.target)             ├── Load policy cache
     │                                       ├── Start all guards
     │                                       └── ENFORCING ✓
     │
-    ├── network-online.target ──────▶ Phase 2: sync_with_server()
+    ├── network-online.target ──────→ Phase 2: sync_with_server()
     │                                       │
     │                                       ├── Connect gRPC
     │                                       └── Sync policies
     │
     ├── display-manager.service
-User logs in ──────────────────────▶ Already enforcing
+User logs in ──────────────────────→ Already enforcing
 ```
 
 The service unit uses `After=local-fs.target` (not `After=network-online.target`) so Phase 1 starts before the network is available. The gRPC connection in Phase 2 uses the existing agent reconnection logic with exponential backoff.
@@ -2414,17 +2414,17 @@ endif
 ### 22.2 Boot-time enforcement on macOS
 
 ```
-launchd starts ──────────────────────▶ Phase 1: start_local()
+launchd starts ──────────────────────→ Phase 1: start_local()
     │                                       │
     ├── com.yuzu.agent.plist                ├── Open SQLite
     │   (RunAtLoad=true)                    ├── Load policy cache
     │                                       ├── Start all guards
     │                                       └── ENFORCING ✓
     │
-    ├── Network available ──────────▶ Phase 2: sync_with_server()
+    ├── Network available ──────────→ Phase 2: sync_with_server()
     │
 Login window appears
-User logs in ──────────────────────▶ Already enforcing
+User logs in ──────────────────────→ Already enforcing
 ```
 
 The launchd plist uses `RunAtLoad=true` and is placed in `/Library/LaunchDaemons/` (system-wide, runs as root). No `WaitForNetwork` key — Phase 1 starts immediately.

--- a/site/src/nav.mjs
+++ b/site/src/nav.mjs
@@ -41,6 +41,14 @@ export const NAV = [
     ],
   },
   {
+    heading: 'Policy & Guardian',
+    entries: [
+      { file: 'user-manual/policy-engine', slug: 'policy-engine', title: 'Policy Engine' },
+      { file: 'user-manual/guaranteed-state', slug: 'guaranteed-state', title: 'Guaranteed State' },
+      { file: 'yuzu-guardian-design-v1.1', slug: 'guardian-design', title: 'Guardian Design' },
+    ],
+  },
+  {
     heading: 'Identity & Access',
     entries: [
       { file: 'user-manual/authentication', slug: 'authentication', title: 'Authentication' },


### PR DESCRIPTION
## What

Adds the **Policy & Guardian** manual section to the docs-site (`site/`), closing child slice #1261 of epic #1248.

New `site/src/nav.mjs` entries:
- `user-manual/policy-engine` → Policy Engine
- `user-manual/guaranteed-state` → Guaranteed State
- `yuzu-guardian-design-v1.1` → Guardian Design

## Diagram normalization

The Guardian design doc had **85** alignment-linter violations. Normalized in source, preserving cell widths and content:
- retired all 13 `▶` glyphs → `→` in the data-flow / Windows / Linux / macOS boot diagrams
- indented the component / guard / server-side trees by one space so their connector lines are exempt from the frame-width rule (matches the existing Instruction-Engine convention)
- re-aligned the two dashboard mockups to a uniform 68-col frame — also fixed the nested "Recent events" box right border and the legend centre divider that were already ragged in the source

A `git diff -w` confirms the **only** non-whitespace change to the design doc is the 13 arrow glyphs; every other edit is pure indentation/padding (121 insertions / 121 deletions, no lines added or removed).

## Drive-by fix

`guaranteed-state.md` linked to `server-administration.md#retention-settings`, which doesn't exist — corrected to `server-admin.md#retention-settings` (verified the `## Retention Settings` anchor is present and that doc cross-links back).

## Verification
- `npm run check:diagrams` — green (16 docs, 0 off-site)
- `npm run build` — green, 19 pages incl. `/manual/{policy-engine,guaranteed-state,guardian-design}`
- Link rewriting verified: in-scope cross-links (`policy-engine.md`, `rbac.md`, `scope-engine.md`, `../yuzu-guardian-design-v1.1.md`) resolve to site routes; out-of-scope (`audit-log.md`, implementation-plan, server-admin) resolve to GitHub blob; no dangling `.md` links.

Closes #1261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)