### PR TITLE
feat(docs-site): add Identity, Data, Operating, Extending manual sections

### DIFF
--- a/site/src/nav.mjs
+++ b/site/src/nav.mjs
@@ -45,6 +45,8 @@ export const NAV = [
     entries: [
       { file: 'user-manual/authentication', slug: 'authentication', title: 'Authentication' },
       { file: 'user-manual/rbac', slug: 'rbac', title: 'RBAC' },
+      { file: 'auth-architecture', slug: 'auth-architecture', title: 'Auth Architecture' },
+      { file: 'user-manual/security-hardening', slug: 'security-hardening', title: 'Security Hardening' },
     ],
   },
   {
@@ -52,6 +54,37 @@ export const NAV = [
     entries: [
       { file: 'user-manual/rest-api', slug: 'rest-api', title: 'REST API' },
       { file: 'user-manual/mcp', slug: 'mcp', title: 'MCP' },
+    ],
+  },
+  {
+    heading: 'Data & Observability',
+    entries: [
+      { file: 'user-manual/response-store', slug: 'response-store', title: 'Response Store' },
+      { file: 'user-manual/audit-log', slug: 'audit-log', title: 'Audit Log' },
+      { file: 'user-manual/metrics', slug: 'metrics', title: 'Metrics' },
+      { file: 'observability-conventions', slug: 'observability-conventions', title: 'Observability Conventions' },
+      { file: 'analytics-events', slug: 'analytics-events', title: 'Analytics Events' },
+    ],
+  },
+  {
+    heading: 'Operating Yuzu',
+    entries: [
+      { file: 'user-manual/server-admin', slug: 'server-admin', title: 'Server Administration' },
+      { file: 'user-manual/gateway', slug: 'gateway', title: 'Gateway' },
+      { file: 'user-manual/upgrading', slug: 'upgrading', title: 'Upgrading' },
+      { file: 'user-manual/release-verification', slug: 'release-verification', title: 'Release Verification' },
+      { file: 'operations/capacity-planning', slug: 'capacity-planning', title: 'Capacity Planning' },
+      { file: 'operations/certificate-renewal', slug: 'certificate-renewal', title: 'Certificate Renewal' },
+      { file: 'operations/disaster-recovery', slug: 'disaster-recovery', title: 'Disaster Recovery' },
+      { file: 'operations/troubleshooting', slug: 'troubleshooting', title: 'Troubleshooting' },
+    ],
+  },
+  {
+    heading: 'Extending & Concepts',
+    entries: [
+      { file: 'data-architecture', slug: 'data-architecture', title: 'Data Architecture' },
+      { file: 'enterprise-edition', slug: 'enterprise-edition', title: 'Enterprise Edition' },
+      { file: 'enterprise-readiness-soc2-first-customer', slug: 'enterprise-readiness', title: 'Enterprise Readiness (SOC 2)' },
     ],
   },
 ];


### PR DESCRIPTION
## What

Batches four epic-#1248 manual-section slices into one PR (per the agreed plan — these are pure `site/src/nav.mjs` curation-manifest adds with **no diagram-normalization work**; none of the 18 docs carry box-drawing diagrams or retired arrows):

- **#1254 Identity & Access** — adds `auth-architecture`, `user-manual/security-hardening` (authentication + rbac were already on the site)
- **#1255 Data & Observability** — `response-store`, `audit-log`, `metrics`, `observability-conventions`, `analytics-events`
- **#1256 Operating Yuzu** — `server-admin`, `gateway`, `upgrading`, `release-verification`, `operations/{capacity-planning,certificate-renewal,disaster-recovery,troubleshooting}`
- **#1257 Extending & Concepts** — `data-architecture`, `enterprise-edition`, `enterprise-readiness-soc2-first-customer`

> Note: #1257's issue text also lists "sdk docs", but `docs/sdk/` does not exist in the repo, so those are omitted. If SDK docs are authored later, adding them is a one-line manifest change.

## Verification
- `npm run check:diagrams` — green (31 docs, 0 off-site)
- `npm run build` — green, **34 pages** (18 new manual routes)
- No dangling `.md` links; no doubled-path resolution bug; in-scope cross-links rewrite to site routes, out-of-scope to GitHub blob.

Closes #1254, #1255, #1256, #1257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)