### PR TITLE
docs(vuln_scan): North Star vulnerability-graph design, ADRs + plain-language explainer

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -61,3 +61,34 @@ Timeline Activity Record. TAR captures ordered endpoint activity and response hi
 ## Gateway
 
 The Erlang service under `gateway/` that scales agent connectivity and command fanout. It proxies registration and heartbeat traffic upstream to the server, exposes agent-facing gRPC, and provides management forwarding for server-dispatched commands.
+
+## Reachability
+
+Whether one node in the fleet can initiate a network connection to another. Yuzu distinguishes two kinds and commits to one:
+
+- **Observed reachability** — an edge backed by a network flow the fleet's own agents *actually saw* (a `fleet_snapshot.v1` connection whose destination resolves to another fleet member via the server's IP→agent map). This is the spine of Yuzu's reachability graph. It deliberately **undercounts** what is possible — a path that policy permits but no host ever exercised is invisible — and that recall trade-off is accepted because trustworthy, low-false-positive results are the product's cornerstone.
+- **Potential reachability** — what the network/firewall *policy would allow*, independent of whether a flow was ever observed. Yuzu can only ever approximate the **host-firewall** slice of this (the set of `(port, protocol, allowed-source)` a host would accept), and only after structured firewall parsing that does not exist yet — it is a later, clearly-labeled enrichment, never conflated with observed edges.
+
+**Fabric-level reachability** — what switch/router ACLs, cloud security groups, and VLAN segmentation permit — is **out of scope**: an on-box agent cannot see it and Yuzu never fabricates it. A seam is left to *consume* it from an upstream source or *publish* Yuzu's observed graph upstream in a future iteration.
+
+Distinct from **Scope**, which is a device-*set* target expression, not a graph; reachability is about edges between nodes, not membership.
+
+## Asset value (Crown jewel)
+
+A risk-weighting of how much a node matters to defend — a *value* axis, **orthogonal** to tags, management groups, and scope (which are *targeting* axes). **Operator-declared**: the defender knows what matters and Yuzu does not guess it, though optional inference *hints* may suggest a value (never auto-apply it). Value is carried by the **service** — the process/listening unit where a vulnerability and an exposed port actually live — and may also be declared on an addressable instance (container, VM, bare-metal host). A host's **effective value is the maximum** of the values of the services/instances it carries: a box is as valuable a target as its most valuable tenant. A **crown jewel** is the high end of that axis — the service whose compromise is the attacker's objective and the defender's nightmare. New term; does not collide with any existing Yuzu concept.
+
+## Trust zone
+
+An operator-declared, ordered trust tier over network positions — a labeled set of CIDRs and/or sites (e.g. `internet` < `partner-extranet` (MPLS / third-party via an extranet block) < `branch-campus` (staff sites with fewer physical controls) < `datacenter` (where crown jewels live)). Trust zones are **declared, not inferred**: Yuzu cannot tell that `10.50.0.0/16` is the branch LAN or that an off-fleet peer arrived over an MPLS extranet — the operator labels the ranges, which Yuzu matches against the host `local_ips` and connection addresses it already collects. This is what disambiguates the blunt `External` edge into `internet` / `partner-extranet` / `branch`. A flow crossing from a lower-trust zone into a higher-trust one is a **cross-trust-boundary** edge — the source side of attack-path enumeration and the cut side of segmentation analysis. **Orthogonal** to **Management Group** (device-grouping for authz/targeting) and to **Scope** (a device-set expression): a host sits in exactly one trust zone *and* any number of management groups. With **Asset value**, trust zones bracket the attack graph — value declares *what attackers are after*, trust zones declare *where they start*.
+
+## Entry point
+
+A service an attacker is assumed able to reach from outside a defended zone — the *source set* for attack-path enumeration. In v1, an entry point is any service **exposed across a trust-zone boundary** (reachable from a zone of lower trust than the service's own), the lowest tier being the public Internet; laptops in low-trust staff zones are entry points as phishing / initial-access landing nodes. **Assume-breach** entry — treating *any* node as a possible foothold to model post-initial-access lateral movement — is a later, explicitly separate view, not the v1 default.
+
+## Attack path
+
+A directed chain through the reachability graph from an **entry point** to a **crown jewel**, where each hop is an observed reachability edge whose destination service carries an exploitable vulnerability. Each hop is weighted by the probability an attacker can exploit the destination service on arrival; the path's score is the product of its hop probabilities — found as a shortest *weighted* path so the **most probable** route surfaces, depth-bounded to the few hops that constitute a real threat. A finding's rank is driven by whether it sits on a short, probable attack path to value — **not** by raw CVSS. Distinct from **TAR** (observed temporal activity): an attack path is a structural statement about *possible* compromise routes, grounded in observed reachability but oriented toward what *could* happen.
+
+## Chokepoint
+
+A node or edge lying on many high-value attack paths, such that removing it — patching/isolating the host, or closing the port/flow — severs the most at-risk value for the least defender effort. Ranked by **defender ROI**: the sum of `crown-jewel value × path probability` over the attack paths the removal would break, **not** by generic graph centrality. The minimum-effort set of removals that fully severs a trust zone from crown jewels it should not reach is a **segmentation recommendation** (a cost-weighted min-cut). Because the graph is observed-grounded, a chokepoint severs *observed* paths; policy-permitted-but-unobserved paths are out of scope until host-firewall potential-reachability enrichment lands.

--- a/docs/adr/0001-observed-grounded-reachability.md
+++ b/docs/adr/0001-observed-grounded-reachability.md
@@ -1,0 +1,40 @@
+---
+status: accepted
+date: 2026-06-08
+owner: "@lesault (Andy Younie)"
+---
+
+# 0001 — The reachability graph is observed-grounded, not potential-based
+
+## Context
+
+The vulnerability engine's differentiator is attack-path-aware prioritisation, which needs
+a fleet reachability graph. The market splits on what "reachable" means: CTEM /
+attack-path tools (XM Cyber) model **potential** reachability derived from network/firewall/
+cloud config (high recall, high noise); the alternative is **observed** reachability —
+edges backed by flows agents actually saw. An audit (2026-06-08) confirmed Yuzu collects
+observed flows well (`fleet_snapshot.v1` + `FleetTopologyStore`) but **cannot** collect
+potential reachability on-box: the firewall plugin only dumps rules as unstructured text,
+and switch ACLs / cloud security groups / VLAN segmentation are invisible to an on-box
+agent by construction.
+
+## Decision
+
+The graph's spine is **observed reachability**. We trade recall for trust on purpose —
+observed flows undercount what is possible, and that is an accepted, written-down
+limitation, because low false-positive results are Yuzu's cornerstone. **Host-firewall
+potential reachability** is a later, clearly-labeled enrichment (it requires structured
+firewall parsing we do not yet have) and is never merged into the observed edge set.
+**Fabric-level potential reachability is out of scope**; a seam is left to *consume* it
+from, or *publish* our observed graph to, an upstream source in a future iteration. Yuzu
+never fabricates reachability it cannot observe.
+
+## Consequences
+
+- The honest headline limitation, stated in every surface: **a path that policy permits
+  but no host ever exercised is invisible.** Segmentation min-cuts (ADR-0005) therefore cut
+  *observed* paths only.
+- The novelty claim is defensible *because* of this constraint, not despite it: we are the
+  attack-path tool grounded in the defender's own observed telemetry.
+- "Reachable" in Yuzu means **network/IPC-reachable host/service** — deliberately not the
+  SCA call-graph sense ("is the vulnerable function invoked"). The term is kept unambiguous.

--- a/docs/adr/0002-reachability-graph-data-model.md
+++ b/docs/adr/0002-reachability-graph-data-model.md
@@ -1,0 +1,52 @@
+---
+status: accepted
+date: 2026-06-08
+owner: "@lesault (Andy Younie)"
+---
+
+# 0002 — Reachability graph data model: host + service nodes, two edge classes
+
+## Context
+
+An attack path is not "host A → host B"; it is "reach the *service* B exposes → exploit the
+CVE *on that service* → own host B → pivot via B's outbound flows." A CVE on a package that
+binds nothing is a finding but not a path. The data already supports a service-level model:
+`fleet_snapshot.v1` collects `listeners[]` (host×port×pid) and `connections[]` whose
+ESTABLISHED rows the viz already resolves to a destination listener.
+
+## Decision
+
+Two node tiers: **host nodes** and **service nodes** = `(host, listening port, protocol,
+owning process)`. A CVE and asset value attach to the **service**; an inbound edge
+terminates at a service. A host is **not** an atomic compromise unit — it is a **sub-graph
+of service nodes joined by local-IPC edges**. Two edge classes: **network reachability
+edges** (`src host → dst service`, observed flow, directional) and **local-IPC edges**
+(`service → service` within a host: Unix socket, named pipe, shared memory, mmap, shared
+file, setuid/sudo hop). **No identity/account nodes** — declared non-goal (no on-box
+identity telemetry; that is the BloodHound space we do not enter).
+
+Value is carried by the service and rolls up to the host by **max**; for path *scoring* the
+captured value is the max over services **locally reachable from the entry service**, not
+the host-max. **Trust zones** (operator-declared, ordered CIDR/site tiers) bracket the
+graph on the source side; **crown jewels** (operator-declared, orthogonal to tags/MGs)
+bracket it on the value side. Standing rule: **`kernel boundary = visibility boundary`** —
+one agent sees one OS kernel; VMs, Hyper-V-isolated containers, and Docker-on-Mac Linux VMs
+are opaque and need their own agent. Container attribution is best-effort and platform-gated
+(Linux cgroup full; Windows process-isolated via silo partial; otherwise none).
+
+## Considered and rejected
+
+- **Flat host-only graph** — cannot express "the CVE is on the SSH service that is actually
+  exposed" vs "a CVE on a library nothing listens on," which is the entire low-FP value of
+  prioritisation.
+- **Reusing the viz renderer's ephemeral `MachineNode`/`ProcessNode` types** — they are a
+  60s-TTL rendering projection. The analytic graph shares the *raw observation model* but
+  the derived layer (traversability, paths, chokepoints, value) is new vocabulary computed
+  on a schedule; coupling the scorer to the renderer's throwaway types was rejected.
+
+## Consequences
+
+- Local-IPC edges beyond sockets are a collection-expansion workstream (rides ADR-0003).
+- On-box *potential* reachability is feasible for the **local** graph (file/pipe/shmem ACLs
+  are locally inspectable) even though it is not for the network graph — the home-field
+  advantage inside the kernel boundary.

--- a/docs/adr/0003-telemetry-capture-model.md
+++ b/docs/adr/0003-telemetry-capture-model.md
@@ -1,0 +1,53 @@
+---
+status: accepted
+date: 2026-06-08
+owner: "@lesault (Andy Younie)"
+scope: platform — viz, vuln-scan graph, and IOC all depend on this
+---
+
+# 0003 — Telemetry capture: event-driven, edge-aggregated, federated edge warehouse
+
+## Context
+
+Connection telemetry today is **poll-based** (`/proc/net/tcp`, `GetExtendedTcpTable`,
+libproc on a 60s snapshot). Polling structurally misses short-lived connections — fatal for
+attack-path evidence ("did A ever reach B?") and C2 detection. Polling was a PoC
+convenience, not a design choice. This is a platform-level decision: the fleet visualiser,
+the vuln-scan graph, and the IOC plugin all consume the same flow telemetry.
+
+## Decision
+
+Move to **event-driven capture**, with three platform collectors converging on one
+flow-summary schema:
+
+- **Linux: eBPF** (tcp_connect/accept tracepoints) — cgroup attribution free.
+- **Windows: ETW** (Kernel-Network provider; Sysmon EID 3 reference) — Server-Silo
+  attribution for process-isolated containers; Hyper-V-isolated opaque.
+- **macOS: NetworkExtension** content filter — heavyweight (Apple entitlement + system
+  extension + user consent); **deferred/optional**. macOS endpoints participate as
+  host-granularity entry-point leaves on the existing poll path until/unless funded by
+  other features.
+
+Aggregate **at the edge** (the in-kernel-map / Cilium-Hubble / Datadog-NPM pattern) into
+flow summaries `(src, dst, port, proto, first_seen, last_seen, count)` — lossless on flow
+*existence* while keeping volume near today's poll volume. Summaries persist in the
+**agent's local SQLite warehouse** (TAR `tcp_live` precedent), retained and **not flushed**;
+each box is a leaf of a distributed SQL warehouse the server queries on demand. The raw
+event firehose **never reaches the server**.
+
+## Considered and rejected
+
+- **Ship raw events to a central columnar store (ClickHouse/Timescale).** Rejected: the
+  firehose volume at 1.2M agents is the problem edge-aggregation removes; centralising it
+  buys nothing the federated edge warehouse doesn't.
+- **eBPF-for-Windows as the Windows path.** Not mature enough to bet v1 on; ETW is the
+  production path. Revisit if the projects converge.
+
+## Consequences
+
+- One shared collection stream feeds viz + scanner + IOC — implement once.
+- `kernel boundary = visibility boundary` (ADR-0002) is enforced here: container attribution
+  is platform-gated and best-effort.
+- Detail is **pull-from-edge and online-only**; offline hosts answer only from last-known
+  summaries persisted server-side (ADR-0004). The graph carries two edge fidelities —
+  live-detail and last-known-summary (stale-flagged).

--- a/docs/adr/0004-server-storage-substrate.md
+++ b/docs/adr/0004-server-storage-substrate.md
@@ -1,0 +1,53 @@
+---
+status: proposed
+date: 2026-06-08
+owner: "@lesault (Andy Younie)"
+scope: platform — affects Guardian, viz, vuln-scan graph, offline-state, secrets
+note: contradicts the standing "SQLite for embedded storage" principle — needs wider buy-in
+---
+
+# 0004 — Introduce server-side PostgreSQL; agent SQLite stays the federated edge warehouse
+
+## Context
+
+Yuzu's stated architecture is "SQLite for embedded storage," and the server already runs
+~24 separate SQLite stores. For the vuln-scan graph alone, an embedded store would suffice
+(the *derived* graph is small). But the decision is not being made in isolation: Guardian
+wants to store more than SQLite comfortably serves at >1M agents; we need durable
+server-side state to answer about **offline endpoints**; secrets want an off-box home; and
+fuzzy software-identity → CPE matching (ADR-0005, §2.2 of the design doc) wants vector
+search. The earlier instinct to keep the graph embedded held *in isolation* but not once
+these drivers are on the table.
+
+## Decision
+
+Introduce **server-side PostgreSQL** as the substrate for the **derived scored graph +
+last-known endpoint state + the cross-store join that is the scoring operation
+(`edges ⨝ findings ⨝ value ⨝ guardian_state`) + pgvector** (identity matching). The
+**agent's SQLite warehouse stays the federated edge store** for raw flow-summary history
+(ADR-0003) — the firehose never reaches the server, which is precisely why plain Postgres
+(not a columnar engine) is sufficient: the server holds only small, derived, joinable state.
+Attack-path/chokepoint computation runs in a server background thread (the `PolicyEvaluator`
+pattern) over an in-memory adjacency loaded from Postgres; no Neo4j/pgrouting (depth-bounded
+paths don't need a graph-native store).
+
+## Considered and rejected
+
+- **Keep everything embedded in SQLite.** Correct for the graph alone; rejected once
+  Guardian-scale, offline-state, and pgvector are weighed, and because cross-store joins
+  across 24 SQLite files make scoring an application-layer join nightmare.
+- **ClickHouse for raw flow history.** Removed by ADR-0003 — the firehose stays at the edge,
+  so the server never ingests the high-cardinality time-series that would justify a columnar
+  engine.
+
+## Consequences
+
+- This **contradicts the embedded-SQLite principle** and is a real operational departure
+  (a server-attached Postgres, likely on a separate box). Surprising without this record —
+  hence the ADR. Needs wider platform buy-in before implementation.
+- **Secrets caveat (load-bearing):** "off-box durable state" ≠ "secrets in a Postgres
+  column." Secrets require envelope encryption / KMS / `pgcrypto`, a separate decision and a
+  `security-guardian` review. Do not let this ADR quietly become "we put secrets in a table."
+- Federated-pull + offline-answering tension is resolved here: the server persists
+  **last-known summaries** so offline hosts still appear (stale-flagged); fresh detail is
+  online-only.

--- a/docs/adr/0005-attack-path-and-chokepoint-scoring.md
+++ b/docs/adr/0005-attack-path-and-chokepoint-scoring.md
@@ -1,0 +1,50 @@
+---
+status: accepted
+date: 2026-06-08
+owner: "@lesault (Andy Younie)"
+---
+
+# 0005 — Attack-path & chokepoint scoring: bounded max-probability paths, ROI chokepoints
+
+## Context
+
+Raw CVSS ranking is noise at fleet scale. We want findings ranked by their position on a
+probable attack path from an entry point to a crown jewel, plus chokepoint and segmentation
+recommendations — at up to **1.2M hosts (HSBC scale)**. The naive approach (enumerate all
+attack paths) is the well-known attack-graph state explosion (worst-case factorial paths);
+generic betweenness centrality is O(V·E) and answers the wrong question.
+
+## Decision
+
+- **Attack-path scoring** — edge weight `w = -log P(traverse)` where `P(traverse)` is the
+  probability of exploiting the *destination service* on arrival (from EPSS ×
+  CVSS-exploitability × KEV × network-vs-local × auth-required — **Andy owns this function,
+  G4**). Non-negative weights ⇒ most-probable path = shortest weighted path = **Dijkstra**;
+  top-k = **Yen's k-shortest paths**; **depth-bounded** (`d ≈ 5`). The per-finding
+  attack-path score **replaces raw CVSS as the default ranking.**
+- **Chokepoints** — **path-set frequency** over the computed top-k paths, weighted by
+  `crown-jewel value × path probability` (defender ROI), **not** Brandes betweenness.
+- **Segmentation** — **cost-weighted min-cut** between entry-zone source and crown-jewel
+  sink, capacities = *defender operational cost*. Cuts **observed** paths only (ADR-0001).
+- **Multi-jewel campaign cost** — Steiner tree is NP-hard; approximate via **MST (Kruskal)
+  over the metric closure** (later, Phase 8).
+- **Scale** — tractability is N-independent (depth-bounding makes per-source cost depend on
+  the d-hop neighborhood; sources/sinks are the *declared* surface). The loading constraint
+  at 1.2M is solved by an **edge pre-filter**: agents self-flag `(has-KEV ∧ exposes-service)`,
+  `(is-crown-jewel)`, `(on-cross-trust-boundary)` as zero-message local facts; the server
+  assembles only the flagged subgraph and runs **O(depth)-round label propagation**
+  (distributed Bellman-Ford / Pregel) over it.
+- **Two-matcher split** — a deliberate, bounded exception to collect-thin: an **agent-side
+  KEV-only pre-filter** (the KEV catalog is ~1,200 CVEs, ~200× smaller than NVD) self-flags
+  candidates for pruning; the **server-side authoritative matcher** remains the only source
+  of low-FP findings. The ~200× size ratio is the line — anyone promoting the agent KEV
+  flag to an authoritative finding re-imports #1206's backport false-positives.
+
+## Consequences
+
+- **The local tripwire proposes; the bounded propagation confirms.** A local-heuristic flag
+  is never shipped as a finding.
+- **Escape hatch:** if even the pre-filtered set stops fitting centrally, push the whole
+  propagation to the agents (true distributed Pregel). Documented; not v1.
+- Andy owns the model knobs (G4 probability function, depth bound, segmentation cost model,
+  acceptance bar); Eng owns the algorithm choices, justified by tractability.

--- a/docs/vuln-scan-engine-design.md
+++ b/docs/vuln-scan-engine-design.md
@@ -1,0 +1,516 @@
+# Modern Vulnerability Detection Engine — North Star Design & Roadmap
+
+| | |
+|---|---|
+| **Status** | North Star — for review |
+| **Domain owner** | @lesault (Andy Younie) — vulnerability management |
+| **Eng partner** | TBD |
+| **Created** | 2026-06-08 |
+| **Last grilled** | 2026-06-08 (`/grill-with-docs`, fresh context — graph layer added) |
+| **Supersedes** | the static PoC matcher in `agents/plugins/vuln_scan/` |
+| **Builds on** | PR #1206 (spike — proved the rule-delivery plumbing) |
+| **Decisions of record** | ADR [0001](adr/0001-observed-grounded-reachability.md) · [0002](adr/0002-reachability-graph-data-model.md) · [0003](adr/0003-telemetry-capture-model.md) · [0004](adr/0004-server-storage-substrate.md) · [0005](adr/0005-attack-path-and-chokepoint-scoring.md) |
+| **Glossary** | `CONTEXT.md` — Reachability, Asset value (Crown jewel), Trust zone, Entry point, Attack path, Chokepoint |
+| **Plain-language version** | [`vulnerability-graph-explained.md`](vulnerability-graph-explained.md) — a non-technical intro to *why a graph*, for curious readers |
+| **Related** | `docs/capability-map.md` §9, `docs/fleet-viz-invariants.md`, `docs/scope-walking-design.md`, `docs/agent-privilege-model.md`, `docs/data-architecture.md` |
+
+---
+
+## 0. North Star in one paragraph
+
+The **floor** is a trustworthy parity scanner: collect inventory thin on the agent,
+correlate rich on the server against NVD + distro/OVAL backports + OSV + CVSS/EPSS/KEV,
+with a low false-positive rate on a real, patched fleet. The **differentiator** — the
+reason this is a Yuzu feature and not a commodity scanner — is that every finding is
+ranked by its **position on an observed attack path toward an operator-declared crown
+jewel**, and the engine recommends the **patching/segmentation with the highest defender
+ROI** (the chokepoints whose removal breaks the most attack paths). The whole thing is
+grounded in **flows our agents already observe** and vulnerabilities the *same* agent's
+inventory reveals — so it is low false-positive *by construction*, which is Yuzu's
+cornerstone.
+
+---
+
+## 1. Two layers: the floor and the differentiator
+
+### 1.1 The floor — a trustworthy parity scanner
+
+"Trustworthy" is the whole game. A scanner that cries wolf — flagging packages that are
+already patched — gets muted within a week. The bar is **low false-positive rate on a
+real, patched fleet**, not raw CVE count. The floor (Phases 1–5) brings Yuzu to parity
+with a credible commercial scanner's *detection* core. It is necessary and not
+sufficient.
+
+### 1.2 The differentiator — topology- and threat-graph-aware prioritization
+
+Raw CVSS ranking is noise at fleet scale: a "critical" on an isolated leaf that nothing
+can reach outranks a "medium" on a pivot one hop from the payments database. The graph
+layer (Phases 6–8) inverts that. It builds a **reachability graph** of the fleet, scores
+each finding by whether it sits on a **short, probable attack path** from an **entry
+point** to a **crown jewel**, and surfaces the **chokepoints** where defender effort has
+the highest payoff. This is attack-path-aware prioritization, not severity sorting.
+
+### 1.3 The honest wedge (positioning)
+
+Yuzu's wedge is **observed-grounded attack-path prioritization from telemetry the
+defender's own agents already produce.**
+
+- **vs XM Cyber / CTEM attack-path management** — they model *potential* reachability
+  scraped from firewall/AD/cloud config (high recall, high noise, and off-box data we
+  structurally cannot see). Yuzu scores paths from **flows our agents actually observed**
+  and the vulnerable service identified by the *same agent's* inventory. We trade recall
+  for trust on purpose.
+- **vs BloodHound** — it maps Active-Directory *identity* attack paths. Yuzu models
+  *network + local-IPC* reachability and explicitly does **not** build an identity graph
+  (no on-box AD telemetry — a declared non-goal).
+- **vs EPSS / CISA KEV** — not competitors but **inputs**; they weight per-hop exploit
+  probability.
+- **vs SCA "reachable vulnerability"** — that is *call-graph* reachability ("is the
+  vulnerable function invoked"). Our "reachable" means **network/IPC-reachable
+  host/service**. We keep the term unambiguous and never conflate the two.
+
+The home-field advantage no config-scraping competitor has: **observed network
+reachability *across* the kernel boundary + *potential* local reachability *inside* it**
+(file/pipe/shared-mem ACLs, sudo, setuid — all locally inspectable), composed by
+**scope-walking** into enforceable remediation targets, all on a platform the customer
+already runs.
+
+### Non-goals (this iteration)
+
+- **Network/unauthenticated scanning.** On-box and agent-based on purpose.
+- **Fabric-level potential reachability** — switch/router ACLs, cloud security groups,
+  VLAN segmentation. An on-box agent cannot see it; we never fabricate it. A seam is left
+  to *consume* it from, or *publish* our observed graph to, an upstream source later
+  (ADR-0001).
+- **Identity attack graphs** (the BloodHound space) — no on-box identity telemetry.
+- **Full SBOM/SCA** of language-ecosystem deps — valuable, later (Phase 5).
+
+---
+
+## 2. The parity floor: *collect thin, correlate rich*
+
+Modern agent-based scanners do **not** do the hard matching on the endpoint. The agent
+reports *what is installed* in a canonical form; a backend service correlates that against
+a rich, continuously-updated vulnerability data plane. This keeps the agent small and lets
+the matching logic (the hard, fast-changing part) live where it can be updated without
+touching every endpoint.
+
+```
+   ┌─────────────────────────────┐         ┌──────────────────────────────────────┐
+   │  Agent (per endpoint)        │         │  Server — Vuln Correlation Service     │
+   │  Inventory collector         │ inventory│  Identity normaliser (CPE/PURL)       │
+   │   dpkg/rpm/apk/registry/...  ├─────────►│      ▼                                 │
+   │   → name, version, source,   │  (CPE/   │  Correlation engine                    │
+   │     arch, normalized id      │   PURL)  │   • version-range matching             │
+   │  (kernel, OS build, apps as  │         │   • backport / fixed-status (OVAL)     │
+   │   additional inventory rows) │         │      ▼                                 │
+   └─────────────────────────────┘         │  Prioritiser (CVSS+EPSS+KEV+graph ctx) │
+   Vuln data plane (synced server-side):    │      ▼                                 │
+     • NVD (CPE + version ranges)           │  Findings store → dashboard/REST/MCP   │
+     • Distro advisories / OVAL             └──────────────────────────────────────┘
+       (Ubuntu USN, Debian, RHEL, Alpine)
+     • OSV.dev (pre-merged, ecosystem)
+     • CISA KEV, FIRST EPSS
+```
+
+PR #1206 put the matcher **on the agent** with a single-threshold rule list. That is the
+part Phases 1–4 replace. The agent keeps the inventory collector (the #1206 `inventory`
+action). **One deliberate, bounded exception** to collect-thin survives: a tiny **KEV-only
+pre-filter** on the agent (§4.4) — justified because the KEV catalog is ~1,200 CVEs versus
+NVD's 250k+, ~200× smaller — used *only* for graph pruning, never as an authoritative
+finding (ADR-0005).
+
+### 2.1 What the #1206 spike proved (keep this)
+
+- **Runtime rule delivery**: `update_rules` + `<data_dir>/staged/cve_rules.json` + real
+  SHA-256 integrity verification + `content_dist.stage` delivery. Rules refresh without
+  re-shipping the agent.
+- **Automated data refresh**: a weekly GitHub Actions workflow regenerates the ruleset
+  from NVD and opens a CODEOWNERS-gated PR.
+- **Inventory action**: `vuln_scan.inventory` emits `name|version` per package — the seed
+  of *collect thin*.
+- **Breadth of collection surface**: package managers across Win/Linux/macOS, kernel
+  version, file-level binary version (PE VERSIONINFO / `.app` Info.plist), CIS config
+  checks.
+- **A version comparator** that understands Debian epochs, RPM/Alpine release suffixes,
+  and semver pre-release ordering.
+
+### 2.2 The engine gap (what the parity phases fix)
+
+The matcher is still the PoC's `substring(product) && version < threshold`, fed a lossy
+keyword subset of NVD. Concrete evidence from the generated `content/cve_rules.json`:
+
+- **Coverage collapses silently.** 31 product keywords queried; only **10** produced any
+  rule. Zero rules for `linux-kernel`, `windows`, `chrome`, `python`, etc. The
+  `kernel_scan` and Windows paths have nothing to match against.
+- **Lower version bound discarded.** NVD's "2.0 ≤ v < 2.4" becomes "v < 2.4"; hosts on
+  unaffected older majors are flagged; range-less CVEs are dropped (false negatives).
+- **No backport awareness.** A patched `openssl 3.0.2-0ubuntu1.18` is compared as upstream
+  `3.0.2 < 3.0.8` and flagged. This alone makes output untrustworthy on any real Linux
+  fleet.
+- **Identity is a display-name substring**, not CPE/PURL: `python` matches `ipython`.
+- **No CVSS vector / EPSS / KEV** — severity is a bare label.
+
+These are the absence of the engine, and exactly where **Andy's domain judgment is the
+input**.
+
+---
+
+## 3. The reachability graph — model (ADR-0002)
+
+### 3.1 Observed spine (ADR-0001)
+
+The graph's spine is **observed reachability** — edges backed by flows the fleet's own
+agents actually saw. It deliberately **undercounts** what is possible (a path policy
+permits but no host exercised is invisible); that recall trade-off is accepted because
+low-FP is the cornerstone. **Potential reachability** enters only as a later, clearly
+labeled enrichment and only for the **host-firewall** slice we can structurally collect
+(§4.3). **Fabric-level reachability is out of scope** (§1 non-goals).
+
+We are not starting from zero: the server **already** builds an observed host-to-host
+graph today. `FleetTopologyStore` ingests `fleet_snapshot.v1` (per-host processes,
+connections with full 4-tuple + state + owning pid, listeners), maintains a cross-fleet
+**IP→agent_id map**, and classifies every edge `Local` / `InternalFleet` / `External`
+with `dst_agent_id` resolved for intra-fleet edges. It is in-memory only (60s TTL, no
+history) — so the graph layer is largely a **persistence + scoring** problem, not a
+greenfield collection problem.
+
+### 3.2 Nodes — host + service (two tiers)
+
+- **Host node** — the agent/device. Carries identity, asset-value rollup, and the pivot
+  capability (its outbound flows).
+- **Service node** — `(host, listening port, protocol, owning process)`. Where a CVE
+  attaches and where an inbound edge *terminates*.
+
+A host is **not** an atomic compromise unit; it is a **sub-graph of service nodes joined
+by local-IPC edges** (§3.3). **No identity/account nodes** (declared non-goal — no on-box
+identity telemetry).
+
+**Instance tiers and the kernel boundary.** One agent sees one OS kernel. Value may be
+declared on any addressable instance — **bare-metal / VM / container** — and a host's
+effective value is the **max** over its instances/services. Container attribution is
+**best-effort and platform-gated** (Linux cgroup via eBPF: full; Windows process-isolated
+via Server Silo: partial; **Hyper-V-isolated containers, Docker-on-Mac, and VMs are opaque
+kernel boundaries** that need their own agent). Standing rule: **`kernel boundary =
+visibility boundary`** — Yuzu never claims cross-kernel X-ray vision (ADR-0002, ADR-0003).
+
+### 3.3 Edges — two classes
+
+- **Network reachability edge** — `src host → dst service`, directional, observed flow.
+  Carries the existing `Local`/`InternalFleet`/`External` scope plus (once trust zones are
+  declared) the source trust tier.
+- **Local-IPC edge** — `service → service` *within* a host: Unix domain socket, named
+  pipe, shared memory, mmap, shared/world-writable file, setuid hop, sudo rule. The
+  intra-host pivot surface. **Today only sockets are observed; the IPC classes are a
+  collection-expansion workstream** that rides the event-capture rewrite (§4.2). This is
+  also where **on-box *potential* reachability is feasible** — file/pipe/shmem ACLs and
+  privilege boundaries are locally inspectable, unlike network potential reachability.
+
+An edge is merely **reachable** until its destination service carries an exploitable vuln,
+at which point it becomes **traversable** (the attack-path weight, §5.1).
+
+### 3.4 Trust zones + entry points
+
+**Trust zones** (`CONTEXT.md`) are an **operator-declared, ordered tier over labeled
+CIDRs/sites** — `internet` < `partner-extranet` (MPLS/third-party) < `branch-campus`
+(staff sites, weak physical controls) < `datacenter` (crown jewels). Declared, not
+inferred: the operator labels the ranges; Yuzu matches them against the `local_ips` and
+connection addresses it already collects. This disambiguates the blunt `External` edge
+into `internet` / `partner-extranet` / `branch`.
+
+**Entry points** are the *source set* for path enumeration: in v1, any service **exposed
+across a trust-zone boundary** (reachable from a lower-trust zone), the lowest tier being
+the public Internet. **Assume-breach** (any node as foothold) is a later, separate view
+(Phase 8), not the v1 default.
+
+### 3.5 Asset value / crown jewels
+
+Value is **operator-declared** (with inference *hints*, never auto-applied), carried by
+the **service**, rolled up to the host by **max**. Two uses of the same axis:
+
+- **Host-max** — the operator-facing "how bad is this box" number.
+- **Locally-reachable-max** — for path *scoring*, the value an attacker captures by
+  landing on a node is the max over services **locally reachable from the entry service**
+  (via §3.3 IPC edges), *not* the host-max. We don't credit an attacker with the crown
+  jewel for landing on an unrelated service on the same box — strictly more honest, lower
+  FP.
+
+---
+
+## 4. Data sources & feasibility (audited 2026-06-08)
+
+### 4.1 What we have, what we must add, what we can never get on-box
+
+| Data | Status | Source / gap |
+|---|---|---|
+| Per-host processes (pid/ppid/name/cmdline/user) | **Have** | `fleet_snapshot.v1` |
+| Per-connection 4-tuple + state + pid + PTR host | **Have** (observed) | `fleet_snapshot.v1`; **poll-based — misses short-lived flows** |
+| Listening sockets (host×port×pid) | **Have** | `fleet_snapshot.v1` `listeners[]` |
+| Cross-fleet IP→agent edge resolution | **Have** | `FleetTopologyStore` (in-memory, 60s TTL, no history) |
+| Tags (role/env/location/service) | **Have** | `TagStore` (SQLite, scope-queryable) |
+| **Crown-jewel / asset-value axis** | **Add** | new operator-declared axis (no `criticality` category today) |
+| **Trust-zone CIDR/site labels** | **Add** | new operator-authoring surface |
+| **Local-IPC edges** (pipe/shmem/file/…) | **Add** | rides event-capture rewrite (§4.2) |
+| **Container/instance attribution** | **Add** | eBPF cgroup / Windows silo; opaque across kernel boundaries |
+| **Event-driven flow capture** | **Add** | eBPF / ETW / NetworkExtension (§4.2) |
+| Persisted reachability graph + history | **Add** | server Postgres + agent edge warehouse (§4.5, ADR-0004) |
+| **Host-firewall potential reachability** | **Add (hard)** | firewall plugin reads rules as **unstructured text only**; no structured `(port,proto,CIDR,default-policy)` on any OS — needs real parsing |
+| **Fabric reachability** (switch ACL, cloud SG, VLAN) | **Never on-box** | out of scope; upstream seam only (ADR-0001) |
+
+### 4.2 Capture model: poll → event (ADR-0003)
+
+Polling (`/proc/net/tcp`, `GetExtendedTcpTable`, libproc on a 60s snapshot) structurally
+misses short-lived connections — fatal for attack-path evidence and C2 detection. Move to
+**event capture**, three platform collectors converging on one flow-summary schema:
+
+- **Linux: eBPF** (tcp_connect/accept tracepoints) — mature; cgroup attribution free.
+- **Windows: ETW** (Kernel-Network provider; Sysmon EID 3 reference) — mature; silo
+  attribution for process-isolated containers; Hyper-V-isolated opaque.
+- **macOS: NetworkExtension content filter** — heavyweight (Apple entitlement + system
+  extension + consent); **deferred/optional**, justified by other features if at all.
+  (Endpoint Security has no network-flow event.)
+
+**Edge-aggregation, not firehose.** Collapse the event stream **in-kernel/at the edge**
+into flow summaries `(src, dst, port, proto, first_seen, last_seen, count)` (the
+Cilium/Hubble, Datadog-NPM pattern). Lossless on *existence* of a flow (all reachability
+needs) while keeping volume near today's poll volume. The summary history stays in the
+**agent's local SQLite warehouse** (TAR `tcp_live` precedent), retained, **not flushed** —
+each box is a leaf of a distributed SQL warehouse the server queries on demand.
+
+**macOS plays a different graph role anyway.** Laptops are **entry points** (initial
+access), not value sinks; their graph role needs only *outbound* flows, which the existing
+poll path already gives. Data difficulty is anti-correlated with data need.
+
+### 4.3 Potential reachability (later enrichment)
+
+The firewall plugin today reads firewall on/off and dumps rules as **unstructured text**
+(Linux iptables/ufw/firewalld, macOS pf) or partially-structured-but-incomplete (Windows
+netsh, inbound only). It cannot compute "what would this host accept." A later enrichment
+adds **structured host-firewall parsing** → per-host `(port, proto, allowed-source)` →
+*host-firewall potential* edges, clearly labeled and never merged with observed edges.
+This is also what would tighten segmentation min-cuts (§5.3). Fabric potential stays out
+of scope.
+
+### 4.4 The two-matcher split (ADR-0005)
+
+| | Server-side authoritative matcher | Agent-side KEV pre-filter |
+|---|---|---|
+| Job | Trustworthy findings — backport-correct, CPE/PURL, version ranges | Cheap local self-flag: "I *might* have a KEV on an exposed service" |
+| FP posture | Low-FP, authoritative (the product output) | FP-tolerant — a pruning hint, never a verdict |
+| Edge data | none (collect-thin) | the KEV catalog only (~1,200 CVEs) |
+| Justification | consistency, freshness control, don't ship NVD/OVAL to 1.2M endpoints | KEV is ~200× smaller than NVD — *that ratio is the line* |
+
+The agent self-flag answers a **node/vuln** question (local, cheap); the **edge/graph**
+questions (reachable-from-low-trust? reaches-a-jewel?) stay server-side propagation. The
+flag makes a node a **candidate**, not a finding.
+
+### 4.5 Storage substrate (ADR-0004)
+
+- **Agent SQLite** — the federated edge flow-summary warehouse (retained, not flushed),
+  queried on demand. The firehose never reaches the server.
+- **Server PostgreSQL** — the derived scored graph + last-known endpoint state (offline
+  answering) + the cross-store join that *is* the scoring operation
+  (`edges ⨝ findings ⨝ value ⨝ guardian_state`) + pgvector (fuzzy software-identity →
+  CPE matching, attacking §2.2's `python`/`ipython` problem). Justified for the server by
+  Guardian volume at >1M agents and offline-state needs beyond what 24 separate SQLite
+  stores serve.
+- **Secrets caveat** — "off-box durable state" ≠ "secrets in a Postgres column." Secrets
+  need envelope encryption / KMS, a separate decision and review.
+
+### 4.6 Requirement ownership
+
+| # | Requirement | Owner |
+|---|---|---|
+| R1 | Canonical identity (CPE 2.3 / PURL, not display name) | Eng, Andy validates key products |
+| R2 | Version-range semantics (`versionStart*`/`End*`, multi-range) | Eng |
+| R3 | Backport/fixed-status (USN/Debian/RHEL-OVAL/Alpine secdb) | **Andy** — feeds, distro order |
+| R4 | Data sources & freshness SLO | **Andy** |
+| R5 | Prioritisation (CVSS+EPSS+KEV+graph ctx) | **Andy** — scoring model |
+| R6 | Coverage (full NVD + kernel + OS + apps) | Andy + Eng |
+| R7 | Acceptance / quality bar (precision/recall, zero-FP ref box) | **Andy** |
+| R8 | SBOM/SCA (later) | Andy + Eng (Phase 5) |
+| **G1** | **Reachability data strategy** (observed spine, potential scope) | **Andy** (ADR-0001) |
+| **G2** | **Trust-zone taxonomy** (the tiers, their CIDR/site labels) | **Andy** |
+| **G3** | **Crown-jewel definition + inference hints** | **Andy** |
+| **G4** | **Traversability probability function** (EPSS/CVSS-exploitability/KEV/auth → P) | **Andy** — heart of the model |
+| **G5** | **Depth bound, entry-point definition, segmentation cost model** | **Andy** |
+| **G6** | **Acceptance bar for rankings** (match expert intuition on a reference topology) | **Andy** |
+
+---
+
+## 5. Algorithms (ADR-0005)
+
+We **do not enumerate attack paths** (the attack-graph state explosion). Instead:
+
+### 5.1 Attack-path scoring — depth-bounded max-probability paths
+
+Edge weight `w = -log P(traverse)` where `P(traverse)` = probability of exploiting the
+**destination service** given reachability (from EPSS × CVSS-exploitability × KEV ×
+network-vs-local × auth-required — **G4, Andy's model**). Non-negative weights ⇒
+**most-probable path = shortest weighted path = Dijkstra**; top-k = **Yen's k-shortest
+paths**; **depth-bounded** (`d ≈ 5`) because real breaches are 2–4 hops and depth-bounding
+is both a tractability and a precision lever. Output: a **per-finding attack-path score
+that replaces raw CVSS as the default ranking.**
+
+### 5.2 Chokepoints — path-set frequency, not Brandes betweenness
+
+Generic betweenness is O(V·E) *and* wrong (weights all-pairs equally). A chokepoint is a
+node/edge appearing in many of the already-computed top-k entry→jewel paths, weighted by
+`crown-jewel value × path probability` — a direct **defender-ROI** number, nearly free.
+
+### 5.3 Segmentation — cost-weighted min-cut
+
+Min-cut (Menger) between the entry-zone super-source and crown-jewel super-sink, on the
+small relevant subgraph, with **capacities = defender operational cost** (a firewall rule
+is cheap; isolating a prod host is expensive). Yields ranked "patch/isolate host X" (node
+cut) or "block port X→Y" (edge cut). **Honest caveat:** cuts *observed* paths only;
+policy-permitted-but-unobserved paths remain until §4.3 enrichment lands.
+
+### 5.4 Multi-jewel campaign cost — Kruskal/Steiner (later)
+
+For "cheapest campaign to take *all* the jewels," the minimum **Steiner tree** is NP-hard;
+the 2-approximation is **MST (Kruskal) over the metric closure** of `{entry} ∪ {jewels}`.
+A `≥2`-fan-out-toward-value local flag is a sensible **Steiner-branch-point** seed.
+(Minimax/MST also gives a "patch the single hardest hop" weakest-link lens — a *different*
+question from our multiplicative whole-chain model; offered as an alternate view.)
+
+### 5.5 Edge pre-filter + server propagation; the scale story
+
+Compute lives in a **server-side background thread** (the `PolicyEvaluator` pattern:
+store-pointer deps, lock-released-before-IO, joined-before-stores), ticking on a *cadence*,
+reading the Postgres graph into an in-memory adjacency.
+
+**Tractability is N-independent** because (a) depth-bounding makes per-source cost depend
+on the *d-hop neighborhood*, not on N, and (b) sources/sinks are bounded by the *declared*
+entry/jewel surface, not fleet size. The remaining constraint is graph *loading* at
+**1.2M hosts (HSBC scale target)** — solved by the **edge pre-filter**: every agent
+self-flags `(has-KEV ∧ exposes-service)`, `(is-crown-jewel)`, `(on-cross-trust-boundary)`
+as zero-message local facts, and **the server assembles only the flagged subgraph + its
+connecting edges.** Even a pessimistic 5% survival = ~60k host-nodes — trivial for central
+propagation. Value-reachability is computed by **O(depth)-round label propagation**
+(distributed Bellman-Ford / Pregel "think-like-a-vertex"), run server-side over the pruned
+graph. **Escape hatch:** if even the pruned set ever stops fitting centrally, push the
+propagation to the agents (true distributed Pregel) — documented, not v1.
+
+**The local tripwire proposes; the bounded propagation confirms.** A local-heuristic flag
+is never shipped as a finding.
+
+---
+
+## 6. From finding to action — scope-walking
+
+The graph layer *produces host sets* (hosts on a probable attack path to a jewel; the
+chokepoint hosts). **Scope-walking materializes those as result sets**
+(`from_result_set:<id>`) that are immediately actionable — patch them, target a Guardian
+baseline at them, re-scan them, run an instruction — with `parent_id` lineage giving the
+audit chain "this remediation targeted the output of that attack-path analysis." Scope-
+walking is **not** how the graph is built (result sets hold device sets, not edges); it is
+how the graph's **conclusions become enforcement** — a primitive no standalone scanner has.
+
+---
+
+## 7. Phased roadmap
+
+Each phase is a shippable slice with an Andy-owned acceptance bar.
+
+**Parity floor**
+
+- **Phase 0 — Spike (DONE, #1206).** Rule-delivery plumbing, inventory action, collection
+  breadth. *Outcome: plumbing proven; matcher acknowledged PoC-grade.*
+- **Phase 1 — Server-side correlation MVP.** Inventory emits normalised identity
+  (CPE/PURL + source + arch); server matches against an NVD mirror with **real
+  version-range logic** for a pilot product set. *Acceptance: match parity vs a
+  hand-labelled reference host; no lower-bound FPs.*
+- **Phase 2 — Backport correctness (the FP killer).** Distro-advisory/OVAL correlation so
+  patched packages report clean. *Acceptance: a fully-patched Ubuntu + RHEL box returns
+  ZERO package CVEs.* This is what makes the product trustworthy.
+- **Phase 3 — Prioritisation.** CVSS vector + EPSS + KEV on every finding; ship the `kev`
+  flag in the rule + result schema (enables §4.4). *Acceptance: the scoring model and
+  default thresholds.*
+- **Phase 4 — Coverage breadth.** Full ingest; kernel (fix CPE identity), Windows (MSRC),
+  endpoint apps; pgvector-assisted identity matching. *Acceptance: target product list
+  covered; recall measured against a known-vulnerable set.*
+- **Phase 5 — SBOM / SCA.** Language-ecosystem deps. *Acceptance: later.*
+
+**Graph differentiator**
+
+- **Phase 6 — Topology ingest & persistence.** Persist the observed reachability graph
+  (server Postgres + agent edge warehouse, ADR-0004); event-capture rewrite begins
+  (ADR-0003); **trust-zone authoring** + **crown-jewel authoring** surfaces.
+  *Acceptance (Andy): the persisted graph faithfully reproduces a known reference topology;
+  trust zones and crown jewels are authorable and queryable.*
+- **Phase 7 — Attack-path scoring.** §5.1 + §5.5 (Dijkstra/Yen, edge pre-filter, server
+  propagation). **Per-finding attack-path score replaces CVSS as the default ranking.**
+  *Acceptance (Andy): on a reference topology, the top-ranked findings are the ones the
+  expert agrees are scariest; the ranking inverts at least one "critical-CVSS-but-isolated
+  < medium-CVSS-on-pivot" case correctly.*
+- **Phase 8 — Chokepoints & segmentation.** §5.2 + §5.3 (path-set-frequency chokepoints,
+  cost-weighted min-cut recs); assume-breach as a second view; Kruskal/Steiner multi-jewel
+  campaign cost. *Acceptance (Andy): the #1 recommended segmentation actually breaks the
+  most at-risk value per unit effort on a reference topology.*
+
+---
+
+## 8. Quality bar
+
+- **Precision** ≥ target on a labelled fleet (backport FPs the main enemy; a patched
+  reference box reports clean).
+- **Recall** ≥ target against a known-vulnerable set — *and* an honest recall statement
+  for the graph: observed reachability undercounts potential.
+- **Freshness**: data-plane sync SLO (e.g. ≤ 24h from advisory publication).
+- **On-box cost**: inventory + flow-summary aggregation bounded (CPU/mem/time per scan).
+- **Scale**: tractable to **1.2M hosts** via edge pre-filter + depth-bounded propagation.
+- **Honesty**: until Phase 2 lands, `capability-map.md` describes this as an early
+  heuristic matcher, **not** "modern vulnerability scanning"; until Phase 7, no attack-path
+  claims.
+
+---
+
+## 9. Open decisions for Andy (resolved ones marked ✓)
+
+1. ✓ **Observed-grounded spine; fabric out of scope, upstream seam only** (ADR-0001).
+2. ✓ **Node model: host + service; host = sub-graph of services + local-IPC edges; no
+   identity nodes** (ADR-0002).
+3. ✓ **Capture: event-driven (eBPF/ETW/NE), edge-aggregated, federated edge warehouse**
+   (ADR-0003).
+4. ✓ **Storage: server Postgres + agent SQLite edge warehouse; secrets separate**
+   (ADR-0004).
+5. ✓ **Value: service-carried, max-rollup, operator-declared + hints; crown jewel new &
+   orthogonal.**
+6. ✓ **Trust zones: operator-declared CIDR/site tiers; v1 default = cross-trust-zone
+   exposure.**
+7. ✓ **Algorithms: depth-bounded max-probability paths; path-set-frequency chokepoints;
+   cost-weighted min-cut; Kruskal-Steiner for multi-jewel (later)** (ADR-0005).
+8. **Primary correlation data source?** (OSV.dev vs NVD+OVAL composition.)
+9. **Distro priority order** for backport feeds?
+10. **G4 — the traversability probability function** (the scoring model's heart).
+11. **G5 — depth bound, segmentation cost model.**
+12. **G6 — acceptance thresholds + the reference fleet/topology.**
+13. **Target product/coverage list** for Phase 1 pilot and Phase 4 breadth.
+
+---
+
+## Appendix A — Evidence from the #1206 spike
+
+- Configured keywords: 31. Products with ≥1 generated rule: **10** (`apache, curl, log4j,
+  nginx, openjdk, openssh, openssl, polkit, sudo, 7-zip`).
+- Zero rules: `chrome, confluence, docker, dotnet, exim, firefox, git, grafana, jenkins,
+  kubernetes, linux-kernel, mysql, postfix, postgresql, putty, python, samba, windows,
+  winrar`.
+- `kernel_scan` (Linux/macOS) and the Windows path have no rules to match.
+- Matching primitive: `icontains(app.name, rule.product) && compare_versions(app.version,
+  affected_below) < 0`. Rule schema collapses NVD ranges to a single `affected_below`,
+  discarding lower bounds; CVEs without a single end bound are dropped.
+
+## Appendix B — Decisions of record (ADRs)
+
+- **ADR-0001** — Observed-grounded reachability (observed vs potential; fabric out of scope).
+- **ADR-0002** — Reachability graph data model (host+service nodes, local-IPC edges, trust
+  zones, crown-jewel value, kernel-boundary rule).
+- **ADR-0003** — Telemetry capture model (poll→event eBPF/ETW/NE; edge aggregation;
+  federated edge warehouse).
+- **ADR-0004** — Server storage substrate (Postgres under the server; agent SQLite edge
+  warehouse; secrets caveat).
+- **ADR-0005** — Attack-path & chokepoint scoring (depth-bounded max-probability paths;
+  path-set-frequency chokepoints; cost-weighted min-cut; two-matcher KEV pre-filter;
+  distributed-Pregel escape hatch).

--- a/docs/vulnerability-graph-explained.md
+++ b/docs/vulnerability-graph-explained.md
@@ -1,0 +1,346 @@
+# Seeing the Map, Not the List
+
+### A plain-language guide to how Yuzu finds the vulnerabilities that actually matter
+
+*No technical background needed. If you're curious about why we keep talking about
+"graphs" and "attack paths," this is the document for you. It's the friendly companion
+to the engineering design in [`vuln-scan-engine-design.md`](vuln-scan-engine-design.md);
+you can read this one on its own.*
+
+---
+
+## The problem: drowning in a list
+
+Every tool that scans computers for security weaknesses produces the same thing — **a
+list**. A very, very long list. A medium-sized company might get back tens of thousands
+of entries: *this program is out of date, that one has a known flaw, this setting is
+risky.*
+
+To help you cope, each item comes with a severity score from 1 to 10. So you sort the
+list by severity, start at the top, and begin fixing. Sensible, right?
+
+Here's the trouble. That severity score answers only one question: **"How bad is this
+flaw *in the abstract*?"** It says nothing about a far more important question: **"How
+bad is this flaw *for us, right here*?"**
+
+A "critical, 9.8" flaw on a machine that sits in a locked closet, that nothing else can
+reach, that holds nothing valuable, is — in real life — not very dangerous at all. And a
+"medium, 5.5" flaw on a machine that an outsider can touch, and that can in turn reach
+the database holding all your customers' money, might be the **most dangerous thing you
+own**.
+
+The list can't tell the difference. It treats every machine as an island. So teams end
+up patching the *loudest* thing instead of the *most dangerous* thing, and the truly
+scary problems hide in plain sight, halfway down a list of ten thousand.
+
+---
+
+## A better question
+
+Imagine your company's computers as **rooms in a large building**. (Really, each program
+running on a machine is its own little room — but picture one room per machine for now.)
+
+A security flaw is like **a faulty lock** on one of those rooms. The severity score is
+just *how easy that particular lock is to pick.*
+
+But a burglar doesn't care only about lock difficulty. A burglar cares about **getting
+from the street to the vault.** A picked lock on a 40th-floor room with no stairs leading
+anywhere is useless to them. A slightly tougher lock on the room *next to the vault*, in
+a hallway that connects straight to the front door — that's the one they want.
+
+So the question that actually keeps a security team up at night isn't *"Which of my locks
+are weakest?"* It's:
+
+> **"If someone broke in through a door, could they make their way — room by room — to
+> something I truly care about? And if so, how?"**
+
+That is a question about **how the rooms connect.** And a plain list of rooms, no matter
+how well sorted, simply cannot answer a question about *connections*. For that, you need
+something a list can never be.
+
+You need a **map.**
+
+---
+
+## So… what on earth is a "graph"?
+
+This is the word that makes people's eyes glaze over, so let's defuse it immediately.
+Forget bar charts and maths class. In this world, a **graph** is just two things:
+
+- **Dots** — the *things*. (Engineers call them "nodes.")
+- **Lines** — the *connections between things*. (Engineers call them "edges.")
+
+That's the entire idea. Dots and lines.
+
+```
+        [ Laptop ] ───── [ Build server ] ───── [ Database ]
+                                │
+                          [ File store ]
+```
+*Four "dots" (computers), connected by "lines" (the fact that they talk to each other).
+That is a graph. Nothing more.*
+
+You already understand graphs perfectly, because you use them every day:
+
+- A **social network** is a graph: people are dots, friendships are lines.
+- A **subway map** is a graph: stations are dots, the tracks between them are lines.
+- A **family tree** is a graph: people are dots, "parent of" is a line.
+
+And here's the magic that makes a map more powerful than a list. Once you have the dots
+*and* the lines, you can ask the one question a list never could: **"How do I get from
+here to there?"**
+
+That's exactly what your phone's map app does when it finds you the fastest route across
+a city. It isn't looking at a *list* of streets — it's looking at a *map* (a graph!) of
+how streets connect, and tracing a path through it. Finding good paths through a graph is
+one of the most well-understood, reliable kinds of computing there is. The same maths
+that routes your morning commute can route an imaginary burglar through your building.
+
+**That is why we use a graph.** Not because it's fashionable, but because security is,
+at its heart, a question about connections — and a graph is the one tool built to answer
+connection questions.
+
+---
+
+## Why a graph is *exactly* the right tool for security
+
+Here's the insight that ties it all together.
+
+**A real attacker does not attack one computer.** They *move.* They slip in somewhere
+soft — a forgotten laptop, an exposed website, a phished employee — and then they hop:
+from that first machine to the next, to the next, patiently working their way toward
+something worth stealing. Security people call this "lateral movement," but you can just
+call it **walking through the building.**
+
+That journey — *first room, then the next room, then the next, all the way to the vault*
+— is literally a **path through a graph.**
+
+Which means: if you have the map, you can trace those paths **before the attacker walks
+them.** You can stand at the front door, look at your own building, and say: *"From here,
+the shortest way to the vault goes through these three rooms — and look, the lock on the
+second one is broken."* You can see the danger in advance, as a route, not as a number.
+
+A list can't do that. A map can. Security was always a map problem; most tools just never
+bothered to draw the map.
+
+---
+
+## Yuzu's unfair advantage: a map drawn from real life
+
+Now, plenty of clever security companies have realised that maps beat lists. So what makes
+Yuzu's map special? **Where the map comes from.**
+
+Most tools that try this have to *guess* the map. They read configuration files — firewall
+rules, cloud settings, network blueprints — and from those they infer which rooms *could*
+connect to which. It's like drawing a map of a building by reading the original architect's
+plans. The problem: plans are often wrong, out of date, or describe doors that were bricked
+up years ago. So the map is full of hallways that don't really exist, and it cries wolf
+constantly.
+
+**Yuzu draws its map from real life.** Because Yuzu already has a small piece of software
+running on every machine, it can simply *watch which machines actually talk to each other* —
+the real foot traffic through the building, observed as it happens. Our map isn't the
+architect's optimistic blueprint; it's a record of the doors people **actually walk
+through.**
+
+This is a genuinely big deal, and it's the reason Yuzu can be **trustworthy** — which is
+the whole point of the product. A map built from real traffic produces far fewer false
+alarms than a map guessed from paperwork. When Yuzu says *"this is a route to your crown
+jewels,"* it's because that route is really used, not because a config file hinted it might
+exist.
+
+There's an honest trade-off, and we believe in stating it plainly: by watching only the
+doors people *actually* use, we might occasionally miss a door that *could* be opened but
+never has been. We accept that. **We would much rather be quiet and right than loud and
+wrong.** A tool you can trust is a tool you'll act on; a tool that cries wolf gets switched
+off within a week.
+
+---
+
+## What the map lets us do: three new powers
+
+Once you have an honest map of your building, three things become possible that a list
+could never offer.
+
+### 1. Find the routes that actually matter
+
+Instead of handing you *"you have 10,000 problems, good luck,"* Yuzu can say:
+
+> *"Here are the five short, realistic routes an intruder could take from an outside door
+> all the way to your most valuable systems — and here is the broken lock that starts each
+> one."*
+
+The findings get ranked **by the route they sit on**, not by their abstract scariness. The
+medium flaw on the stepping-stone machine — the one that opens the door to a path toward
+the vault — now correctly outranks the "critical" flaw on the island that leads nowhere.
+That single re-ordering is the heart of the whole idea. *(The engineers call one of these
+routes an "attack path.")*
+
+### 2. Judge a flaw by *where it sits*, not just how loud it is
+
+Picture the floor plan again. Some hallways are quiet dead-ends. Others are the busy
+central corridor that nearly every route to the vault has to pass through.
+
+A broken lock on the busy central corridor is **far** more dangerous than the identical
+broken lock in a quiet broom closet — not because the lock is different, but because of
+*where it is.* Yuzu scores each weakness by its **position** in the map: how many of the
+dangerous routes run through it. Position, not just severity.
+
+### 3. Find the chokepoints — the highest-payoff fixes
+
+This is the most valuable power of all, and it's pure defender's economics.
+
+If forty different break-in routes all funnel through **one** particular hallway, then
+putting a single wall across that hallway doesn't close one route — it closes *forty.*
+Yuzu hunts for exactly these spots: the **chokepoints** where one well-chosen fix — a
+patch, a closed connection, a new wall between two areas — breaks the most attack routes
+at once.
+
+So instead of *"here are 200 things to fix,"* you get *"do this **one** thing first; it
+protects more than the next twenty combined."* That's the difference between a to-do list
+and a *plan.* *(Engineers call these high-value fixes "chokepoints," and the "build one
+wall to close the most routes" calculation has a precise mathematical answer.)*
+
+---
+
+## Who decides what's precious — and where danger comes from?
+
+Two things in this picture are **your** call, not ours, and that's by design.
+
+**What counts as a "crown jewel"?** Yuzu does *not* presume to know which of your systems
+matter most. Is it the payments database? The patient records? The trading platform? Your
+own experts mark those — the "vaults" the whole analysis aims at. We bring the map and the
+maths; you bring the judgment about what's worth protecting. *(In the engineering docs,
+these precious systems are called "crown jewels.")*
+
+**Where do attackers come from?** Not every entrance is equally risky. The public internet
+is the wild street outside. A partner company's network, reaching in over a private link,
+is a side door. The staff WiFi at a branch office — with far weaker physical security than
+a locked datacentre — is another. Your team labels these entrances by how exposed they are,
+and Yuzu treats each as a possible starting point for an intruder. *(Engineers call these
+labelled areas "trust zones.")*
+
+In short: **you** declare what's precious and where danger starts; **Yuzu** does the
+tireless work of tracing every route between the two and ranking them.
+
+---
+
+## A story, to make it real
+
+Let's walk through a day in the life of this idea at an imaginary finance company.
+
+An intern's laptop, sitting on the office WiFi, is running a slightly out-of-date chat
+application. That app has a known flaw. On its own, the severity is **medium** — a 5 out
+of 10. In a traditional scanner, this entry sits unremarkably around line 4,000 of the
+report, buried beneath hundreds of "criticals." Nobody will ever get to it.
+
+But look at what Yuzu's map reveals:
+
+```
+   STAFF WIFI                                              THE VAULT
+   (an entrance)                                       (a "crown jewel")
+        │                                                     ▲
+        ▼                                                     │
+   [Intern laptop] ──talks to──→ [Build server] ──talks to──→ [DB gateway] ──→ [Payments DB]
+     broken lock                                                                 the money
+        (1)                          (2)                          (3)
+```
+
+That intern's laptop *regularly talks to* a build server. The build server *talks to* a
+database gateway. And the gateway *can reach the payments database* — the company's single
+most precious system. Three hops. A short, real road from a forgotten laptop to the money.
+
+Yuzu surfaces that medium-severity laptop flaw as **finding number one**, because it's the
+beginning of the shortest genuine route to a crown jewel. The old tool's 4,000 "criticals"
+on dead-end machines drop below it, exactly where they belong.
+
+And then the chokepoint analysis adds the move that a list could never suggest. It points
+out that the single highest-payoff action **isn't even patching the laptop.** It's putting
+a wall between the build server and the database gateway — because that one wall doesn't
+just break this path, it breaks *forty other* routes that all squeeze through the same
+spot. One change. Forty roads closed. *That's* the recommendation that lands on the
+security team's desk first.
+
+That is the entire product in one story: from *"here are ten thousand problems sorted by
+how scary each sounds"* to *"here is the one road to your money, and the one wall that
+closes the most roads."*
+
+---
+
+## Being honest about what we *can't* see
+
+A trustworthy tool has to be candid about its blind spots, so here are ours.
+
+Yuzu sees the world from *inside* each of your machines. That gives it a wonderful view:
+the real conversations between machines, and what's locked (or unlocked) within each one.
+There's even a special advantage here — from inside a machine, Yuzu can see fine details
+about how one program could quietly hand control to another *on the same machine*, a kind
+of internal pathway that a tool peering only at the network from outside would entirely
+miss.
+
+But Yuzu does **not** see the building's hidden wiring behind the walls — the deep network
+plumbing, the cloud provider's own controls, the configuration of physical network gear.
+That's a different blueprint, owned by a different team, and **we refuse to pretend we have
+it.** Where that information matters, we leave a clean way to plug it in later from a system
+that *does* have it — but we will never fabricate a map we can't actually see. Quiet and
+right beats loud and wrong, every time.
+
+---
+
+## Why this is *part of* Yuzu, not a bolt-on
+
+You might reasonably ask: couldn't you buy a separate product for this? Here's why it lives
+naturally inside Yuzu.
+
+- **It uses information we already gather.** The map is drawn from machine-to-machine
+  traffic that Yuzu's software already observes for other reasons. We're not asking you to
+  install yet another agent or open yet another data feed.
+- **It runs on the platform you already have.** No new console to learn, no separate world
+  to manage.
+- **And — crucially — it turns a finding straight into an action.** Other tools hand you a
+  prettier list and wish you luck. Because Yuzu also *manages* your machines, the moment it
+  identifies "these are the machines on the dangerous route" or "wall off this connection,"
+  it can hand that set of machines directly to the part of Yuzu that *fixes things* — patch
+  them, isolate them, enforce a rule on them. The insight and the cure live in the same
+  place.
+
+It isn't another dashboard of problems. It's a prioritised plan, with the reasoning shown,
+wired directly to the levers that resolve it.
+
+---
+
+## The whole idea, in one breath
+
+Traditional scanning hands you **a list of every problem, sorted by how frightening each
+one sounds in isolation.**
+
+Yuzu hands you **a map of how an intruder could actually move through your systems toward
+the things you care about most — the real routes, ranked by danger, and the single fixes
+that close the most routes at once.**
+
+From a list to a map. From noise to a plan. From *"how bad is this flaw?"* to *"could this
+flaw get someone to the vault — and what's the one wall that stops the most of them?"*
+
+That's the shift. Everything else is detail.
+
+---
+
+## If you'd like the real vocabulary
+
+Curious enough to want the proper terms? Here's the plain-language idea mapped to the words
+the engineering team uses — so you can follow along in the technical docs and the glossary
+(`CONTEXT.md`):
+
+| In this guide | The real term | What it means |
+|---|---|---|
+| The map of who-talks-to-whom | **Reachability graph** | The dots-and-lines picture of which machines can reach which |
+| Drawn from real foot traffic | **Observed reachability** | Built from connections we actually saw, not guessed from config |
+| A room / what's running in it | **Host** / **Service** | A machine, and the individual programs on it |
+| A route from a door to the vault | **Attack path** | A realistic chain of hops from an entrance to something precious |
+| The busy hallway everyone passes through | **Chokepoint** | A spot where one fix breaks the most routes |
+| What's precious | **Crown jewel** | The systems you mark as most valuable to protect |
+| The different entrances and their risk | **Trust zone** | Labelled areas (internet, partner link, staff WiFi, datacentre) ranked by exposure |
+
+When you're ready for the full picture — including how we keep this accurate at the scale
+of over a million machines — the engineering design lives in
+[`vuln-scan-engine-design.md`](vuln-scan-engine-design.md).

--- a/site/src/nav.mjs
+++ b/site/src/nav.mjs
@@ -49,6 +49,12 @@ export const NAV = [
     ],
   },
   {
+    heading: 'Vulnerability Management',
+    entries: [
+      { file: 'vulnerability-graph-explained', slug: 'vulnerability-graph', title: 'Vulnerability Graph, Explained' },
+    ],
+  },
+  {
     heading: 'Identity & Access',
     entries: [
       { file: 'user-manual/authentication', slug: 'authentication', title: 'Authentication' },


### PR DESCRIPTION
## What

Brings the **documentation** produced in the vuln-scan `/grill-with-docs` session to `dev`, **independent of the spike code** (which stays in #1206 — this PR does not touch it).

- **`docs/vuln-scan-engine-design.md`** — restructured into a **North Star**. The collect-thin / correlate-rich parity engine is the **floor (Phases 1–5)**; the differentiator is a topology- and threat-graph-aware layer: **Ph6 topology ingest → Ph7 attack-path scoring (replaces CVSS ranking) → Ph8 chokepoints/segmentation.** Grounded in an audit of what the agent actually collects today.
- **`docs/adr/0001–0005`** — decisions of record:
  - 0001 observed-grounded reachability (recall traded for trust; fabric out of scope)
  - 0002 host + service graph data model (no identity nodes; `kernel boundary = visibility boundary`)
  - 0003 telemetry capture poll→event (eBPF / ETW / NetworkExtension; federated edge warehouse)
  - 0004 server-side Postgres — **`proposed`; contradicts the embedded-SQLite principle; needs wider platform buy-in**
  - 0005 attack-path & chokepoint scoring (depth-bounded most-probable paths; ROI chokepoints; cost-weighted min-cut; KEV edge pre-filter at 1.2M scale)
- **`CONTEXT.md`** — new glossary terms: Reachability, Asset value (Crown jewel), Trust zone, Entry point, Attack path, Chokepoint.
- **`docs/vulnerability-graph-explained.md`** — plain-language companion for a non-technical audience ("why a graph at all"); **surfaced on the docs site** (new "Vulnerability Management" nav section in `site/src/nav.mjs`).

## Why a separate PR

#1206 is a fork-based **spike** carrying the vuln_scan engine *code*. This work is **design documentation** that should live on `dev` on its own merits, ahead of / independent of that code. Keeping them separate avoids entangling the docs with the spike's lifecycle.

## Notes for review

- **Docs only — no engine code.**
- **ADR-0004 (server Postgres) is `proposed`**, not accepted — it's a platform-level call (Guardian scale, offline state, pgvector) that deviates from "SQLite for embedded storage," with a secrets-handling caveat for `security-guardian`.
- Domain calls (primary correlation source, distro priority, the **G4 traversability-probability function**, acceptance bar) remain @lesault's — see design doc §9.
- **Verification:** diagram linter passes (40 docs); full `npm run build` clean (45 pages, pagefind indexed).

Related: #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)
