### PR TITLE
docs(adr): Postgres substrate architecture decisions (ADR-0007/0008/0009)

### DIFF
--- a/docs/adr/0007-server-single-backend-no-sqlite-fallback.md
+++ b/docs/adr/0007-server-single-backend-no-sqlite-fallback.md
@@ -1,0 +1,55 @@
+---
+status: accepted
+date: 2026-06-09
+owner: Nathan Dornbrook (platform)
+deciders: Nathan Dornbrook; grill-with-docs design session 2026-06-09
+scope: platform — the server storage layer architecture
+builds-on: ADR-0006 (PostgreSQL is the server substrate)
+---
+
+# 0007 — The server is single-backend: PostgreSQL only, no SQLite fallback
+
+## Context
+
+ADR-0006 made PostgreSQL the server-side storage substrate. That leaves an immediate
+architectural fork: do we *also* keep SQLite as a selectable single-node/dev fallback behind a
+storage abstraction (dual-backend), or do we commit to one engine on the server (single-backend)?
+
+The server runs ~29 concrete stores, each talking to `sqlite3*` directly with **no interface
+abstraction** today. A dual-backend world would require introducing a real abstraction over
+*both* engines and implementing every store twice. The pull toward keeping SQLite is the
+zero-config, single-binary "just run the server" experience that is genuinely nice for evals,
+demos, and tiny single-node installs.
+
+## Decision
+
+**The server is single-backend: PostgreSQL only. There is no server-side SQLite fallback.**
+The storage layer abstracts over *one* engine, not two. The convenience of zero-config
+single-node is recovered at the **deployment** layer instead of the **code** layer — a bundled
+`yuzu-postgres` image in the composes and an install script that provisions a local Postgres
+(ADR-0008 / the migration plan), not a second engine kept alive in C++.
+
+The agent remains SQLite (ADR-0006) — this decision is about the *server* only.
+
+## Considered and rejected
+
+- **Dual-backend behind a storage seam.** Rejected. With ~29 stores and no existing
+  abstraction, every store would be implemented twice, migrations would exist twice, and the
+  server test matrix would roughly double — a permanent tax on every future store and every
+  bug fix. The single-node convenience does not justify a forever-doubled maintenance and test
+  surface, especially when deployment-layer bundling recovers most of it.
+- **Hard-require Postgres but auto-provision an embedded Postgres inside the server binary.**
+  Rejected for the foundation. It keeps one engine in the code (good) but loads the server
+  process with embedded-distribution management and lifecycle burden; a bundled container +
+  install-script provisioning achieves the same operator experience without that complexity.
+
+## Consequences
+
+- **The single-binary, zero-dependency server is gone.** Every server install now depends on a
+  reachable Postgres. The server **fails closed** if no DSN is configured or the database is
+  unreachable (`startup_failed()` → non-zero exit). This is a breaking deployment change.
+- The storage abstraction stays thin: concrete store classes over a shared connection pool, no
+  virtual backend interface (there is only one backend to dispatch to). See ADR-0008.
+- Dev / demo / eval ergonomics are a **deployment** responsibility: the bundled `yuzu-postgres`
+  image (compose) and `scripts/install-*.sh` local-Postgres provisioning must stay
+  one-command, or the loss of single-binary convenience becomes real friction.

--- a/docs/adr/0008-postgres-substrate-architecture.md
+++ b/docs/adr/0008-postgres-substrate-architecture.md
@@ -1,0 +1,74 @@
+---
+status: accepted
+date: 2026-06-09
+owner: Nathan Dornbrook (platform)
+deciders: Nathan Dornbrook; grill-with-docs design session 2026-06-09
+scope: platform — the shared server Postgres substrate layer (server/core/src/pg/)
+builds-on: ADR-0006 (Postgres substrate), ADR-0007 (single-backend)
+---
+
+# 0008 — Postgres substrate architecture: libpq + in-house RAII, shared pool, schema-per-store
+
+## Context
+
+ADR-0006/0007 commit the server to a single PostgreSQL backend. Before any store is written or
+migrated, the shared substrate layer must be specified: the client library, the connection
+model, the schema-migration mechanism, and how the one database is namespaced. The existing
+SQLite layer sets the idioms to mirror: per-store `sqlite3*` handles guarded by a
+`shared_mutex`, the `SqliteTxn`/`SqliteStmt` RAII owners (`server/core/src/sqlite_raii.hpp`),
+the `MigrationRunner` (numbered `{version, sql}` migrations + a per-store `schema_meta` row,
+`server/core/src/migration_runner.hpp`), the `RETURNING`/#1033 atomic-mutate idiom, and one
+existing shared-connection pool (`InstructionDbPool`). The Windows build is a hard constraint:
+the MSVC triplet forces **static** linkage (the #375 gRPC static-link saga).
+
+## Decision
+
+The substrate (new `server/core/src/pg/`) is:
+
+- **Client library: raw `libpq` wrapped in in-house RAII** (`PgConn` owns `PGconn*`/`PQfinish`,
+  `PgResult` owns `PGresult*`/`PQclear`, `PgTxn` is a direct port of `SqliteTxn`, plus a
+  prepared-statement helper). Chosen over `libpqxx`: `libpq` is pure C with an OpenSSL-only
+  dependency (we already static-link OpenSSL), giving the **lowest Windows MSVC static-link
+  risk**, and it maps almost 1:1 onto the existing per-store `sqlite3*` idiom. We already
+  hand-write RAII, so `libpqxx`'s ergonomics buy little and add a second C++ static-link surface.
+- **Connection model: one shared in-process `PgPool`** (bounded set of `PgConn`, checkout-per-
+  operation, pin-per-transaction), injected into every store in place of the per-store handle.
+  This generalizes `InstructionDbPool` to the whole server, exploits Postgres's real
+  concurrency (the per-store `shared_mutex` serialization goes away), and bounds backend
+  processes. Synchronous `libpq` + a thread-safe pool fits the current thread model; no async.
+- **Migrations: `PgMigrationRunner`**, a port of `MigrationRunner` — numbered `{version, sql}`
+  migrations registered in C++ next to each store, applied against a shared
+  `schema_meta(store, version, upgraded_at)` table. No external migration tool, no new runtime
+  dependency, migrations stay co-located with store code exactly as today.
+- **Namespacing: one Postgres SCHEMA per store** (`response`, `audit`, `guardian`,
+  `vuln_graph`, …). Preserves the logical "29 separate stores" isolation and each store's own
+  migration lineage, and turns the vuln-graph scoring join (`vuln_graph.edges ⨝
+  guardian.state`) into a real qualified-name SQL join instead of an application-layer stitch.
+- **No virtual backend interface.** Single-backend (ADR-0007) ⇒ stores stay concrete classes
+  over `PgPool`; the only shared base is an optional thin ctor helper, not a polymorphic seam.
+
+A **Windows static-link canary** (libpq linked on the MSVC static triplet running `SELECT 1`)
+is built and verified **before** the substrate timeline is committed — the #375 lesson.
+
+## Considered and rejected
+
+- **`libpqxx`** — ergonomic C++ transactions/typed rows, but a second C++ static-link surface
+  on the platform that produced the gRPC LNK2038/LNK2005 saga, duplicating RAII we own anyway.
+- **Per-store dedicated connection** (1:1 with today's `sqlite3*`) — simplest mechanical port,
+  but 29+ idle backend processes per server and it keeps the per-store mutex serialization.
+- **An external migration tool (Flyway/Liquibase/sqitch)** — standard versioned-SQL tooling,
+  but a heavy foreign dependency (JVM for Flyway/Liquibase), a separate file format, and
+  out-of-process runs — alien to the in-C++ embedded-migration idiom and the Meson build.
+- **Single shared `public` schema with table-name prefixes** — simpler `search_path`, but
+  weaker isolation and noisier naming than schema-per-store.
+
+## Consequences
+
+- The substrate is a small, well-bounded set of new files (`pg_raii.hpp`, `pg_pool.{hpp,cpp}`,
+  `pg_migration_runner.{hpp,cpp}`) that every later store builds on. Getting their ownership and
+  exception-safety right (cpp-safety review) is load-bearing for the whole program.
+- `RETURNING` is the mandated mutate-and-return idiom (the #1033 anti-pattern becomes moot per
+  migrated store but the discipline carries over).
+- `vcpkg.json` gains `libpq`; `meson.build` wires a `libpq_dep` with `include_type: 'system'`.
+  The Windows static-link result from the canary can still reshape the timeline (fallback:
+  dynamic libpq / dynamic Windows server) — which is exactly why the canary is first.

--- a/docs/adr/0009-per-store-first-boot-backfill-cutover.md
+++ b/docs/adr/0009-per-store-first-boot-backfill-cutover.md
@@ -1,0 +1,60 @@
+---
+status: accepted
+date: 2026-06-09
+owner: Nathan Dornbrook (platform)
+deciders: Nathan Dornbrook; grill-with-docs design session 2026-06-09
+scope: platform — how each existing server SQLite store cuts over to Postgres
+builds-on: ADR-0006 (Postgres substrate), ADR-0008 (substrate architecture)
+---
+
+# 0009 — Existing stores cut over via a one-time, idempotent first-boot backfill
+
+## Context
+
+ADR-0006 migrates ~29 existing server SQLite stores to Postgres incrementally (strangler), each
+behind its own per-store ADR. This ADR fixes the *mechanism* every such migration uses, so the
+per-store ADRs don't each re-invent it. The risk is data loss / corruption on a live store
+during cutover. The stores fall into classes with different durability needs: TTL'd ephemeral
+(response 90d), SOC 2 retained (audit 365d), config/reference (rbac, tags, baselines,
+management-groups, policies, custom-properties, product-packs — operator state that cannot be
+lost), and build-time-seeded (instructions — re-seeded from embedded content, plus operator
+additions). The upgrade-test rig (`scripts/test/docker-compose.upgrade-test.yml`) already
+exercises previous-release → new-release and is the natural gate.
+
+## Decision
+
+**Big-bang per store via a one-time, idempotent first-boot backfill.** When a migrated store
+comes up on Postgres, finds its Postgres schema empty **and** a legacy `<name>.db` SQLite file
+present, it copies rows over (a per-store `migrate_from_sqlite()` step) and stamps itself
+migrated; subsequent boots skip it. The backfill runs **at startup, before the server serves**,
+and **fails closed** on any error (the server refuses to start rather than serve half-migrated
+data).
+
+- **Backfill is mandatory** for config/reference stores and for `audit` (SOC 2 retention).
+- **Backfill may be skipped** (behind a flag) for purely TTL'd ephemeral stores (`response`) —
+  history ages out, so a clean cut with a bounded gap is acceptable.
+- **The legacy SQLite file is retained read-only for one release** as a rollback net, then
+  removed in the following release.
+- Each per-store migration's upgrade-test must assert that config/reference/audit data survives
+  the previous-release-SQLite → new-release-Postgres transition.
+
+## Considered and rejected
+
+- **Dual-write window per store** (write both engines, read SQLite, flip reads to Postgres,
+  then drop SQLite). Zero-gap and trivially reversible, but ~29× the complexity and a
+  long-lived two-engine code path running through the entire multi-quarter program — the exact
+  cost ADR-0007's single-backend decision exists to avoid.
+- **Cutover with no backfill (fresh start everywhere).** Simplest code, but it discards
+  operator config and SOC 2 audit history — unacceptable for the reference and audit stores.
+
+## Consequences
+
+- Each per-store migration carries a `migrate_from_sqlite()` implementation and an upgrade-test
+  assertion; the recipe is uniform, so per-store ADRs focus on schema, not mechanism.
+- The rollback window is exactly one release (the read-only legacy file). A defect discovered
+  after the legacy file is removed has no in-place rollback — so the one-release retention and
+  the upgrade-test gate are load-bearing, not optional.
+- **Secrets stores (`api_token`, `ca`) are explicitly out of scope for this mechanism.** They
+  migrate last and only behind a dedicated secrets-at-rest ADR (envelope encryption / KMS /
+  `pgcrypto`) + `security-guardian` review — a plain `migrate_from_sqlite()` copy into Postgres
+  columns is forbidden for secret material (the ADR-0004/0006 carve-out).


### PR DESCRIPTION
## What

Records the three decisions of record crystallized in a **grill-with-docs** design session for the **ADR-0006** server SQLite → PostgreSQL migration. **Docs-only** — no code, no schema, no deploy wiring. The implementation plan and phased ladder are tracked separately.

## The ADRs

| ADR | Decision | Why it's a decision of record |
|---|---|---|
| **0007** | Server is **single-backend** — Postgres only, no SQLite fallback | Hard to reverse (a dual-backend seam would otherwise be retrofitted forever); the alternative (dual-backend) was a real, tempting option rejected to avoid a doubled store/test surface. Convenience moves to the deploy layer. |
| **0008** | Substrate = **libpq + in-house RAII**, one shared **PgPool**, **PgMigrationRunner**, **schema-per-store** | Surprising without context (why not libpqxx? why not a migration tool?); each choice is a deliberate trade-off, several driven by the Windows MSVC static-link constraint (#375). Canary front-loaded. |
| **0009** | Existing stores cut over via a **one-time idempotent first-boot backfill** | Data-loss risk on live stores; dual-write was the real alternative, rejected for ~29× complexity. Fail-closed, one-release rollback file, secrets carved out. |

## Lineage

- Builds on **ADR-0006** (PostgreSQL is the server substrate, merged 2026-06-09).
- ADR-0007 settles the single- vs dual-backend fork ADR-0006 left open.
- ADR-0008 specifies the substrate every later store builds on.
- ADR-0009 fixes the cutover mechanism so per-store migration ADRs focus on schema, not mechanism.

## Carve-outs preserved

- **Agent SQLite is untouched** (server-only decisions).
- **Secrets** (`api_token`, `ca`) migrate last, only behind a dedicated secrets-at-rest ADR + security-guardian review — never a plain `migrate_from_sqlite()` into Postgres columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)