### PR TITLE
Postgres F0: libpq static-link canary (#1317)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,20 @@ jobs:
       - name: Build
         run: meson compile -C build-linux-${{ matrix.compiler }}-${{ matrix.build_type }}
 
+      # Link-provenance assertion (#1331 review HIGH-2): prove the canary linked
+      # vcpkg's static libpq archive, not a system/dynamic libpq. Per ADR-0008
+      # ("Correction (2026-06-10)"): unix is static, Windows is deliberately a DLL.
+      - name: Assert canary libpq link provenance (static on Linux)
+        run: |
+          bin="build-linux-${{ matrix.compiler }}-${{ matrix.build_type }}/server/core/yuzu_pg_canary"
+          test -x "$bin" || { echo "::error::canary binary missing at $bin"; exit 1; }
+          if ldd "$bin" | grep -qi 'libpq'; then
+            echo "::error::canary dynamically links libpq — expected vcpkg static archive (ADR-0008)"
+            ldd "$bin" | grep -i 'libpq'
+            exit 1
+          fi
+          echo "OK: no dynamic libpq dependency — static archive linked"
+
       - name: Test
         run: meson test -C build-linux-${{ matrix.compiler }}-${{ matrix.build_type }} --print-errorlogs
 
@@ -540,6 +554,23 @@ jobs:
       - name: Build
         run: meson compile -C build-windows-${{ matrix.build_type }}
 
+      # Link-provenance assertion (#1331 review HIGH-2): on Windows libpq is
+      # DELIBERATELY dynamic (triplet static override = grpc stack only; the
+      # release zip's vcpkg-DLL sweep ships libpq.dll like sqlite3/openssl —
+      # ADR-0008 "Correction (2026-06-10)"). Assert the import is present so a
+      # silent posture flip in either direction is caught.
+      - name: Assert canary libpq link provenance (DLL import on Windows)
+        run: |
+          bin="build-windows-${{ matrix.build_type }}/server/core/yuzu_pg_canary.exe"
+          test -f "$bin" || { echo "::error::canary binary missing at $bin"; exit 1; }
+          deps="$(dumpbin -dependents "$bin")"
+          if ! echo "$deps" | grep -qi 'libpq.dll'; then
+            echo "::error::canary does not import libpq.dll — Windows linkage posture changed (expected dynamic per ADR-0008 Correction; if flipping to static, update this assert + the triplet override together)"
+            echo "$deps"
+            exit 1
+          fi
+          echo "OK: libpq.dll import present — dynamic linkage as recorded in ADR-0008"
+
       - name: Test
         run: |
           if [[ "${{ matrix.build_type }}" == "debug" ]]; then
@@ -678,6 +709,20 @@ jobs:
 
       - name: Build
         run: meson compile -C build-macos
+
+      # Link-provenance assertion (#1331 review HIGH-2): hosted macOS images can
+      # carry a system PostgreSQL, so prove the canary linked vcpkg's static
+      # archive rather than a system dylib resolved by cmake's FindPostgreSQL.
+      - name: Assert canary libpq link provenance (static on macOS)
+        run: |
+          bin="build-macos/server/core/yuzu_pg_canary"
+          test -x "$bin" || { echo "::error::canary binary missing at $bin"; exit 1; }
+          if otool -L "$bin" | grep -qi 'libpq'; then
+            echo "::error::canary dynamically links libpq — expected vcpkg static archive (ADR-0008)"
+            otool -L "$bin" | grep -i 'libpq'
+            exit 1
+          fi
+          echo "OK: no dynamic libpq dependency — static archive linked"
 
       - name: Test
         run: meson test -C build-macos --print-errorlogs
@@ -863,6 +908,20 @@ jobs:
 
       - name: Build
         run: meson compile -C build-linux
+
+      # Link-provenance assertion (#1331 review HIGH-2) — same check as the
+      # self-hosted Linux leg; the GHA-hosted image ships PostgreSQL client
+      # libs, making this the leg most at risk of a system-libpq resolution.
+      - name: Assert canary libpq link provenance (static on Linux)
+        run: |
+          bin="build-linux/server/core/yuzu_pg_canary"
+          test -x "$bin" || { echo "::error::canary binary missing at $bin"; exit 1; }
+          if ldd "$bin" | grep -qi 'libpq'; then
+            echo "::error::canary dynamically links libpq — expected vcpkg static archive (ADR-0008)"
+            ldd "$bin" | grep -i 'libpq'
+            exit 1
+          fi
+          echo "OK: no dynamic libpq dependency — static archive linked"
 
       # Test step intentionally absent — the canary's purpose is
       # workflow-regression detection on a fresh-disk runner, not test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             cmake ninja-build pkg-config curl zip unzip tar python3-pip ccache \
+            bison flex \
             ${{ matrix.compiler == 'gcc-13' && 'gcc-13 g++-13' || 'clang-19' }}
           pip3 install --user --break-system-packages --require-hashes -r requirements-ci.txt
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
@@ -593,7 +594,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install cmake ninja ccache pipx
+          # autoconf/automake/libtool: vcpkg's libpq port (Postgres substrate,
+          # ADR-0006) runs autoreconf during its build and the hosted macOS
+          # image doesn't ship autotools.
+          brew install cmake ninja ccache pipx autoconf automake libtool
           # awk strips the trailing ` \` that pip-compile adds when the
           # requirement is continued by `--hash=...` lines.
           pipx install "$(awk '/^meson==/ {print $1}' requirements-ci.txt)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -792,7 +792,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             cmake ninja-build gcc-13 g++-13 \
-            pkg-config curl zip unzip tar python3-pip ccache
+            pkg-config curl zip unzip tar python3-pip ccache \
+            bison flex
           pip3 install --user --break-system-packages --require-hashes -r requirements-ci.txt
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -76,7 +76,9 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
+          # DPkg lock timeout: all nightly jobs share one self-hosted box and one
+          # cron fire time, so concurrent installs race the dpkg lock (gov #1331 UP-9).
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y \
             cmake ninja-build gcc-13 g++-13 \
             pkg-config curl zip unzip tar python3-pip ccache \
             bison flex
@@ -192,7 +194,9 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
+          # DPkg lock timeout: all nightly jobs share one self-hosted box and one
+          # cron fire time, so concurrent installs race the dpkg lock (gov #1331 UP-9).
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y \
             cmake ninja-build gcc-13 g++-13 \
             pkg-config curl zip unzip tar python3-pip ccache \
             bison flex
@@ -418,7 +422,9 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
+          # DPkg lock timeout: all nightly jobs share one self-hosted box and one
+          # cron fire time, so concurrent installs race the dpkg lock (gov #1331 UP-9).
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y \
             cmake ninja-build gcc-13 g++-13 \
             pkg-config curl zip unzip tar python3-pip ccache \
             bison flex

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -78,7 +78,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             cmake ninja-build gcc-13 g++-13 \
-            pkg-config curl zip unzip tar python3-pip ccache
+            pkg-config curl zip unzip tar python3-pip ccache \
+            bison flex
           pip3 install --user --break-system-packages --require-hashes -r requirements-ci.txt
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
@@ -193,7 +194,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             cmake ninja-build gcc-13 g++-13 \
-            pkg-config curl zip unzip tar python3-pip ccache
+            pkg-config curl zip unzip tar python3-pip ccache \
+            bison flex
           pip3 install --user --break-system-packages --require-hashes -r requirements-ci.txt
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
@@ -418,7 +420,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             cmake ninja-build gcc-13 g++-13 \
-            pkg-config curl zip unzip tar python3-pip ccache
+            pkg-config curl zip unzip tar python3-pip ccache \
+            bison flex
           # requirements-ci.txt is hash-pinned (includes gcovr for the
           # coverage report).
           pip3 install --user --break-system-packages --require-hashes -r requirements-ci.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,12 +72,15 @@ jobs:
       - name: Verify build dependencies
         run: |
           MISSING=""
-          for cmd in gcc-13 g++-13 cmake ninja meson ccache pkg-config rpmbuild; do
+          # bison/flex: vcpkg's libpq port builds postgresql from source and
+          # cannot auto-acquire them on Linux (gov #1331 — do not rely on the
+          # machine-wide side effect of ci.yml's apt step).
+          for cmd in gcc-13 g++-13 cmake ninja meson ccache pkg-config rpmbuild bison flex; do
             command -v "$cmd" >/dev/null 2>&1 || MISSING="$MISSING $cmd"
           done
           if [ -n "$MISSING" ]; then
             echo "::error::Missing tools on self-hosted runner:$MISSING"
-            echo "Install with: sudo apt-get install -y ccache rpm"
+            echo "Install with: sudo apt-get install -y ccache rpm bison flex"
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -744,7 +744,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install cmake ninja ccache pipx
+          # autoconf/automake/libtool: vcpkg's libpq port (Postgres substrate,
+          # ADR-0006) runs autoreconf during its build and the hosted macOS
+          # image doesn't ship autotools.
+          brew install cmake ninja ccache pipx autoconf automake libtool
           # awk strips the trailing ` \` that pip-compile adds when the
           # requirement is continued by `--hash=...` lines.
           pipx install "$(awk '/^meson==/ {print $1}' requirements-ci.txt)"

--- a/.github/workflows/sanitizer-tests.yml
+++ b/.github/workflows/sanitizer-tests.yml
@@ -77,7 +77,7 @@ jobs:
           # toolchain baked in. Fail loudly if anything is missing so
           # the gate operator can fix the runner rather than accept
           # silent misconfiguration.
-          for tool in meson ninja gcc-13 g++-13 ccache python3; do
+          for tool in meson ninja gcc-13 g++-13 ccache python3 bison flex; do
               if ! command -v "$tool" >/dev/null; then
                   echo "::error::$tool not on PATH on yuzu-wsl2-linux runner"
                   exit 1
@@ -209,7 +209,7 @@ jobs:
 
       - name: Assert toolchain available
         run: |
-          for tool in meson ninja gcc-13 g++-13 ccache python3; do
+          for tool in meson ninja gcc-13 g++-13 ccache python3 bison flex; do
               if ! command -v "$tool" >/dev/null; then
                   echo "::error::$tool not on PATH on yuzu-wsl2-linux runner"
                   exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **libpq (PostgreSQL client library) added as a build dependency on all
+  platforms (#1317, ADR-0006/ADR-0008).** This is the F0 link-proof canary for
+  the server's storage-substrate migration to PostgreSQL — **no product
+  behavior changes and no server-side Postgres usage in this release**; the
+  migration lands incrementally over future releases (advance notice:
+  ADR-0006). Building from source on Linux now requires `bison` and `flex`;
+  on macOS, `autoconf`/`automake`/`libtool` (Windows: none — vcpkg
+  auto-acquires winflexbison). The Windows release zip gains `libpq.dll` via
+  the existing vcpkg-DLL bundling.
+
 - **Subordinate-CA — root Yuzu's internal CA in your enterprise PKI (PKI PR6,
   M2).** Export the install CA's signing request (`GET /api/v1/ca/root-csr`,
   `Security:Read`), have your enterprise root sign it as a subordinate CA, then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,12 @@ Meson is the sole build system. **Every time you add, remove, or rename a source
 - CMake (required by Meson's cmake dependency method — not used as a build system)
 - C++23 compiler: GCC 13+, Clang 18+, MSVC 19.38+, or Apple Clang 15+
 - vcpkg (set `VCPKG_ROOT`)
+- **Linux:** `bison`, `flex` — vcpkg's libpq port (Postgres substrate, ADR-0006) builds
+  postgresql from source and cannot auto-acquire them on Linux (`sudo apt-get install -y
+  bison flex`)
+- **macOS:** `autoconf`, `automake`, `libtool` — same libpq port runs autoreconf
+  (`brew install autoconf automake libtool`)
+- **Windows:** no new packages — vcpkg auto-acquires winflexbison
 
 ### Quick start (setup script)
 ```bash
@@ -205,6 +211,7 @@ docs/             Architecture docs, conventions, roadmap, capability map
 - `builtin-baseline` is required because of the `version>=` constraint on abseil. Without it vcpkg resolves against HEAD.
 - OpenSSL is a **required dependency on every platform including Windows**. vcpkg's gRPC port compiles its TLS / JWT / PEM code paths against OpenSSL headers regardless of linkage mode, so `grpc.lib` has unresolved references to `BIO_*`, `EVP_*`, `PEM_*`, `X509_*`, `OPENSSL_sk_*` that must be satisfied by `libssl.lib` + `libcrypto.lib` at final link time. A previous iteration of `vcpkg.json` marked openssl `"platform": "!windows"` with a comment that gRPC would use schannel — that was aspirational, never actually wired up, and confirmed wrong by the #375 option D canary's LNK2019 errors. The comment and platform filter have been removed; openssl is an unconditional top-level dep.
 - `catch2` is platform-filtered to `x64 | arm64` (not 32-bit ARM).
+- **libpq (Postgres substrate, ADR-0006/0008): no cmake target carries static libpq's full closure.** `libpgcommon`/`libpgport` (scram/auth helpers) and OpenSSL appear only in `libpq.pc`'s `Libs.private`, so the meson `libpq_dep` block wires them explicitly (unix: cmake `FindPostgreSQL` + `find_library`; Windows: hand-wired per the #375 pattern below). On Windows libpq is a **DLL** (the triplet's static override covers the grpc stack only) and ships via the release zip's vcpkg-DLL sweep — see the ADR-0008 Correction (2026-06-10). `libpq_dep` is gated on `build_server` (the agent stays SQLite). Manifest pins `default-features: false, features: [openssl]`. Pure-C libpq carries no MSVC `detect_mismatch` records, so a wrong-CRT lib pick links silently — the buildtype-conditional `_vcpkg_lib_win` selection is load-bearing. Cold vcpkg builds need bison/flex (Linux) and autotools (macOS) — see Prerequisites.
 - **Windows grpc/protobuf/abseil is load-bearing — both halves.** The `triplets/x64-windows.cmake` static-linkage override AND `meson.build`'s Windows-specific `cxx.find_library()` hand-wired `protobuf_dep`/`grpcpp_dep` construction are the **only configuration we've found** that simultaneously avoids LNK2038 (meson cmake-dep bug) and LNK2005 (abseil DLL symbol conflicts). Do not simplify either half without reading `.claude/agents/build-ci.md` "Windows MSVC static-link history and #375" — full timeline, every failed approach, and the #376 strategic escape (migrate off gRPC to QUIC) are there. Linux/macOS are unaffected.
 
 ## CI architecture

--- a/NOTICE
+++ b/NOTICE
@@ -52,6 +52,7 @@ section is maintained manually; see `vcpkg.json` and
   CLI11 ................................. BSD-3-Clause
   cpp-httplib ........................... MIT
   SQLite ................................ Public Domain
+  libpq (PostgreSQL client library) ..... PostgreSQL License (BSD-style)
   OpenSSL ............................... Apache-2.0 / OpenSSL
   Catch2 (test only) .................... BSL-1.0
   grpcbox / gpb ......................... Apache-2.0

--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ Open `http://localhost:8080` and sign in with the credentials set during first-r
   on MSYS2). Required at `meson setup` for the build-time
   `InstructionDefinition` content embed; meson configure fails fast
   with a clear error if missing.
+- **Linux:** `bison` and `flex` (`sudo apt-get install -y bison flex`) —
+  vcpkg's libpq port (PostgreSQL client library, part of the server storage
+  substrate) builds postgresql from source and cannot auto-acquire them.
+- **macOS:** `autoconf`, `automake`, `libtool`
+  (`brew install autoconf automake libtool`) — same libpq port runs
+  autoreconf. Windows needs nothing extra (vcpkg auto-acquires winflexbison).
 
 ### Quick Start
 

--- a/deploy/docker/Dockerfile.agent
+++ b/deploy/docker/Dockerfile.agent
@@ -15,6 +15,7 @@ ARG TRIPLET=x64-linux
 RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake ninja-build gcc-13 g++-13 pkg-config make linux-libc-dev \
     curl zip unzip tar git ca-certificates \
+    bison flex \
     python3-pip python3-venv python3-yaml \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100 \

--- a/deploy/docker/Dockerfile.agent.chisel
+++ b/deploy/docker/Dockerfile.agent.chisel
@@ -40,6 +40,7 @@ ARG TRIPLET=
 RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake ninja-build gcc-13 g++-13 ccache pkg-config make linux-libc-dev \
     curl zip unzip tar git ca-certificates \
+    bison flex \
     python3-pip python3-venv python3-yaml \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100 \

--- a/deploy/docker/Dockerfile.ci
+++ b/deploy/docker/Dockerfile.ci
@@ -22,6 +22,7 @@ FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae
 RUN apt-get update && apt-get install -y \
         cmake ninja-build pkg-config curl zip unzip tar \
         python3-pip ccache git \
+        bison flex \
         gcc-13 g++-13 clang-18 \
     && pip3 install --break-system-packages meson==1.9.2 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/deploy/docker/Dockerfile.ci-linux
+++ b/deploy/docker/Dockerfile.ci-linux
@@ -21,8 +21,8 @@ RUN apt-get update && apt-get install -y \
     # Build essentials
     cmake ninja-build make pkg-config ccache \
     gcc-13 g++-13 \
-    # Autotools (required by vcpkg ports: c-ares, grpc)
-    autoconf automake libtool \
+    # Autotools (required by vcpkg ports: c-ares, grpc) + bison/flex (libpq)
+    autoconf automake libtool bison flex \
     # OpenSSL build deps
     perl linux-libc-dev \
     # Utilities

--- a/deploy/docker/Dockerfile.server
+++ b/deploy/docker/Dockerfile.server
@@ -40,6 +40,7 @@ ARG TRIPLET=x64-linux
 RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake ninja-build gcc-13 g++-13 ccache pkg-config make linux-libc-dev \
     curl zip unzip tar git ca-certificates \
+    bison flex \
     python3-pip python3-venv python3-yaml \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100 \

--- a/deploy/docker/Dockerfile.server.chisel
+++ b/deploy/docker/Dockerfile.server.chisel
@@ -30,6 +30,7 @@ ARG TRIPLET=
 RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake ninja-build gcc-13 g++-13 ccache pkg-config make linux-libc-dev \
     curl zip unzip tar git ca-certificates \
+    bison flex \
     python3-pip python3-venv python3-yaml \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100 \

--- a/docs/adr/0008-postgres-substrate-architecture.md
+++ b/docs/adr/0008-postgres-substrate-architecture.md
@@ -72,3 +72,23 @@ is built and verified **before** the substrate timeline is committed — the #37
 - `vcpkg.json` gains `libpq`; `meson.build` wires a `libpq_dep` with `include_type: 'system'`.
   The Windows static-link result from the canary can still reshape the timeline (fallback:
   dynamic libpq / dynamic Windows server) — which is exactly why the canary is first.
+
+## Correction (2026-06-10) — Windows linkage is dynamic, and that was already the norm
+
+The F0 canary (PR #1331, #1317) surfaced a false premise in this ADR's Context and Decision:
+`triplets/x64-windows.cmake` does **not** force static linkage globally — its base is
+`VCPKG_LIBRARY_LINKAGE dynamic`, with a static override scoped to the gRPC stack only
+(`abseil|grpc|protobuf|upb|re2|c-ares|utf8-range`, the #375 fix). OpenSSL and sqlite3 are
+already DLLs on Windows, bundled into the release zip by the vcpkg-bin DLL sweep
+(`release.yml` packaging step). "We already static-link OpenSSL" above is therefore wrong
+for Windows, and "the MSVC triplet forces static linkage" describes only the gRPC stack.
+
+What the canary actually proved — and what the #375 lesson actually requires — is that
+libpq **builds at the pinned baseline and links on MSVC with no LNK2005/LNK2038-class
+errors**. It does, as a DLL + import lib, consistent with the existing Windows shipping
+model: `libpq.dll` rides the same release-zip DLL sweep as `sqlite3.dll` and the OpenSSL
+DLLs. **Decision consequence: the substrate proceeds with dynamic libpq on Windows.** If a
+future requirement forces static libpq (e.g. single-file server distribution), add `libpq`
+to the triplet's static-override regex and re-run the canary — the meson wiring already
+lists the static closure (pgcommon/pgport + system libs) so no build-graph change is needed.
+Linux/macOS remain fully static as assumed.

--- a/docs/darwin-compat.md
+++ b/docs/darwin-compat.md
@@ -39,6 +39,7 @@ Before invoking `/test` (the pre-commit/pre-push gate skill) on a fresh macOS de
 
 | Tool | Install | Why |
 |---|---|---|
+| autoconf/automake/libtool | `brew install autoconf automake libtool` | vcpkg's libpq port (Postgres substrate, ADR-0006) runs autoreconf during `vcpkg install`; a fresh mac fails the configure phase without them |
 | GNU bash 5+ | `brew install bash` | `mapfile` and `declare -A` are bash-4-only; stock `/bin/bash` 3.2 trips the version guards in `preflight.sh`, `perf-gate.sh`, `teardown.sh`, `test-fixtures-verify.sh` |
 | Erlang/OTP 28 | via kerl (see `scripts/ensure-erlang.sh` or `scripts/darwin-activate-erlang.sh` if you've created a local shim) | Gateway build + EUnit + dialyzer |
 | OrbStack or Docker Desktop | GUI / `brew install --cask orbstack` | Phase 1 image build + Phase 2 upgrade-test. Without a running Docker daemon both phases SKIP gracefully (the rest of `/test` continues), but you cannot exercise the upgrade-test surface |

--- a/meson.build
+++ b/meson.build
@@ -273,6 +273,44 @@ endif
 sqlite3_dep     = dependency('SQLite3', method: 'cmake', modules: ['SQLite::SQLite3'],
   required: true, include_type: 'system')
 
+# libpq — Postgres client library for the server storage substrate (ADR-0006/
+# ADR-0008). vcpkg builds it static on every triplet we use, and static libpq
+# needs the companion libpgcommon/libpgport archives (scram/auth helpers live
+# there) that neither cmake's FindPostgreSQL nor any imported target carries —
+# only libpq.pc's Libs.private lists them, and pkg-config isn't wired to the
+# vcpkg prefix in this build. So: resolve libpq via cmake (unix) or hand-wired
+# find_library (windows, same reasoning as the #375 protobuf/grpc block above),
+# then add pgcommon/pgport from the vcpkg lib dir explicitly.
+if host_os == 'windows'
+  _libpq_libs = []
+  foreach _pq_name : ['libpq', 'libpgcommon', 'libpgport']
+    _libpq_libs += _cxx.find_library(_pq_name, dirs: [_vcpkg_lib_win], required: true)
+  endforeach
+  # Static libpq's Windows auth paths (SSPI) and socket layer need these
+  # system libs; libssl/libcrypto are reused from the grpc block above.
+  foreach _pq_sys : ['ws2_32', 'secur32', 'advapi32', 'shell32', 'crypt32']
+    _libpq_libs += _cxx.find_library(_pq_sys, required: true)
+  endforeach
+  libpq_dep = declare_dependency(
+    include_directories: _vcpkg_inc_win,
+    dependencies: _libpq_libs + [_libssl, _libcrypto],
+  )
+else
+  libpq_dep = dependency('PostgreSQL', method: 'cmake', modules: ['PostgreSQL::PostgreSQL'],
+    required: true, include_type: 'system')
+  _pq_prefixes = get_option('cmake_prefix_path')
+  _pq_extras = []
+  foreach _pq_name : ['pgcommon', 'pgport']
+    _pq_extras += cxx.find_library(_pq_name,
+      dirs: _pq_prefixes.length() > 0 ? [_pq_prefixes[0] / 'lib'] : [],
+      required: true)
+  endforeach
+  # vcpkg's libpq is built with the openssl feature, so libpq.a's TLS layer
+  # (fe-secure-openssl.o) needs libssl/libcrypto at final link.
+  _pq_openssl = dependency('openssl', required: true, include_type: 'system')
+  libpq_dep = declare_dependency(dependencies: [libpq_dep] + _pq_extras + [_pq_openssl])
+endif
+
 # macOS frameworks needed by gRPC, abseil, and cpp-httplib
 if host_os == 'darwin'
   corefoundation_dep = dependency('appleframeworks', modules: ['CoreFoundation', 'Security', 'CFNetwork'])

--- a/meson.build
+++ b/meson.build
@@ -274,20 +274,36 @@ sqlite3_dep     = dependency('SQLite3', method: 'cmake', modules: ['SQLite::SQLi
   required: true, include_type: 'system')
 
 # libpq — Postgres client library for the server storage substrate (ADR-0006/
-# ADR-0008). vcpkg builds it static on every triplet we use, and static libpq
-# needs the companion libpgcommon/libpgport archives (scram/auth helpers live
-# there) that neither cmake's FindPostgreSQL nor any imported target carries —
-# only libpq.pc's Libs.private lists them, and pkg-config isn't wired to the
-# vcpkg prefix in this build. So: resolve libpq via cmake (unix) or hand-wired
-# find_library (windows, same reasoning as the #375 protobuf/grpc block above),
-# then add pgcommon/pgport from the vcpkg lib dir explicitly.
-if host_os == 'windows'
+# ADR-0008). Server-only: the agent stays SQLite (ADR-0006), so agent-only
+# (-Dbuild_server=false) and cross builds must not require libpq at configure.
+#
+# Linkage per platform: static .a on Linux/macOS (vcpkg static triplets);
+# **dynamic DLL on Windows** — triplets/x64-windows.cmake's base linkage is
+# dynamic and its static override is scoped to the grpc stack only, so vcpkg
+# produces libpq.dll + import lib, same as sqlite3/openssl. The release zip's
+# vcpkg-DLL sweep (release.yml `Get-ChildItem $vcpkgBin *.dll`) bundles it.
+# Static libpq (unix) needs the companion libpgcommon/libpgport archives
+# (scram/auth helpers) that neither cmake's FindPostgreSQL nor any imported
+# target carries — only libpq.pc's Libs.private lists them, and pkg-config
+# isn't wired to the vcpkg prefix in this build. So: resolve libpq via cmake
+# (unix) or hand-wired find_library (windows, same reasoning as the #375
+# protobuf/grpc block above), then add pgcommon/pgport explicitly. Pure-C
+# libpq carries no MSVC detect_mismatch records, so the buildtype-conditional
+# _vcpkg_lib_win selection is load-bearing — a wrong-CRT pick links silently
+# rather than failing with LNK2038. Baseline-bump watch: a vcpkg libpq port
+# moving to PostgreSQL 17/18's meson build may rename or drop the
+# pgcommon/pgport archives — revisit this block on any baseline change.
+if not build_server
+  libpq_dep = disabler()
+elif host_os == 'windows'
   _libpq_libs = []
   foreach _pq_name : ['libpq', 'libpgcommon', 'libpgport']
     _libpq_libs += _cxx.find_library(_pq_name, dirs: [_vcpkg_lib_win], required: true)
   endforeach
-  # Static libpq's Windows auth paths (SSPI) and socket layer need these
-  # system libs; libssl/libcrypto are reused from the grpc block above.
+  # With dynamic libpq (the current triplet posture) the DLL self-contains
+  # these; they are listed so a future flip of libpq to the static override
+  # (SSPI auth paths + socket layer + OpenSSL) links without edits here.
+  # Harmless overlinking today. libssl/libcrypto reused from the grpc block.
   foreach _pq_sys : ['ws2_32', 'secur32', 'advapi32', 'shell32', 'crypt32']
     _libpq_libs += _cxx.find_library(_pq_sys, required: true)
   endforeach

--- a/server/core/meson.build
+++ b/server/core/meson.build
@@ -379,9 +379,12 @@ executable(
   install: true,
 )
 
-# Postgres F0 static-link canary (#1317, ADR-0008): proves libpq links on the
-# MSVC static triplet before any substrate code is committed (the #375 lesson).
-# Throwaway — folded into the pg/ substrate when F1 (#1320) lands.
+# Postgres F0 link canary (#1317, ADR-0008): proves libpq builds at the pinned
+# vcpkg baseline and links on MSVC with no LNK-class errors, before any
+# substrate code is committed (the #375 lesson). Linkage is static on
+# Linux/macOS, dynamic DLL on Windows (see the libpq_dep comment in the root
+# meson.build and the ADR-0008 Correction). Throwaway — folded into the pg/
+# substrate when F1 (#1320) lands.
 executable(
   'yuzu_pg_canary',
   files('src/pg/canary_main.cpp'),

--- a/server/core/meson.build
+++ b/server/core/meson.build
@@ -378,3 +378,13 @@ executable(
   dependencies: [yuzu_server_core_dep, cli11_dep] + auth_crypto_deps,
   install: true,
 )
+
+# Postgres F0 static-link canary (#1317, ADR-0008): proves libpq links on the
+# MSVC static triplet before any substrate code is committed (the #375 lesson).
+# Throwaway — folded into the pg/ substrate when F1 (#1320) lands.
+executable(
+  'yuzu_pg_canary',
+  files('src/pg/canary_main.cpp'),
+  dependencies: [libpq_dep],
+  install: false,
+)

--- a/server/core/src/pg/canary_main.cpp
+++ b/server/core/src/pg/canary_main.cpp
@@ -1,16 +1,21 @@
-// Postgres F0 static-link canary (#1317, ADR-0008).
+// Postgres F0 link canary (#1317, ADR-0008).
 //
 // Connects to the DSN given as argv[1] (or YUZU_POSTGRES_DSN), runs SELECT 1,
 // and prints the result plus libpq/server versions. Its only job is to prove
-// that libpq links — in particular statically on the Windows MSVC triplet —
-// before the pg/ substrate (F1, #1320) is built on top of it.
+// that libpq builds at the pinned vcpkg baseline and links on every platform
+// — static .a on Linux/macOS, DLL + import lib on Windows (see the ADR-0008
+// Correction) — before the pg/ substrate (F1, #1320) is built on top of it.
 //
 // Exit codes: 0 = SELECT 1 succeeded, 1 = connect/query failure, 2 = no DSN.
-
-#include <libpq-fe.h>
+// The exit codes are the only stable contract; stdout format is not. Note for
+// CI wiring (#1318): PQconnectdb/PQexec have no client-side timeout — include
+// connect_timeout=<s> in the DSN or wrap in timeout(1) before using as a
+// smoke step, or a black-holed host wedges the job.
 
 #include <cstdio>
 #include <cstdlib>
+
+#include <libpq-fe.h>
 
 int main(int argc, char** argv) {
     const char* dsn = argc > 1 ? argv[1] : std::getenv("YUZU_POSTGRES_DSN");

--- a/server/core/src/pg/canary_main.cpp
+++ b/server/core/src/pg/canary_main.cpp
@@ -1,0 +1,45 @@
+// Postgres F0 static-link canary (#1317, ADR-0008).
+//
+// Connects to the DSN given as argv[1] (or YUZU_POSTGRES_DSN), runs SELECT 1,
+// and prints the result plus libpq/server versions. Its only job is to prove
+// that libpq links — in particular statically on the Windows MSVC triplet —
+// before the pg/ substrate (F1, #1320) is built on top of it.
+//
+// Exit codes: 0 = SELECT 1 succeeded, 1 = connect/query failure, 2 = no DSN.
+
+#include <libpq-fe.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+int main(int argc, char** argv) {
+    const char* dsn = argc > 1 ? argv[1] : std::getenv("YUZU_POSTGRES_DSN");
+    if (dsn == nullptr || dsn[0] == '\0') {
+        std::fprintf(stderr,
+                     "usage: yuzu_pg_canary <dsn>  (or set YUZU_POSTGRES_DSN)\n"
+                     "e.g.   yuzu_pg_canary \"postgresql://yuzu:yuzu@localhost:5432/yuzu\"\n");
+        return 2;
+    }
+
+    PGconn* conn = PQconnectdb(dsn);
+    if (PQstatus(conn) != CONNECTION_OK) {
+        std::fprintf(stderr, "canary: connect failed: %s", PQerrorMessage(conn));
+        PQfinish(conn);
+        return 1;
+    }
+
+    PGresult* res = PQexec(conn, "SELECT 1");
+    if (PQresultStatus(res) != PGRES_TUPLES_OK) {
+        std::fprintf(stderr, "canary: SELECT 1 failed: %s", PQerrorMessage(conn));
+        PQclear(res);
+        PQfinish(conn);
+        return 1;
+    }
+
+    std::printf("canary: SELECT 1 -> %s (libpq %d, server %d)\n", PQgetvalue(res, 0, 0),
+                PQlibVersion(), PQserverVersion(conn));
+
+    PQclear(res);
+    PQfinish(conn);
+    return 0;
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -21,6 +21,7 @@
     "cli11",
     "cpp-httplib",
     "sqlite3",
+    "libpq",
     "openssl",
     {
       "name": "catch2",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -21,7 +21,11 @@
     "cli11",
     "cpp-httplib",
     "sqlite3",
-    "libpq",
+    {
+      "name": "libpq",
+      "default-features": false,
+      "features": ["openssl"]
+    },
     "openssl",
     {
       "name": "catch2",


### PR DESCRIPTION
## Summary

F0 of the Postgres substrate program (ADR-0006/0007/0008/0009): prove libpq — the client library the server will link under ADR-0008 — **builds at the pinned vcpkg baseline and links on Windows MSVC with no LNK2005/LNK2038-class errors** before any substrate code is committed. The #375 lesson applied.

> **Correction (governance round):** earlier revisions of this PR claimed a *static* Windows link. The triplet's base linkage is dynamic (the static override covers the grpc stack only), so libpq is a **DLL on Windows** — same as sqlite3/openssl, bundled by the release zip's existing vcpkg-DLL sweep. The substrate proceeds with dynamic libpq on Windows; see the ADR-0008 "Correction (2026-06-10)" section. Linux/macOS are fully static as planned.

- `vcpkg.json`: add `libpq`, pinned `default-features: false, features: [openssl]`
- `meson.build`: `libpq_dep` — gated on `build_server` (agent stays SQLite; agent-only/cross configures unaffected); hand-wired `find_library` on Windows per the #375 pattern; cmake `FindPostgreSQL` + explicit `pgcommon`/`pgport`/openssl closure on unix (no cmake target carries static libpq's closure — only `libpq.pc` `Libs.private` does)
- `server/core/src/pg/canary_main.cpp` + `yuzu_pg_canary` target (install: false): SELECT 1 against argv/`YUZU_POSTGRES_DSN`; exit codes are the only stable contract
- Build-dep rollout for the libpq port: bison/flex (Linux) + autotools (macOS) across ci/nightly/release/sanitizer workflows **and all six Dockerfiles that run `vcpkg install`**; `DPkg::Lock::Timeout` on the nightly's shared-box apt installs
- Docs: ADR-0008 Correction, CLAUDE.md/README prerequisites + vcpkg closure entry, darwin-compat table, CHANGELOG advance-notice entry, NOTICE PostgreSQL License row

## Verification

- macOS (arm64, vcpkg static libpq 16.9, pinned features): links clean; `SELECT 1 -> 1` live against postgres:16; bad-DSN exit 1, no-DSN exit 2; full build green
- Linux: `SELECT 1 -> 1` live (gcc:13); vcpkg static link via Tier-1 CI leg
- Windows MSVC: linked clean ×2 in CI (DLL + import lib per triplet posture); live run pending a Windows box with Postgres (#1317 note)
- Agent-only configure (`-Dbuild_server=false`) verified clean with the gating
- Full `/governance` run (8 gates, 14 agent reviews): Gate 2 PASS; 4 blocking-class findings all fixed in the hardening commit; Gate 8 security re-review of the hardening commit PASS. Follow-ups: #1336 (canary smoke wiring), #1337 (CI package-list consolidation), #1338 (chaos backlog)

Closes #1317

🤖 Generated with [Claude Code](https://claude.com/claude-code)