### PR TITLE
fix(pki): agent fail-closed TLS + default-leaf clock-skew + R-5 doc — #1303 #1302 #1304

### DIFF
--- a/docs/auth-architecture.md
+++ b/docs/auth-architecture.md
@@ -297,6 +297,19 @@ the agent never receives the cert (an active MITM stripping the field, or a
 persistent signer outage), the agent bounds its retries and gives up
 auto-provisioning for that run rather than looping.
 
+**Agent CA pinning is fail-closed (#1303).** When the agent has TLS on but no CA
+to pin — no `--ca-cert` **and** no install CA auto-discovered at the standard
+shared-cert path (`/etc/yuzu/certs/default-ca.pem`, ProgramData on Windows) — it
+**refuses to connect** rather than silently falling back to the system trust
+store. An empty root set makes gRPC verify against the OS roots, which do **not**
+trust a Yuzu self-signed install CA, so with the gateway one-way-TLS edge live any
+publicly-trusted impostor cert for the dial host would be accepted — a fail-open
+MITM on the command fan-out plane. The deliberate escape hatch is
+`--tls-system-roots` / `YUZU_TLS_SYSTEM_ROOTS`, for the legitimate case where the
+server certificate chains to a public or corporate CA already in the system store;
+it logs a loud warning and is never the default. (`--no-tls` remains the dev/demo
+opt-out.)
+
 **Operator surface.** Server: `--ca-dir` (shared with the default-cert
 bootstrap). Agent: `--cert-dir` / env `YUZU_CERT_DIR` (where the provisioned
 credential lives) and `--no-auto-provision-cert` (disable the CSR-at-enrollment
@@ -340,6 +353,33 @@ gateway-proxied agent promptly, revoke at the gateway/management layer (disconne
 the agent) in addition to `POST /api/v1/ca/revoke`. This is the same
 direct-connect-authoritative caveat called out in `docs/pki-architecture.md`
 ("Gateway path identity").
+
+**Gateway CSR-swap forgery (R-5, accepted M1 residual).** Wiring `ProxyRegister`
+to sign forwarded CSRs makes the gateway a bounded **confused deputy**. The
+server signs the relayed CSR's public key under the **gateway-supplied**
+`agent_id` (the through-gateway identity is the app-layer `gateway_observed_peer`,
+not a transport-cryptographic binding in M1), so a compromised or on-path gateway
+can relay a *victim's* `agent_id` paired with its *own* CSR and obtain a real
+CA-signed leaf for that `agent_id`. Worse than a transient relay: that leaf is a
+durable credential the attacker can present for **persistent direct mTLS
+reconnect**, bypassing the gateway entirely — it **survives gateway eviction**.
+Compensating controls (why this is accepted for M1, not a live break):
+
+- Every forged leaf is recorded in `ca_issued` and is **revocable** — and #1290
+  stamps `via=gateway_proxy` on the `ca.cert.issued` audit + issuance metric, so
+  an incident responder can **scope and bulk-revoke the gateway-issued population**
+  after a gateway compromise (the row the forensic control depends on).
+- The gateway authenticates to the server over **upstream mutual TLS** (a rogue
+  gateway cannot reach the issuance path without being an enrolled gateway).
+- PR5c **one-way TLS** on the agent↔gateway edge mitigates the *on-path* (non-gateway-
+  compromise) variant.
+
+The actual cryptographic remediation — gateway agent-identity **attestation** +
+per-gateway issuance **scoping** so a gateway can only obtain leaves for the
+`agent_id`s it legitimately fronts — is tracked in **#1292** (cryptographic
+through-gateway binding lands with the QUIC migration, #376). Full threat model:
+`docs/security-reviews/pki-pr5-gateway-tls.md`; also summarised in
+`docs/pki-architecture.md`.
 
 ## HTTP security response headers (SOC2-C1)
 

--- a/server/core/src/default_certs.cpp
+++ b/server/core/src/default_certs.cpp
@@ -606,7 +606,13 @@ bool ensure_default_certs(const fs::path& dir, const std::string& hostname, CaSt
     const std::string ca_key_id = pki::issuer_key_id(*ca_cert_pem).value_or(std::string{});
     // Leaves are sized to the CA's exact notAfter so they never outlive the
     // issuer (the x509_ca leaf-<=-CA invariant would otherwise reject them).
-    const pki::Validity leaf_validity{std::chrono::system_clock::now(), ca_info->not_after};
+    // #1302: backdate notBefore by the clock-skew allowance — mirrors the CA root
+    // and the per-agent client leaf (sign_agent_csr, PR3 H-2). Without this, an
+    // agent whose clock lags the server at first connect sees these freshly-minted
+    // server leaves as not-yet-valid and rejects the TLS handshake, and the retry
+    // paths don't recover a "valid cert, skewed clock" until the skew elapses.
+    const pki::Validity leaf_validity{
+        std::chrono::system_clock::now() - pki::kClockSkewBackdate, ca_info->not_after};
 
     pki::SubjectAltNames san;
     san.dns = {"localhost"};

--- a/tests/unit/server/test_default_certs.cpp
+++ b/tests/unit/server/test_default_certs.cpp
@@ -22,6 +22,7 @@
 #include <openssl/x509v3.h>
 
 #include <algorithm>
+#include <chrono>
 #include <cstddef>
 #include <filesystem>
 #include <fstream>
@@ -137,6 +138,27 @@ TEST_CASE("default_certs: leaf EKUs match each role (server is also a client —
     const uint32_t https_eku = leaf_eku_flags(set.https_cert);
     REQUIRE((https_eku & XKU_SSL_SERVER) != 0);
     REQUIRE((https_eku & XKU_SSL_CLIENT) == 0);
+}
+
+TEST_CASE("default_certs: server leaves backdate notBefore by the clock-skew allowance (#1302)",
+          "[default_certs]") {
+    // An agent whose clock lags the server at first connect must not reject a
+    // freshly-minted server leaf as not-yet-valid. The CA root + per-agent client
+    // leaf already backdate notBefore by kClockSkewBackdate; this pins the same for
+    // the server-facing default leaves (HTTPS / agent-gRPC / gateway), which the
+    // PR3 H-2 fix had missed.
+    TempDir dir;
+    DefaultCertSet set;
+    const auto now = std::chrono::system_clock::now();
+    REQUIRE(ensure_default_certs(dir.path, "test-host", nullptr, set));
+    // now is captured BEFORE generation, so notBefore <= now - backdate (minus a
+    // little slack for test execution time). Use 280s against the 300s backdate.
+    const auto floor = now - pki::kClockSkewBackdate + std::chrono::seconds(20);
+    for (const auto& leaf : {set.https_cert, set.server_cert, set.gateway_cert}) {
+        auto c = pki::parse_certificate(read_file(leaf));
+        REQUIRE(c);
+        REQUIRE(c->not_before <= floor); // genuinely backdated, not now()
+    }
 }
 
 TEST_CASE("default_certs: --cert-san extra SANs land on every default leaf", "[default_certs]") {


### PR DESCRIPTION
## PKI #1289 hardening, round 2 — agent fail-closed + clock-skew + R-5 doc

Three governance-deferred M1 follow-ups that harden the secure-by-default TLS posture
from #1289. **Stacked on #1314** (`feat/pki-tls-go-live`) — #1303 extends #1289's
agent CA auto-discovery, so it must build on it.

### #1303 — agent fails closed when no CA can be pinned (security, the headline)
When the agent had TLS on but **no CA to pin** (no `--ca-cert` *and* no install CA
auto-discovered at `/etc/yuzu/certs/default-ca.pem`), it built gRPC creds with an
empty root set and connected anyway — silently verifying against the OS **system
trust store**, which does *not* trust a Yuzu self-signed install CA. With the gateway
one-way-TLS edge live (the #1289 flip), that's a **fail-open MITM window** on the
command fan-out plane (any publicly-trusted impostor cert for the dial host accepted).

- Now **refuses to connect** in that state. Deliberate escape hatch:
  `--tls-system-roots` / `YUZU_TLS_SYSTEM_ROOTS` (`Config::tls_allow_system_trust`)
  for the legitimate "server cert chains to a public/corporate CA already in the
  system store" case — loud warning, never the default. `--no-tls` remains the
  dev/demo opt-out.
- Verified non-breaking for provisioned agents: `provisioning_eligible` requires
  `!tls_ca_cert.empty()`, so any provisioned agent has `--ca-cert` set and the guard
  never fires. The only behavior change is the intended fail-closed refusal.

### #1302 — backdate server default-leaf `notBefore`
The CA root + per-agent client leaf backdate `notBefore` by `kClockSkewBackdate`
(PR3 H-2), but the server-facing default leaves (HTTPS / gRPC / gateway) were minted
at exactly `now()` — so an agent whose clock lags the server at first connect saw a
fresh server leaf as not-yet-valid and rejected the handshake, with no retry recovery.
Aligned. (CA is minted before the leaf and backdates identically, so `leaf.notBefore`
≥ `ca.notBefore` — invariant intact.)

### #1304 — document the gateway CSR-swap (R-5) residual in `auth-architecture.md`
PR5d's `ProxyRegister` CSR-signing makes the gateway a bounded confused deputy
(relay a victim's `agent_id` + own CSR → CA-signed leaf valid for persistent *direct*
mTLS reconnect that survives gateway eviction). Documented in the security annex +
`pki-architecture.md` but the PR5d review (B-1) required it in `auth-architecture.md`
too. Adds the forgery, the escalation, and the compensating controls (`ca_issued`
inventory + revocation; #1290 `via=gateway_proxy` scoping; upstream gateway mTLS; PR5c
one-way TLS), cross-referencing #1292 (the cryptographic fix). Also documents the
#1303 fail-closed posture.

### Validation
- **Unit:** full server suite green (2229 cases / 25,333 assertions); agent green
  (407 cases). New test: every server default leaf's `notBefore` is genuinely
  backdated (#1302).
- **Hermes ×2** (mandatory security gate): pass 1 (adversarial) → 0 CRITICAL/HIGH,
  **2 MEDIUM + 1 LOW**:
  - **M-1** — `--tls-system-roots` used CLI11 `->envname()` (presence-only), so
    `YUZU_TLS_SYSTEM_ROOTS=0` would *enable* the fallback. Fixed: dropped `envname`,
    added value-aware `env_truthy()` (with whitespace trim) seeded before parse so the
    CLI flag still wins.
  - **M-2** — a present-but-empty install CA file fired the fail-closed guard with a
    generic message. Fixed: a specific "exists but is empty/unreadable" diagnostic
    (failing closed stays correct).
  - **L-1** — verified the CA root backdates identically; no change needed.
  Pass 2 (cybersecurity) re-attacked the fixed diff → **clean, 0 findings**: env
  precedence correct in all 4 combinations, guard still complete + fail-closed,
  `--tls-system-roots` widens only the root set (hostname/SAN verification preserved),
  no key material on the refusal path.
- `build_channel` is an untested internal lambda (the codebase doesn't unit-test it);
  the fail-closed guard is covered by the clear reviewed logic + Hermes ×2. A live
  enroll→connect boot-test is the recommended pre-merge manual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
