### PR TITLE
Postgres F4/F5: yuzu-postgres image + bundled Postgres in composes and CI (#1318)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,14 @@ jobs:
       - name: Build
         run: meson compile -C build-linux-${{ matrix.compiler }}-${{ matrix.build_type }}
 
+      # Postgres 16 for server tests (ADR-0006 decision 8, #1318). On this
+      # self-hosted runner the script idempotently (re)uses a persistent
+      # `yuzu-ci-postgres` docker container on 127.0.0.1:15432 and exports
+      # YUZU_TEST_POSTGRES_DSN via GITHUB_ENV — one-time cost per runner,
+      # no per-run install. Non-fatal until #1320 ships the first consumer.
+      - name: Ensure Postgres 16 (server tests)
+        run: bash scripts/ci/ensure-postgres.sh
+
       - name: Test
         run: meson test -C build-linux-${{ matrix.compiler }}-${{ matrix.build_type }} --print-errorlogs
 
@@ -539,6 +547,16 @@ jobs:
       - name: Build
         run: meson compile -C build-windows-${{ matrix.build_type }}
 
+      # Postgres 16 for server tests (ADR-0006 decision 8, #1318).
+      # Precondition on yuzu-local-windows: a native PostgreSQL 16 service
+      # with role yuzu / password yuzu / db yuzu_test (one-time bootstrap,
+      # see docs/ci-architecture.md "Postgres for server tests"), or a
+      # runner-level YUZU_TEST_POSTGRES_DSN override. The script probes
+      # 127.0.0.1:5432 and exports the DSN; warns (non-fatal until #1320)
+      # when nothing is listening.
+      - name: Ensure Postgres 16 (server tests)
+        run: bash scripts/ci/ensure-postgres.sh
+
       - name: Test
         run: |
           if [[ "${{ matrix.build_type }}" == "debug" ]]; then
@@ -674,6 +692,15 @@ jobs:
 
       - name: Build
         run: meson compile -C build-macos
+
+      # Postgres 16 for server tests (ADR-0006 decision 8, #1318). GHA
+      # macOS runners have no docker; the script brew-installs
+      # postgresql@16 (bottle, ~1 min), boots a throwaway trust-auth
+      # cluster under $RUNNER_TEMP on 127.0.0.1:15432 and exports
+      # YUZU_TEST_POSTGRES_DSN. Non-fatal until #1320 ships the first
+      # consumer.
+      - name: Ensure Postgres 16 (server tests)
+        run: bash scripts/ci/ensure-postgres.sh
 
       - name: Test
         run: meson test -C build-macos --print-errorlogs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,8 +554,14 @@ jobs:
       # runner-level YUZU_TEST_POSTGRES_DSN override. The script probes
       # 127.0.0.1:5432 and exports the DSN; warns (non-fatal until #1320)
       # when nothing is listening.
+      #
+      # `source`, NOT `bash scripts/...`: inside the step's MSYS2 bash,
+      # PATH puts C:\Windows\system32 before C:\msys64\usr\bin, so a bare
+      # `bash` resolves to the WSL stub, which refuses to run as the
+      # LOCAL SYSTEM service account (Bash/WSL_E_LOCAL_SYSTEM_NOT_SUPPORTED).
+      # Same idiom as `source setup_msvc_env.sh` / `ensure-erlang.sh`.
       - name: Ensure Postgres 16 (server tests)
-        run: bash scripts/ci/ensure-postgres.sh
+        run: source scripts/ci/ensure-postgres.sh
 
       - name: Test
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -137,6 +137,13 @@ jobs:
       - name: Build
         run: meson compile -C build-linux-asan
 
+      # Postgres 16 for server tests (ADR-0006 decision 8, #1318).
+      # Idempotent persistent `yuzu-ci-postgres` docker container on
+      # 127.0.0.1:15432 — same step as ci.yml's linux job, shared on this
+      # runner. Non-fatal until #1320 ships the first consumer.
+      - name: Ensure Postgres 16 (server tests)
+        run: bash scripts/ci/ensure-postgres.sh
+
       - name: Test
         run: meson test -C build-linux-asan --print-errorlogs
 
@@ -314,6 +321,11 @@ jobs:
             -o /tmp/libgai_sync_shim.so /tmp/gai_sync_shim.c
           file /tmp/libgai_sync_shim.so
 
+      # Postgres 16 for server tests (ADR-0006 decision 8, #1318) — same
+      # idempotent docker-container step as ci.yml's linux job.
+      - name: Ensure Postgres 16 (server tests)
+        run: bash scripts/ci/ensure-postgres.sh
+
       - name: Test
         id: test
         env:
@@ -484,6 +496,11 @@ jobs:
 
       - name: Build
         run: meson compile -C build-linux-coverage
+
+      # Postgres 16 for server tests (ADR-0006 decision 8, #1318) — same
+      # idempotent docker-container step as ci.yml's linux job.
+      - name: Ensure Postgres 16 (server tests)
+        run: bash scripts/ci/ensure-postgres.sh
 
       - name: Test
         run: meson test -C build-linux-coverage --print-errorlogs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1232,6 +1232,171 @@ jobs:
             echo "Signed with cosign keyless + SLSA provenance attestation."
           } >> "$GITHUB_STEP_SUMMARY"
 
+  # ── yuzu-postgres — the server's storage substrate image ─────────────
+  # Postgres 16 + pgvector + app role/db init (ADR-0006/0007/0008, #1318).
+  # Mirrors docker-publish (login / metadata / SBOM / attestation / cosign)
+  # with three differences:
+  #   1. No needs on build-linux/build-gateway — the image contains no Yuzu
+  #      build artifacts (it's postgres + pgvector + init SQL), so a core
+  #      build failure is irrelevant to it. It IS in the release job's
+  #      needs: the composes release-pin ghcr.io/.../yuzu-postgres:X.Y.Z,
+  #      so a release must not publish if this image failed to.
+  #   2. Multi-arch linux/amd64,linux/arm64 (the demo/viz rigs are arm64).
+  #      The arm64 leg runs under QEMU on the amd64 self-hosted runner —
+  #      cheap here (apt install + one small C extension compile), unlike
+  #      the chisel jobs' full vcpkg-from-source builds.
+  #   3. Distinct local buildcache path (postgres suffix).
+  docker-publish-postgres:
+    name: "Publish postgres image"
+    runs-on: [self-hosted, Linux]
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+      id-token: write        # cosign keyless + Sigstore OIDC
+      attestations: write    # actions/attest-build-provenance
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          clean: false
+          persist-credentials: false
+
+      - name: Lowercase repository owner
+        id: owner
+        run: echo "value=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      # QEMU + docker-container driver for the multi-arch (amd64+arm64)
+      # manifest-list push — same rationale as docker-publish-chisel.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        with:
+          driver: docker-container
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          # GHCR_PAT (write:packages-only PAT owned by Tr3kkR) instead
+          # of GITHUB_TOKEN — see docker-publish for the full rationale.
+          username: Tr3kkR
+          password: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags and labels
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ghcr.io/${{ steps.owner.outputs.value }}/yuzu-postgres
+          # Tag convention mirrors docker-publish / scripts/docker-release.sh:
+          #   - stable (no -alpha/-beta/-rc suffix): :X.Y.Z + :X.Y + :latest
+          #   - pre-release:                         :X.Y.Z-suffix only
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref_name, '-') }}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+          labels: |
+            org.opencontainers.image.title=yuzu-postgres
+            org.opencontainers.image.description=Yuzu server storage substrate — PostgreSQL 16 + pgvector (ADR-0006)
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ github.ref_name }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=AGPL-3.0-or-later
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: deploy/docker/Dockerfile.postgres
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Distinct local buildcache path — never collides with the
+          # server/gateway/chisel caches on this runner.
+          cache-from: type=local,src=/mnt/d/docker-buildcache/postgres
+          cache-to: type=local,dest=/mnt/d/docker-buildcache/postgres,mode=max
+          # Disable buildx's own provenance/sbom attestation — we emit
+          # GitHub-native attestations + cosign signatures below (single
+          # verification path, same as docker-publish).
+          provenance: false
+          sbom: false
+
+      # ── Docker image SBOM (CycloneDX + SPDX) ────────────────────────
+      - name: Generate image SBOM (CycloneDX)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ghcr.io/${{ steps.owner.outputs.value }}/yuzu-postgres@${{ steps.build.outputs.digest }}
+          format: cyclonedx-json
+          output-file: yuzu-postgres-image.cdx.json
+          artifact-name: yuzu-postgres-image.cdx.json
+          upload-artifact: false
+
+      - name: Generate image SBOM (SPDX)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ghcr.io/${{ steps.owner.outputs.value }}/yuzu-postgres@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: yuzu-postgres-image.spdx.json
+          artifact-name: yuzu-postgres-image.spdx.json
+          upload-artifact: false
+
+      - name: Upload image SBOM artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        continue-on-error: true
+        with:
+          name: yuzu-postgres-image-sbom
+          path: |
+            yuzu-postgres-image.cdx.json
+            yuzu-postgres-image.spdx.json
+          retention-days: 3
+
+      # ── SLSA build provenance (by image digest) ─────────────────────
+      - name: Attest image provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/${{ steps.owner.outputs.value }}/yuzu-postgres
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      # ── cosign keyless image signing (Sigstore / Fulcio / Rekor) ────
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Sign image (keyless)
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE: ghcr.io/${{ steps.owner.outputs.value }}/yuzu-postgres
+        run: |
+          # cosign v3.0+ auto-detects the OIDC issuer from the workflow's
+          # id-token; an explicit --oidc-issuer is redundant and a hard
+          # error in v3 (see docker-publish for the #495 history).
+          cosign sign --yes "${IMAGE}@${DIGEST}"
+          echo "Signed ${IMAGE}@${DIGEST} with cosign keyless (OIDC)"
+
+      - name: Image summary
+        env:
+          META_TAGS: ${{ steps.meta.outputs.tags }}
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          {
+            echo "## Published \`yuzu-postgres\` image (multi-arch)"
+            echo ""
+            echo '```'
+            echo "$META_TAGS"
+            echo '```'
+            echo ""
+            echo "**Digest:** \`$BUILD_DIGEST\`"
+            echo ""
+            echo "Platforms: \`linux/amd64,linux/arm64\` (arm64 via QEMU)."
+            echo "Signed with cosign keyless + SLSA provenance attestation."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   # ── Chiselled demo images — server + gateway + agent, multi-arch ─────
   # Publishes the FROM-scratch chiselled Ubuntu 26.04 demo images to GHCR
   # under a distinct `-chisel` repo suffix (see docs/demo-environment.md).
@@ -1612,7 +1777,10 @@ jobs:
   # ── Create GitHub Release ────────────────────────────────────────────
   release:
     name: "Create Release"
-    needs: [build-linux, build-gateway, build-windows, build-macos, docker-publish]
+    # docker-publish-postgres is in the needs: the composes release-pin
+    # ghcr.io/.../yuzu-postgres:X.Y.Z (#1318), so publishing a release
+    # whose postgres image failed to push would ship broken composes.
+    needs: [build-linux, build-gateway, build-windows, build-macos, docker-publish, docker-publish-postgres]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:

--- a/deploy/docker/Dockerfile.postgres
+++ b/deploy/docker/Dockerfile.postgres
@@ -1,0 +1,74 @@
+# syntax=docker/dockerfile:1.7
+# Yuzu Postgres — the server's storage substrate (ADR-0006/0007/0008).
+#
+# PostgreSQL 16 + pgvector, plus an init script that creates the Yuzu app
+# role and database on first boot (docker-entrypoint-initdb.d). Per-store
+# SCHEMAs and all tables are created at runtime by the server's migration
+# runner (ADR-0008 "PgMigrationRunner") — deliberately NOT here, so the
+# database image never has to move in lockstep with server-side schema
+# changes.
+#
+# Published as ghcr.io/<owner>/yuzu-postgres:<version> by the
+# `docker-publish-postgres` job in .github/workflows/release.yml (cosign
+# keyless + SLSA provenance + SBOM, same as the other three images) and
+# release-pinned in the composes via ${YUZU_VERSION:-X.Y.Z}
+# (scripts/check-compose-versions.sh enforces the pin).
+#
+# Version pinning:
+#   - Base image is pinned tag + manifest-list digest (multi-arch:
+#     linux/amd64 + linux/arm64 — the demo/viz rigs are arm64).
+#   - pgvector is built from source at a pinned release tag. The PGDG apt
+#     package (postgresql-16-pgvector) was considered but rejected: PGDG
+#     only carries the latest package revision, so an apt version pin rots
+#     as soon as PGDG supersedes it. A git release tag is reproducible for
+#     as long as the upstream repo exists.
+#
+# Local build:
+#   docker build -t yuzu-postgres:local -f deploy/docker/Dockerfile.postgres .
+#
+# Runtime contract (consumed by the composes):
+#   POSTGRES_PASSWORD   required by the upstream entrypoint (superuser).
+#   YUZU_DB_USER        app role name        (default: yuzu)
+#   YUZU_DB_NAME        app database name    (default: yuzu)
+#   YUZU_DB_PASSWORD    app role password    (default: POSTGRES_PASSWORD)
+#   Data dir: /var/lib/postgresql/data (mount a named volume).
+#   Healthcheck lives in the composes: pg_isready -h 127.0.0.1 -U yuzu -d yuzu
+#   (-h 127.0.0.1 is load-bearing — during docker-entrypoint-initdb.d the
+#   temporary server listens on the unix socket only, so a TCP probe cannot
+#   false-positive mid-init).
+
+# Global ARG so both stages use the same pinned base.
+# postgres:16.14-bookworm, multi-arch manifest list (amd64 + arm64),
+# resolved 2026-06-10.
+ARG PG_BASE=postgres:16.14-bookworm@sha256:da514b7d293c5e9126503f85ecd835f4fb0942a77e012fe74f016c114c3e25b8
+
+# ── Stage 1: build pgvector against the exact server version ────────────
+FROM ${PG_BASE} AS pgvector-build
+
+# pgvector release tag — bump deliberately, never float.
+ARG PGVECTOR_VERSION=v0.8.2
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential git ca-certificates postgresql-server-dev-16 \
+    && rm -rf /var/lib/apt/lists/*
+
+# OPTFLAGS="" strips pgvector's default -march=native — this image must be
+# portable across CPUs (and across the amd64/arm64 publish matrix), not
+# tuned to the build host. Same convention as the upstream pgvector image.
+RUN git clone --branch "${PGVECTOR_VERSION}" --depth 1 \
+        https://github.com/pgvector/pgvector.git /tmp/pgvector \
+    && make -C /tmp/pgvector OPTFLAGS="" -j"$(nproc)" \
+    && make -C /tmp/pgvector install DESTDIR=/out
+
+# ── Stage 2: runtime — stock postgres + the extension + init SQL ────────
+FROM ${PG_BASE}
+
+# vector.so + extension control/SQL files + LLVM bitcode (JIT inlining),
+# captured wholesale via DESTDIR so a pgvector layout change can't silently
+# drop a file.
+COPY --from=pgvector-build /out/ /
+
+# First-boot init: creates the app role + database and installs the vector
+# extension into the app database. Runs only when the data volume is empty
+# (upstream entrypoint semantics) — existing deployments are never touched.
+COPY deploy/docker/postgres-init/ /docker-entrypoint-initdb.d/

--- a/deploy/docker/Dockerfile.postgres
+++ b/deploy/docker/Dockerfile.postgres
@@ -28,11 +28,17 @@
 #
 # Runtime contract (consumed by the composes):
 #   POSTGRES_PASSWORD   required by the upstream entrypoint (superuser).
-#   YUZU_DB_USER        app role name        (default: yuzu)
+#   YUZU_DB_USER        app role name        (default: yuzu; must differ
+#                       from POSTGRES_USER — init refuses otherwise)
 #   YUZU_DB_NAME        app database name    (default: yuzu)
-#   YUZU_DB_PASSWORD    app role password    (default: POSTGRES_PASSWORD)
+#   YUZU_DB_PASSWORD    app role password    REQUIRED — must differ from
+#                       POSTGRES_PASSWORD. First-boot init refuses to run
+#                       if it is unset or equal to the superuser password
+#                       (a leaked app DSN must never disclose superuser
+#                       credentials — PR #1334 review, S1).
 #   Data dir: /var/lib/postgresql/data (mount a named volume).
-#   Healthcheck lives in the composes: pg_isready -h 127.0.0.1 -U yuzu -d yuzu
+#   Healthcheck lives in the composes: pg_isready -h 127.0.0.1 (liveness)
+#   && psql over the app DSN for SELECT 1 (proves the app credential).
 #   (-h 127.0.0.1 is load-bearing — during docker-entrypoint-initdb.d the
 #   temporary server listens on the unix socket only, so a TCP probe cannot
 #   false-positive mid-init).
@@ -45,8 +51,12 @@ ARG PG_BASE=postgres:16.14-bookworm@sha256:da514b7d293c5e9126503f85ecd835f4fb094
 # ── Stage 1: build pgvector against the exact server version ────────────
 FROM ${PG_BASE} AS pgvector-build
 
-# pgvector release tag — bump deliberately, never float.
+# pgvector release tag + the commit it resolved to at pin time — bump both
+# deliberately, never float. Tags are mutable refs; the commit SHA is the
+# actual pin (PR #1334 review). Resolved 2026-06-11 via
+#   git ls-remote https://github.com/pgvector/pgvector.git refs/tags/v0.8.2
 ARG PGVECTOR_VERSION=v0.8.2
+ARG PGVECTOR_COMMIT=cab9da72c04353f143bb06b42ab70a403daac64a
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential git ca-certificates postgresql-server-dev-16 \
@@ -55,8 +65,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # OPTFLAGS="" strips pgvector's default -march=native — this image must be
 # portable across CPUs (and across the amd64/arm64 publish matrix), not
 # tuned to the build host. Same convention as the upstream pgvector image.
+# The rev-parse check fails the build if upstream ever moves the tag, so a
+# retagged v0.8.2 cannot silently change what we ship.
 RUN git clone --branch "${PGVECTOR_VERSION}" --depth 1 \
         https://github.com/pgvector/pgvector.git /tmp/pgvector \
+    && [ "$(git -C /tmp/pgvector rev-parse HEAD)" = "${PGVECTOR_COMMIT}" ] \
+       || { echo "pgvector tag ${PGVECTOR_VERSION} no longer points at pinned commit ${PGVECTOR_COMMIT}" >&2; exit 1; } \
     && make -C /tmp/pgvector OPTFLAGS="" -j"$(nproc)" \
     && make -C /tmp/pgvector install DESTDIR=/out
 

--- a/deploy/docker/Dockerfile.server
+++ b/deploy/docker/Dockerfile.server
@@ -100,8 +100,15 @@ FROM debian:trixie-slim@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b
 # (The deb/rpm/systemd paths instead make /etc/yuzu itself service-owned, so the
 # server's runtime mkdir of certs/ succeeds there without this eager pre-create;
 # the container needs it because the base image's /etc/yuzu is root-owned.)
+# libpq5 replaced libsqlite3-0 in #1318 (Postgres substrate, ADR-0006/0008).
+# libsqlite3-0 was vestigial: ldd on the shipped 0.12.0 binary shows SQLite
+# is statically linked from vcpkg (only libstdc++/libm/libgcc_s/libc are
+# dynamic). libpq5 is forward-insurance for the #1320 server-side Postgres
+# wiring — ADR-0008 plans static vcpkg libpq, in which case this too is
+# belt-and-braces, but it keeps the image correct if the Windows static-link
+# canary forces a dynamic-libpq fallback.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libssl3 libsqlite3-0 ca-certificates bash \
+    libssl3 libpq5 ca-certificates bash \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -r -s /usr/sbin/nologin yuzu \
     && mkdir -p /var/lib/yuzu /etc/yuzu/certs \

--- a/deploy/docker/Dockerfile.server-local
+++ b/deploy/docker/Dockerfile.server-local
@@ -11,8 +11,10 @@
 
 FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
 
+# libpq5 replaced libsqlite3-0 in #1318 — mirrors Dockerfile.server stage 3
+# (SQLite is statically linked from vcpkg; see the comment there).
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libssl3 libsqlite3-0 ca-certificates \
+    libssl3 libpq5 ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -r -s /usr/sbin/nologin yuzu \
     && mkdir -p /var/lib/yuzu /etc/yuzu \

--- a/deploy/docker/Dockerfile.server.chisel
+++ b/deploy/docker/Dockerfile.server.chisel
@@ -94,6 +94,11 @@ RUN set -eux; \
 
 # See Dockerfile.agent.chisel for the per-slice rationale. The server needs no
 # plugin/DSO slices but is otherwise the same closure.
+# libpq5_libs replaced libsqlite3-0_libs in #1318 (Postgres substrate,
+# ADR-0006/0008) — the sqlite slice was vestigial (SQLite is statically
+# linked from vcpkg; verified via ldd on the published image, see
+# Dockerfile.server). libpq5_libs' essential slices (libgssapi-krb5-2,
+# libldap2) are resolved by chisel automatically.
 # Retry loop: `chisel cut` downloads the Ubuntu archive indices (main +
 # universe) over the network and the large universe index occasionally EOFs
 # mid-fetch. Retrying keeps release rebuilds reliable.
@@ -101,7 +106,7 @@ RUN set -eux; mkdir -p /rootfs; \
     SLICES="base-files_base base-files_etc base-files_var base-files_tmp \
       base-files_release-info base-passwd_data netbase_config \
       ca-certificates_data openssl_config libc6_libs libgcc-s1_libs \
-      libstdc++6_libs libssl3t64_libs libsqlite3-0_libs zlib1g_libs \
+      libstdc++6_libs libssl3t64_libs libpq5_libs zlib1g_libs \
       busybox-static_bins"; \
     ok=0; for i in 1 2 3 4 5; do \
       if chisel cut --release "${CHISEL_RELEASE}" --root /rootfs ${SLICES}; then ok=1; break; fi; \

--- a/deploy/docker/docker-compose.demo.yml
+++ b/deploy/docker/docker-compose.demo.yml
@@ -62,6 +62,11 @@ services:
       # gRPC honours them and breaks cross-container bidi RPC. Force-bypass.
       NO_PROXY: "*"
       no_proxy: "*"
+      # Postgres substrate DSN (ADR-0006, #1318) — inert until #1320 wires
+      # the server-side consumer; env var (not CLI flag) on purpose because
+      # the current binary rejects unknown flags. Demo-only baked default —
+      # same convenience class as the baked admin password above.
+      YUZU_POSTGRES_DSN: postgresql://yuzu:${YUZU_POSTGRES_PASSWORD:-yuzu-demo}@postgres:5432/yuzu
     ports:
       - "8080:8080"     # Dashboard + REST API (operator-facing)
     volumes:
@@ -74,6 +79,33 @@ services:
       timeout: 3s
       retries: 40
       start_period: 5s
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # ── Tier 1b: PostgreSQL (server storage substrate, ADR-0006) ───────────
+  # Release-pinned like every other image here (no -chisel variant — this is
+  # the same yuzu-postgres image production composes use). Published + signed
+  # by docker-publish-postgres in release.yml; start-demo.sh --build builds
+  # it locally during pre-release bootstrap.
+  postgres:
+    image: ${YUZU_REGISTRY:-ghcr.io/tr3kkr}/yuzu-postgres:${YUZU_VERSION:-0.12.0}
+    container_name: yuzu-demo-postgres
+    environment:
+      NO_PROXY: "*"
+      no_proxy: "*"
+      POSTGRES_PASSWORD: ${YUZU_POSTGRES_PASSWORD:-yuzu-demo}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      # -h 127.0.0.1 forces TCP — the init-phase temporary server is
+      # unix-socket-only, so a socket probe could pass mid-init.
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
     restart: unless-stopped
 
   # ── Tier 2: Erlang Gateway (chiselled Ubuntu 26.04) ────────────────────
@@ -142,3 +174,4 @@ services:
 
 volumes:
   server-data:
+  postgres-data:

--- a/deploy/docker/docker-compose.demo.yml
+++ b/deploy/docker/docker-compose.demo.yml
@@ -64,9 +64,11 @@ services:
       no_proxy: "*"
       # Postgres substrate DSN (ADR-0006, #1318) — inert until #1320 wires
       # the server-side consumer; env var (not CLI flag) on purpose because
-      # the current binary rejects unknown flags. Demo-only baked default —
-      # same convenience class as the baked admin password above.
-      YUZU_POSTGRES_DSN: postgresql://yuzu:${YUZU_POSTGRES_PASSWORD:-yuzu-demo}@postgres:5432/yuzu
+      # the current binary rejects unknown flags. ⚠ DEMO-ONLY baked default
+      # password ('yuzu-demo-app') — same convenience class as the baked
+      # admin password above; never reuse outside this rig. The DSN carries
+      # the APP role credential, distinct from the superuser's below.
+      YUZU_POSTGRES_DSN: postgresql://yuzu:${YUZU_DB_PASSWORD:-yuzu-demo-app}@postgres:5432/yuzu
     ports:
       - "8080:8080"     # Dashboard + REST API (operator-facing)
     volumes:
@@ -95,13 +97,22 @@ services:
     environment:
       NO_PROXY: "*"
       no_proxy: "*"
+      # ⚠ DEMO-ONLY default passwords — superuser ('yuzu-demo') and app
+      # role ('yuzu-demo-app') must stay DISTINCT: first-boot init refuses
+      # to run if they are equal (PR #1334 review, S1).
       POSTGRES_PASSWORD: ${YUZU_POSTGRES_PASSWORD:-yuzu-demo}
+      YUZU_DB_PASSWORD: ${YUZU_DB_PASSWORD:-yuzu-demo-app}
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
       # -h 127.0.0.1 forces TCP — the init-phase temporary server is
-      # unix-socket-only, so a socket probe could pass mid-init.
-      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu"]
+      # unix-socket-only, so a socket probe could pass mid-init. psql
+      # SELECT 1 over the app DSN proves the app credential authenticates
+      # ($$ defers expansion to the container's shell). The psql leg
+      # dials the container's own hostname, NOT loopback: initdb leaves
+      # 'trust' auth on 127.0.0.1, so only a non-loopback connection
+      # actually verifies the password (scram).
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu && psql \"postgresql://yuzu:$${YUZU_DB_PASSWORD}@$$(hostname):5432/yuzu\" -tA -c 'SELECT 1' >/dev/null"]
       interval: 5s
       timeout: 5s
       retries: 12

--- a/deploy/docker/docker-compose.full-uat.yml
+++ b/deploy/docker/docker-compose.full-uat.yml
@@ -52,8 +52,9 @@ services:
     environment:
       # Postgres substrate DSN (ADR-0006, #1318) — inert until #1320 wires
       # the server-side consumer; env var (not CLI flag) on purpose because
-      # the current binary rejects unknown flags.
-      - YUZU_POSTGRES_DSN=postgresql://yuzu:${YUZU_POSTGRES_PASSWORD:-yuzu}@postgres:5432/yuzu
+      # the current binary rejects unknown flags. ⚠ DEV/UAT-ONLY default
+      # password ('yuzu-app') — distinct from the superuser default.
+      - YUZU_POSTGRES_DSN=postgresql://yuzu:${YUZU_DB_PASSWORD:-yuzu-app}@postgres:5432/yuzu
     ports:
       - "8080:8080"     # Web dashboard + REST API
       - "50052:50052"   # gRPC (management)
@@ -78,13 +79,22 @@ services:
     image: yuzu-postgres:local
     container_name: yuzu-uat-postgres
     environment:
+      # ⚠ DEV/UAT-ONLY default passwords — superuser ('yuzu') and app role
+      # ('yuzu-app') must stay DISTINCT: first-boot init refuses to run if
+      # they are equal (PR #1334 review, S1).
       - POSTGRES_PASSWORD=${YUZU_POSTGRES_PASSWORD:-yuzu}
+      - YUZU_DB_PASSWORD=${YUZU_DB_PASSWORD:-yuzu-app}
     volumes:
       - postgres-uat-data:/var/lib/postgresql/data
     healthcheck:
       # -h 127.0.0.1 forces TCP — the init-phase temporary server is
-      # unix-socket-only, so a socket probe could pass mid-init.
-      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu"]
+      # unix-socket-only, so a socket probe could pass mid-init. psql
+      # SELECT 1 over the app DSN proves the app credential authenticates
+      # ($$ defers expansion to the container's shell). The psql leg
+      # dials the container's own hostname, NOT loopback: initdb leaves
+      # 'trust' auth on 127.0.0.1, so only a non-loopback connection
+      # actually verifies the password (scram).
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu && psql \"postgresql://yuzu:$${YUZU_DB_PASSWORD}@$$(hostname):5432/yuzu\" -tA -c 'SELECT 1' >/dev/null"]
       interval: 5s
       timeout: 5s
       retries: 12

--- a/deploy/docker/docker-compose.full-uat.yml
+++ b/deploy/docker/docker-compose.full-uat.yml
@@ -49,6 +49,11 @@ services:
       - "5"
       - "--analytics-batch-size"
       - "50"
+    environment:
+      # Postgres substrate DSN (ADR-0006, #1318) — inert until #1320 wires
+      # the server-side consumer; env var (not CLI flag) on purpose because
+      # the current binary rejects unknown flags.
+      - YUZU_POSTGRES_DSN=postgresql://yuzu:${YUZU_POSTGRES_PASSWORD:-yuzu}@postgres:5432/yuzu
     ports:
       - "8080:8080"     # Web dashboard + REST API
       - "50052:50052"   # gRPC (management)
@@ -61,6 +66,29 @@ services:
     depends_on:
       clickhouse:
         condition: service_started
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # ── PostgreSQL (server storage substrate, ADR-0006) ────────────────────
+  postgres:
+    build:
+      context: ../..
+      dockerfile: deploy/docker/Dockerfile.postgres
+    image: yuzu-postgres:local
+    container_name: yuzu-uat-postgres
+    environment:
+      - POSTGRES_PASSWORD=${YUZU_POSTGRES_PASSWORD:-yuzu}
+    volumes:
+      - postgres-uat-data:/var/lib/postgresql/data
+    healthcheck:
+      # -h 127.0.0.1 forces TCP — the init-phase temporary server is
+      # unix-socket-only, so a socket probe could pass mid-init.
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
     restart: unless-stopped
 
   # ── Erlang Gateway ─────────────────────────────────────────────────────
@@ -134,6 +162,7 @@ services:
 
 volumes:
   server-data:
+  postgres-uat-data:
   prometheus-uat-data:
   grafana-uat-data:
   clickhouse-uat-data:

--- a/deploy/docker/docker-compose.reference.yml
+++ b/deploy/docker/docker-compose.reference.yml
@@ -22,7 +22,12 @@
 ##
 ## Usage:
 ##   export YUZU_VERSION=0.10.0
-##   export YUZU_POSTGRES_PASSWORD="$(openssl rand -hex 24)"   # store it in your secrets manager
+##   # Two DISTINCT credentials — store both in your secrets manager. The
+##   # superuser password stays inside the postgres service; the app role
+##   # password is what the server's DSN carries. They must differ (the
+##   # image's first-boot init refuses to run if they are equal).
+##   export YUZU_POSTGRES_PASSWORD="$(openssl rand -hex 24)"   # postgres superuser
+##   export YUZU_DB_PASSWORD="$(openssl rand -hex 24)"         # yuzu app role
 ##   docker compose -f docker-compose.reference.yml up -d
 ##   docker compose -f docker-compose.reference.yml logs -f server
 ##
@@ -80,7 +85,10 @@ services:
       # flags. Pointing this at an external/managed Postgres instead of
       # the bundled service below is fully supported — replace the whole
       # DSN and drop the postgres service + depends_on if you do.
-      YUZU_POSTGRES_DSN: postgresql://yuzu:${YUZU_POSTGRES_PASSWORD:?set YUZU_POSTGRES_PASSWORD (no insecure default in the reference template)}@postgres:5432/yuzu
+      # The DSN carries the APP role password (YUZU_DB_PASSWORD), never the
+      # superuser's — a leaked server environment must not disclose
+      # superuser credentials.
+      YUZU_POSTGRES_DSN: postgresql://yuzu:${YUZU_DB_PASSWORD:?set YUZU_DB_PASSWORD (app role password, distinct from YUZU_POSTGRES_PASSWORD; no insecure default in the reference template)}@postgres:5432/yuzu
     depends_on:
       postgres:
         condition: service_healthy
@@ -152,6 +160,10 @@ services:
     restart: unless-stopped
     environment:
       POSTGRES_PASSWORD: ${YUZU_POSTGRES_PASSWORD:?set YUZU_POSTGRES_PASSWORD (no insecure default in the reference template)}
+      # App role password — DISTINCT from the superuser password above.
+      # First-boot init refuses to run if they are equal or if this is
+      # unset. The server's YUZU_POSTGRES_DSN carries this credential.
+      YUZU_DB_PASSWORD: ${YUZU_DB_PASSWORD:?set YUZU_DB_PASSWORD (app role password, distinct from YUZU_POSTGRES_PASSWORD)}
     volumes:
       # Database state — same persistence rules as server-data: back it up,
       # never `down -v` unless you intend to destroy it.
@@ -160,8 +172,14 @@ services:
       # -h 127.0.0.1 forces a TCP probe — during first-boot init the
       # temporary server listens on the unix socket only, so a socket
       # probe would report ready before the init scripts have run.
-      # -U yuzu -d yuzu also proves the app role/db exist.
-      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu"]
+      # pg_isready is the liveness baseline; the psql SELECT 1 over the
+      # exact app DSN proves the app credential authenticates (PR #1334
+      # review, S5). $$ defers expansion to the container's shell so the
+      # password never appears in `docker compose config` output. The
+      # psql leg dials the container's own hostname, NOT loopback:
+      # initdb leaves 'trust' auth on 127.0.0.1, so only a non-loopback
+      # connection actually verifies the password (scram).
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu && psql \"postgresql://yuzu:$${YUZU_DB_PASSWORD}@$$(hostname):5432/yuzu\" -tA -c 'SELECT 1' >/dev/null"]
       interval: 5s
       timeout: 5s
       retries: 12

--- a/deploy/docker/docker-compose.reference.yml
+++ b/deploy/docker/docker-compose.reference.yml
@@ -22,6 +22,7 @@
 ##
 ## Usage:
 ##   export YUZU_VERSION=0.10.0
+##   export YUZU_POSTGRES_PASSWORD="$(openssl rand -hex 24)"   # store it in your secrets manager
 ##   docker compose -f docker-compose.reference.yml up -d
 ##   docker compose -f docker-compose.reference.yml logs -f server
 ##
@@ -71,6 +72,18 @@ services:
       nofile:
         soft: 65536
         hard: 65536
+    environment:
+      # Postgres substrate DSN (ADR-0006/0007, #1318). The server does not
+      # consume this yet — #1320 wires the server-side plumbing — so it is
+      # inert today and the server still boots without Postgres. Env var
+      # (not a CLI flag) on purpose: the current binary rejects unknown
+      # flags. Pointing this at an external/managed Postgres instead of
+      # the bundled service below is fully supported — replace the whole
+      # DSN and drop the postgres service + depends_on if you do.
+      YUZU_POSTGRES_DSN: postgresql://yuzu:${YUZU_POSTGRES_PASSWORD:?set YUZU_POSTGRES_PASSWORD (no insecure default in the reference template)}@postgres:5432/yuzu
+    depends_on:
+      postgres:
+        condition: service_healthy
     volumes:
       # Single writable volume for all server state:
       #   - SQLite databases (response, audit, policy, RBAC, etc.)
@@ -127,6 +140,33 @@ services:
       retries: 3
       start_period: 30s
 
+  # ── PostgreSQL (server storage substrate, ADR-0006) ──────────────────
+  # Release-pinned, signed yuzu-postgres image: PostgreSQL 16 + pgvector +
+  # first-boot app role/db init. Per-store schemas are created at runtime
+  # by the server's migration runner. Using an external/managed Postgres
+  # instead is first-class — point YUZU_POSTGRES_DSN at it and remove this
+  # service.
+  postgres:
+    image: ghcr.io/tr3kkr/yuzu-postgres:${YUZU_VERSION:-0.12.0}
+    container_name: yuzu-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: ${YUZU_POSTGRES_PASSWORD:?set YUZU_POSTGRES_PASSWORD (no insecure default in the reference template)}
+    volumes:
+      # Database state — same persistence rules as server-data: back it up,
+      # never `down -v` unless you intend to destroy it.
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      # -h 127.0.0.1 forces a TCP probe — during first-boot init the
+      # temporary server listens on the unix socket only, so a socket
+      # probe would report ready before the init scripts have run.
+      # -U yuzu -d yuzu also proves the app role/db exist.
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+
   # ── Yuzu Agent — install natively, not in Docker ─────────────────────
   #
   # Agents always run natively on each managed endpoint. We do NOT
@@ -148,7 +188,8 @@ services:
   # encourage that path.
 
 volumes:
-  # Named volume for server state — must persist across
+  # Named volumes for server + database state — must persist across
   # `docker compose down`. Do NOT use `docker compose down -v` unless
   # you intend to destroy state.
   server-data:
+  postgres-data:

--- a/deploy/docker/docker-compose.sanitizer-uat.yml
+++ b/deploy/docker/docker-compose.sanitizer-uat.yml
@@ -30,6 +30,11 @@ services:
       - "--metrics-no-auth"
       - "--config"
       - "/var/lib/yuzu/yuzu-server.cfg"
+    environment:
+      # Postgres substrate DSN (ADR-0006, #1318) — inert until #1320 wires
+      # the server-side consumer; env var (not CLI flag) on purpose because
+      # the current binary rejects unknown flags.
+      - YUZU_POSTGRES_DSN=postgresql://yuzu:${YUZU_POSTGRES_PASSWORD:-yuzu}@postgres:5432/yuzu
     ports:
       - "8080:8080"
       - "50051:50051"
@@ -39,6 +44,32 @@ services:
       # InstructionDefinitions are embedded into yuzu-server at build time
       # (server/core/scripts/embed_content.py); no host mount required.
       - sanitizer-logs:/var/log/yuzu
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+
+  # ── PostgreSQL (server storage substrate, ADR-0006) ──────────────────
+  # Not sanitizer-instrumented (upstream postgres + pgvector); built from
+  # deploy/docker/Dockerfile.postgres on demand by `docker compose up`.
+  postgres:
+    build:
+      context: ../..
+      dockerfile: deploy/docker/Dockerfile.postgres
+    image: yuzu-postgres:local
+    container_name: yuzu-san-postgres
+    environment:
+      - POSTGRES_PASSWORD=${YUZU_POSTGRES_PASSWORD:-yuzu}
+    healthcheck:
+      # -h 127.0.0.1 forces TCP — the init-phase temporary server is
+      # unix-socket-only, so a socket probe could pass mid-init.
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    # Ephemeral rig — no data volume on purpose (matches restart: "no"
+    # everywhere else in this file).
     restart: "no"
 
   gateway:

--- a/deploy/docker/docker-compose.sanitizer-uat.yml
+++ b/deploy/docker/docker-compose.sanitizer-uat.yml
@@ -33,8 +33,9 @@ services:
     environment:
       # Postgres substrate DSN (ADR-0006, #1318) — inert until #1320 wires
       # the server-side consumer; env var (not CLI flag) on purpose because
-      # the current binary rejects unknown flags.
-      - YUZU_POSTGRES_DSN=postgresql://yuzu:${YUZU_POSTGRES_PASSWORD:-yuzu}@postgres:5432/yuzu
+      # the current binary rejects unknown flags. ⚠ DEV/UAT-ONLY default
+      # password ('yuzu-app') — distinct from the superuser default.
+      - YUZU_POSTGRES_DSN=postgresql://yuzu:${YUZU_DB_PASSWORD:-yuzu-app}@postgres:5432/yuzu
     ports:
       - "8080:8080"
       - "50051:50051"
@@ -59,11 +60,20 @@ services:
     image: yuzu-postgres:local
     container_name: yuzu-san-postgres
     environment:
+      # ⚠ DEV/UAT-ONLY default passwords — superuser ('yuzu') and app role
+      # ('yuzu-app') must stay DISTINCT: first-boot init refuses to run if
+      # they are equal (PR #1334 review, S1).
       - POSTGRES_PASSWORD=${YUZU_POSTGRES_PASSWORD:-yuzu}
+      - YUZU_DB_PASSWORD=${YUZU_DB_PASSWORD:-yuzu-app}
     healthcheck:
       # -h 127.0.0.1 forces TCP — the init-phase temporary server is
-      # unix-socket-only, so a socket probe could pass mid-init.
-      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu"]
+      # unix-socket-only, so a socket probe could pass mid-init. psql
+      # SELECT 1 over the app DSN proves the app credential authenticates
+      # ($$ defers expansion to the container's shell). The psql leg
+      # dials the container's own hostname, NOT loopback: initdb leaves
+      # 'trust' auth on 127.0.0.1, so only a non-loopback connection
+      # actually verifies the password (scram).
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu && psql \"postgresql://yuzu:$${YUZU_DB_PASSWORD}@$$(hostname):5432/yuzu\" -tA -c 'SELECT 1' >/dev/null"]
       interval: 5s
       timeout: 5s
       retries: 12

--- a/deploy/docker/docker-compose.viz-uat.yml
+++ b/deploy/docker/docker-compose.viz-uat.yml
@@ -110,8 +110,9 @@ services:
       no_proxy: "*"
       # Postgres substrate DSN (ADR-0006, #1318) — inert until #1320 wires
       # the server-side consumer; env var (not CLI flag) on purpose because
-      # the current binary rejects unknown flags.
-      YUZU_POSTGRES_DSN: postgresql://yuzu:${YUZU_POSTGRES_PASSWORD:-yuzu}@postgres:5432/yuzu
+      # the current binary rejects unknown flags. ⚠ DEV/UAT-ONLY default
+      # password ('yuzu-app') — distinct from the superuser default.
+      YUZU_POSTGRES_DSN: postgresql://yuzu:${YUZU_DB_PASSWORD:-yuzu-app}@postgres:5432/yuzu
     ports:
       - "8080:8080"   # Web dashboard + REST API (operator-facing)
       - "50055:50055" # Gateway upstream (debugging convenience)
@@ -145,13 +146,22 @@ services:
     image: yuzu-postgres:local
     container_name: yuzu-viz-postgres
     environment:
+      # ⚠ DEV/UAT-ONLY default passwords — superuser ('yuzu') and app role
+      # ('yuzu-app') must stay DISTINCT: first-boot init refuses to run if
+      # they are equal (PR #1334 review, S1).
       POSTGRES_PASSWORD: ${YUZU_POSTGRES_PASSWORD:-yuzu}
+      YUZU_DB_PASSWORD: ${YUZU_DB_PASSWORD:-yuzu-app}
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
       # -h 127.0.0.1 forces TCP — the init-phase temporary server is
-      # unix-socket-only, so a socket probe could pass mid-init.
-      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu"]
+      # unix-socket-only, so a socket probe could pass mid-init. psql
+      # SELECT 1 over the app DSN proves the app credential authenticates
+      # ($$ defers expansion to the container's shell). The psql leg
+      # dials the container's own hostname, NOT loopback: initdb leaves
+      # 'trust' auth on 127.0.0.1, so only a non-loopback connection
+      # actually verifies the password (scram).
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu && psql \"postgresql://yuzu:$${YUZU_DB_PASSWORD}@$$(hostname):5432/yuzu\" -tA -c 'SELECT 1' >/dev/null"]
       interval: 5s
       timeout: 5s
       retries: 12

--- a/deploy/docker/docker-compose.viz-uat.yml
+++ b/deploy/docker/docker-compose.viz-uat.yml
@@ -108,9 +108,16 @@ services:
       # and doesn't need a proxy.
       NO_PROXY: "*"
       no_proxy: "*"
+      # Postgres substrate DSN (ADR-0006, #1318) — inert until #1320 wires
+      # the server-side consumer; env var (not CLI flag) on purpose because
+      # the current binary rejects unknown flags.
+      YUZU_POSTGRES_DSN: postgresql://yuzu:${YUZU_POSTGRES_PASSWORD:-yuzu}@postgres:5432/yuzu
     ports:
       - "8080:8080"   # Web dashboard + REST API (operator-facing)
       - "50055:50055" # Gateway upstream (debugging convenience)
+    depends_on:
+      postgres:
+        condition: service_healthy
     volumes:
       # VIZ_UAT_CONFIG must be set explicitly -- the launcher always exports
       # it after generate_config() writes the cfg file. There is no compose
@@ -128,6 +135,27 @@ services:
       timeout: 3s
       retries: 30
       start_period: 5s
+    restart: unless-stopped
+
+  # ── PostgreSQL (server storage substrate, ADR-0006) ──────────────────────
+  postgres:
+    build:
+      context: ../..
+      dockerfile: deploy/docker/Dockerfile.postgres
+    image: yuzu-postgres:local
+    container_name: yuzu-viz-postgres
+    environment:
+      POSTGRES_PASSWORD: ${YUZU_POSTGRES_PASSWORD:-yuzu}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      # -h 127.0.0.1 forces TCP — the init-phase temporary server is
+      # unix-socket-only, so a socket probe could pass mid-init.
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
     restart: unless-stopped
 
   # ── Erlang Gateway ──────────────────────────────────────────────────────
@@ -318,3 +346,4 @@ services:
 
 volumes:
   server-data:
+  postgres-data:

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -35,7 +35,10 @@ services:
       # so today it is inert and the server still boots without Postgres.
       # Env var (not a CLI flag) on purpose: the current binary would
       # reject an unknown --postgres-dsn flag.
-      YUZU_POSTGRES_DSN: postgresql://yuzu:${YUZU_POSTGRES_PASSWORD:-yuzu}@postgres:5432/yuzu
+      # ⚠ DEV-ONLY default password ('yuzu-app') — this compose is a local
+      # dev rig. Production deployments use docker-compose.reference.yml,
+      # which REQUIRES distinct YUZU_POSTGRES_PASSWORD + YUZU_DB_PASSWORD.
+      YUZU_POSTGRES_DSN: postgresql://yuzu:${YUZU_DB_PASSWORD:-yuzu-app}@postgres:5432/yuzu
     volumes:
       - server-data:/var/lib/yuzu
     # File-descriptor headroom mirrors the systemd unit
@@ -58,15 +61,23 @@ services:
       dockerfile: deploy/docker/Dockerfile.postgres
     image: yuzu-postgres:local
     environment:
+      # ⚠ DEV-ONLY default passwords — superuser ('yuzu') and app role
+      # ('yuzu-app') must stay DISTINCT: the image's first-boot init
+      # refuses to run if they are equal (PR #1334 review, S1).
       POSTGRES_PASSWORD: ${YUZU_POSTGRES_PASSWORD:-yuzu}
+      YUZU_DB_PASSWORD: ${YUZU_DB_PASSWORD:-yuzu-app}
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
       # -h 127.0.0.1 forces a TCP probe — during first-boot init the
       # temporary server listens on the unix socket only, so a socket
       # probe would report ready before the init scripts have run.
-      # -U yuzu -d yuzu also proves the app role/db exist.
-      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu"]
+      # psql SELECT 1 over the app DSN proves the app credential
+      # authenticates ($$ defers expansion to the container's shell).
+      # The psql leg dials the container's own hostname, NOT loopback:
+      # initdb leaves 'trust' auth on 127.0.0.1, so only a non-loopback
+      # connection actually verifies the password (scram).
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu && psql \"postgresql://yuzu:$${YUZU_DB_PASSWORD}@$$(hostname):5432/yuzu\" -tA -c 'SELECT 1' >/dev/null"]
       interval: 5s
       timeout: 5s
       retries: 12

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -29,6 +29,13 @@ services:
       - "8080:8080"     # Web dashboard + REST API
       - "50051:50051"   # gRPC (agent connections)
       - "50052:50052"   # gRPC (management)
+    environment:
+      # Postgres substrate DSN (ADR-0006/0007, #1318). The server does not
+      # consume this yet — #1320 wires the --postgres-dsn / env plumbing —
+      # so today it is inert and the server still boots without Postgres.
+      # Env var (not a CLI flag) on purpose: the current binary would
+      # reject an unknown --postgres-dsn flag.
+      YUZU_POSTGRES_DSN: postgresql://yuzu:${YUZU_POSTGRES_PASSWORD:-yuzu}@postgres:5432/yuzu
     volumes:
       - server-data:/var/lib/yuzu
     # File-descriptor headroom mirrors the systemd unit
@@ -39,6 +46,31 @@ services:
       nofile:
         soft: 65536
         hard: 65536
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # ── PostgreSQL (server storage substrate, ADR-0006) ─────────────────
+  postgres:
+    build:
+      context: ../..
+      dockerfile: deploy/docker/Dockerfile.postgres
+    image: yuzu-postgres:local
+    environment:
+      POSTGRES_PASSWORD: ${YUZU_POSTGRES_PASSWORD:-yuzu}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      # -h 127.0.0.1 forces a TCP probe — during first-boot init the
+      # temporary server listens on the unix socket only, so a socket
+      # probe would report ready before the init scripts have run.
+      # -U yuzu -d yuzu also proves the app role/db exist.
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
     restart: unless-stopped
 
   # ── Prometheus ──────────────────────────────────────────────────────
@@ -66,5 +98,6 @@ services:
 
 volumes:
   server-data:
+  postgres-data:
   prometheus-data:
   grafana-data:

--- a/deploy/docker/postgres-init/10-create-yuzu-role-db.sh
+++ b/deploy/docker/postgres-init/10-create-yuzu-role-db.sh
@@ -10,18 +10,43 @@
 #
 # Runs under the upstream postgres entrypoint (docker-entrypoint-initdb.d),
 # i.e. only when the data directory is empty. Guarded with WHERE NOT EXISTS
-# anyway so a custom POSTGRES_USER/POSTGRES_DB that collides with the Yuzu
-# defaults cannot abort initdb.
+# so a custom POSTGRES_USER/POSTGRES_DB that collides with the Yuzu defaults
+# cannot abort initdb — but a pre-existing role/db is then VALIDATED
+# (non-superuser, login-capable, correct db owner) so the collision cannot
+# silently hand the app DSN superuser rights (PR #1334 review, S4).
 #
 # Env contract (see Dockerfile.postgres header):
 #   YUZU_DB_USER      app role      (default: yuzu)
 #   YUZU_DB_NAME      app database  (default: yuzu)
-#   YUZU_DB_PASSWORD  app password  (default: POSTGRES_PASSWORD)
+#   YUZU_DB_PASSWORD  app password  REQUIRED — must differ from
+#                     POSTGRES_PASSWORD. There is deliberately no fallback
+#                     to the superuser password: a leaked app DSN must never
+#                     disclose superuser credentials (PR #1334 review, S1).
 set -euo pipefail
 
 YUZU_DB_USER="${YUZU_DB_USER:-yuzu}"
 YUZU_DB_NAME="${YUZU_DB_NAME:-yuzu}"
-YUZU_DB_PASSWORD="${YUZU_DB_PASSWORD:-${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set (upstream image contract)}}"
+
+# ── Credential / identity guards (S1 + S4) ───────────────────────────────
+if [[ -z "${YUZU_DB_PASSWORD:-}" ]]; then
+    echo "yuzu-postgres init: ERROR — YUZU_DB_PASSWORD is not set." >&2
+    echo "  The app role password must be provided explicitly and must" >&2
+    echo "  differ from POSTGRES_PASSWORD (the superuser password)." >&2
+    echo "  Generate one:  openssl rand -hex 24" >&2
+    exit 1
+fi
+if [[ "${YUZU_DB_PASSWORD}" == "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set (upstream image contract)}" ]]; then
+    echo "yuzu-postgres init: ERROR — YUZU_DB_PASSWORD equals POSTGRES_PASSWORD." >&2
+    echo "  The app role and the superuser must not share a password: a" >&2
+    echo "  leaked app DSN would disclose superuser credentials." >&2
+    exit 1
+fi
+if [[ "${YUZU_DB_USER}" == "${POSTGRES_USER}" ]]; then
+    echo "yuzu-postgres init: ERROR — YUZU_DB_USER ('${YUZU_DB_USER}') equals POSTGRES_USER." >&2
+    echo "  The app role must not be the bootstrap superuser. Pick a" >&2
+    echo "  different YUZU_DB_USER (or POSTGRES_USER)." >&2
+    exit 1
+fi
 
 # psql variable substitution (:'var' literal / :"var" identifier) + format()
 # with %I/%L handles quoting safely — role/db names and the password are
@@ -38,9 +63,49 @@ WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = :'yuzu_user')
 SELECT format('CREATE DATABASE %I OWNER %I', :'yuzu_db', :'yuzu_user')
 WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = :'yuzu_db')
 \gexec
+EOSQL
 
-\connect :"yuzu_db"
+# ── Post-create validation (S4) ──────────────────────────────────────────
+# Whether we just created them or a custom POSTGRES_USER/POSTGRES_DB
+# collided with the Yuzu names, the end state must be: non-superuser
+# login-capable app role, app database owned by it. Fail the boot loudly
+# otherwise — a silently-superuser app role is worse than no database.
+role_attrs=$(psql -At -v ON_ERROR_STOP=1 -v yuzu_user="${YUZU_DB_USER}" \
+    --username "${POSTGRES_USER}" --dbname postgres <<'EOSQL'
+SELECT CASE
+         WHEN NOT rolsuper AND rolcanlogin THEN 'ok'
+         ELSE 'rolsuper=' || rolsuper::text || ',rolcanlogin=' || rolcanlogin::text
+       END
+  FROM pg_roles WHERE rolname = :'yuzu_user'
+EOSQL
+)
+if [[ "${role_attrs}" != "ok" ]]; then
+    echo "yuzu-postgres init: ERROR — role '${YUZU_DB_USER}' exists but is not a plain login role" >&2
+    echo "  (${role_attrs:-role missing}; expected rolsuper=false, rolcanlogin=true)." >&2
+    echo "  Refusing to hand the app DSN to this role. Drop/fix it or choose" >&2
+    echo "  a different YUZU_DB_USER." >&2
+    exit 1
+fi
+
+db_owner=$(psql -At -v ON_ERROR_STOP=1 -v yuzu_db="${YUZU_DB_NAME}" \
+    --username "${POSTGRES_USER}" --dbname postgres <<'EOSQL'
+SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = :'yuzu_db'
+EOSQL
+)
+if [[ "${db_owner}" != "${YUZU_DB_USER}" ]]; then
+    echo "yuzu-postgres init: ERROR — database '${YUZU_DB_NAME}' is owned by '${db_owner:-<missing>}'," >&2
+    echo "  expected '${YUZU_DB_USER}'. Refusing to continue with wrong ownership." >&2
+    exit 1
+fi
+
+# ── Extension + schema hardening inside the app database ─────────────────
+# REVOKE CREATE: PG15+ already restricts the public schema, but be explicit
+# — non-owner roles must not be able to create objects in public. The app
+# role keeps create rights via database/schema ownership.
+psql -v ON_ERROR_STOP=1 \
+     --username "${POSTGRES_USER}" --dbname "${YUZU_DB_NAME}" <<'EOSQL'
 CREATE EXTENSION IF NOT EXISTS vector;
+REVOKE CREATE ON SCHEMA public FROM PUBLIC;
 EOSQL
 
 echo "yuzu-postgres init: role '${YUZU_DB_USER}' + database '${YUZU_DB_NAME}' ready (pgvector installed)"

--- a/deploy/docker/postgres-init/10-create-yuzu-role-db.sh
+++ b/deploy/docker/postgres-init/10-create-yuzu-role-db.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# 10-create-yuzu-role-db.sh — first-boot init for the yuzu-postgres image.
+#
+# Creates the Yuzu application role and database, and installs the pgvector
+# extension into the app database (extension creation needs superuser; doing
+# it here means the app role never needs elevated rights).
+#
+# Per-store SCHEMAs and all tables are created at runtime by the server's
+# migration runner (ADR-0008) — deliberately NOT here.
+#
+# Runs under the upstream postgres entrypoint (docker-entrypoint-initdb.d),
+# i.e. only when the data directory is empty. Guarded with WHERE NOT EXISTS
+# anyway so a custom POSTGRES_USER/POSTGRES_DB that collides with the Yuzu
+# defaults cannot abort initdb.
+#
+# Env contract (see Dockerfile.postgres header):
+#   YUZU_DB_USER      app role      (default: yuzu)
+#   YUZU_DB_NAME      app database  (default: yuzu)
+#   YUZU_DB_PASSWORD  app password  (default: POSTGRES_PASSWORD)
+set -euo pipefail
+
+YUZU_DB_USER="${YUZU_DB_USER:-yuzu}"
+YUZU_DB_NAME="${YUZU_DB_NAME:-yuzu}"
+YUZU_DB_PASSWORD="${YUZU_DB_PASSWORD:-${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set (upstream image contract)}}"
+
+# psql variable substitution (:'var' literal / :"var" identifier) + format()
+# with %I/%L handles quoting safely — role/db names and the password are
+# never spliced into SQL by the shell.
+psql -v ON_ERROR_STOP=1 \
+     -v yuzu_user="${YUZU_DB_USER}" \
+     -v yuzu_pass="${YUZU_DB_PASSWORD}" \
+     -v yuzu_db="${YUZU_DB_NAME}" \
+     --username "${POSTGRES_USER}" --dbname postgres <<'EOSQL'
+SELECT format('CREATE ROLE %I LOGIN PASSWORD %L', :'yuzu_user', :'yuzu_pass')
+WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = :'yuzu_user')
+\gexec
+
+SELECT format('CREATE DATABASE %I OWNER %I', :'yuzu_db', :'yuzu_user')
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = :'yuzu_db')
+\gexec
+
+\connect :"yuzu_db"
+CREATE EXTENSION IF NOT EXISTS vector;
+EOSQL
+
+echo "yuzu-postgres init: role '${YUZU_DB_USER}' + database '${YUZU_DB_NAME}' ready (pgvector installed)"

--- a/deploy/systemd/yuzu-server.service
+++ b/deploy/systemd/yuzu-server.service
@@ -1,8 +1,14 @@
 [Unit]
 Description=Yuzu Endpoint Management Server
 Documentation=https://github.com/Tr3kkR/Yuzu
-After=network-online.target
-Wants=network-online.target
+# postgresql.service ordering is SOFT (Wants=, not Requires=): a missing
+# unit in Wants= is silently ignored, so installs without a local Postgres
+# — including those pointing YUZU_POSTGRES_DSN at an external/managed
+# database via the EnvironmentFile below — are unaffected. When a local
+# postgresql.service IS present, the server starts after it. (ADR-0006 /
+# #1318; the server-side DSN consumer lands in #1320.)
+After=network-online.target postgresql.service
+Wants=network-online.target postgresql.service
 # Restart-loop guard. If the process crashes more than StartLimitBurst
 # times within StartLimitIntervalSec, systemd stops restarting it and
 # the unit enters `failed` state. Without this, an auth.db corruption
@@ -20,6 +26,12 @@ StartLimitBurst=3
 Type=simple
 User=yuzu
 Group=yuzu
+# Optional environment file (leading '-' = no error when absent). Written
+# by scripts/install-server-postgres.sh; carries YUZU_POSTGRES_DSN for
+# either a locally-provisioned Postgres or an external/managed one —
+# external DSNs are first-class, just edit the file. Mode 0600 yuzu:yuzu
+# (the DSN embeds a credential).
+EnvironmentFile=-/etc/yuzu/yuzu-server.env
 ExecStart=/usr/local/bin/yuzu-server \
     --listen 0.0.0.0:50051 \
     --gateway-upstream 0.0.0.0:50055 \

--- a/docker-compose.uat.yml
+++ b/docker-compose.uat.yml
@@ -193,8 +193,9 @@ services:
       - YUZU_LOG_FORMAT=json
       # Postgres substrate DSN (ADR-0006, #1318) — inert until #1320 wires
       # the server-side consumer; env var (not CLI flag) on purpose because
-      # the current binary rejects unknown flags.
-      - YUZU_POSTGRES_DSN=postgresql://yuzu:${YUZU_POSTGRES_PASSWORD:-yuzu}@postgres:5432/yuzu
+      # the current binary rejects unknown flags. ⚠ DEV/UAT-ONLY default
+      # password ('yuzu-app') — distinct from the superuser default.
+      - YUZU_POSTGRES_DSN=postgresql://yuzu:${YUZU_DB_PASSWORD:-yuzu-app}@postgres:5432/yuzu
     command:
       - "--listen"
       - "0.0.0.0:50051"
@@ -257,13 +258,22 @@ services:
     container_name: yuzu-postgres
     restart: unless-stopped
     environment:
+      # ⚠ DEV/UAT-ONLY default passwords — superuser ('yuzu') and app role
+      # ('yuzu-app') must stay DISTINCT: first-boot init refuses to run if
+      # they are equal (PR #1334 review, S1).
       - POSTGRES_PASSWORD=${YUZU_POSTGRES_PASSWORD:-yuzu}
+      - YUZU_DB_PASSWORD=${YUZU_DB_PASSWORD:-yuzu-app}
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
       # -h 127.0.0.1 forces TCP — the init-phase temporary server is
-      # unix-socket-only, so a socket probe could pass mid-init.
-      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu"]
+      # unix-socket-only, so a socket probe could pass mid-init. psql
+      # SELECT 1 over the app DSN proves the app credential authenticates
+      # ($$ defers expansion to the container's shell). The psql leg
+      # dials the container's own hostname, NOT loopback: initdb leaves
+      # 'trust' auth on 127.0.0.1, so only a non-loopback connection
+      # actually verifies the password (scram).
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu && psql \"postgresql://yuzu:$${YUZU_DB_PASSWORD}@$$(hostname):5432/yuzu\" -tA -c 'SELECT 1' >/dev/null"]
       interval: 5s
       timeout: 5s
       retries: 12

--- a/docker-compose.uat.yml
+++ b/docker-compose.uat.yml
@@ -191,6 +191,10 @@ services:
     environment:
       - YUZU_LOG_LEVEL=info
       - YUZU_LOG_FORMAT=json
+      # Postgres substrate DSN (ADR-0006, #1318) — inert until #1320 wires
+      # the server-side consumer; env var (not CLI flag) on purpose because
+      # the current binary rejects unknown flags.
+      - YUZU_POSTGRES_DSN=postgresql://yuzu:${YUZU_POSTGRES_PASSWORD:-yuzu}@postgres:5432/yuzu
     command:
       - "--listen"
       - "0.0.0.0:50051"
@@ -244,6 +248,26 @@ services:
     depends_on:
       clickhouse:
         condition: service_healthy
+      postgres:
+        condition: service_healthy
+
+  # ── PostgreSQL (server storage substrate, ADR-0006) ─────────────────
+  postgres:
+    image: ghcr.io/tr3kkr/yuzu-postgres:${YUZU_VERSION:-0.12.0}
+    container_name: yuzu-postgres
+    restart: unless-stopped
+    environment:
+      - POSTGRES_PASSWORD=${YUZU_POSTGRES_PASSWORD:-yuzu}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      # -h 127.0.0.1 forces TCP — the init-phase temporary server is
+      # unix-socket-only, so a socket probe could pass mid-init.
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
 
   # ── Yuzu Gateway (Erlang/OTP) ────────────────────────────────────────
   gateway:
@@ -347,6 +371,7 @@ services:
 
 volumes:
   server-data:
+  postgres-data:
   prometheus-data:
   grafana-data:
   clickhouse-data:

--- a/docs/ci-architecture.md
+++ b/docs/ci-architecture.md
@@ -65,6 +65,40 @@ stalled runner. Requires the `RUNNER_INVENTORY_TOKEN` PAT secret
 (fine-grained, Administration:read on Tr3kkR/Yuzu); without it preflight
 returns false and self-hosted jobs are skipped with a clear reason.
 
+## Postgres for server tests (`YUZU_TEST_POSTGRES_DSN`)
+
+ADR-0006 decision 8: every tier that runs server tests gets a real
+PostgreSQL 16 and exports `YUZU_TEST_POSTGRES_DSN`. One script implements
+it everywhere — `scripts/ci/ensure-postgres.sh`, inserted as an
+`Ensure Postgres 16 (server tests)` step between Build and Test in
+ci.yml (linux / windows / macos) and nightly.yml (asan / tsan / coverage).
+Resolution order inside the script:
+
+1. **Pre-set `YUZU_TEST_POSTGRES_DSN`** (runner-level env) — trusted
+   as-is. The escape hatch for any bespoke runner setup.
+2. **Docker** (self-hosted Linux: `yuzu-wsl2-linux` / `yuzu-shulgi`) —
+   idempotent persistent container `yuzu-ci-postgres` on
+   `127.0.0.1:15432` (`docker start` || `docker run --restart
+   unless-stopped`, image pinned to the same digest as
+   `deploy/docker/Dockerfile.postgres`'s base). One-time cost per runner;
+   port 15432 avoids colliding with native clusters or UAT rigs on 5432.
+3. **brew** (GHA-hosted macOS, no docker) — `postgresql@16` bottle +
+   throwaway trust-auth cluster under `$RUNNER_TEMP` on
+   `127.0.0.1:15432`.
+4. **Native cluster on `127.0.0.1:5432`** — the `yuzu-local-windows`
+   precondition: a PostgreSQL 16 Windows service with role `yuzu` /
+   password `yuzu` / database `yuzu_test`, bootstrapped **once** per
+   runner (installer or `choco install postgresql16`, then
+   `createuser`/`createdb` as above). Prefer the runner-level env
+   override (path 1) if the box already runs Postgres with different
+   credentials.
+5. Nothing found → `::warning`, exit 0.
+
+**Non-fatal by design (for now):** no test consumes the DSN until #1320
+lands the server-side Postgres substrate. When the first Postgres-backed
+store test ships, flip `SOFT_EXIT=1` in the script so a missing database
+fails the job instead of silently skipping coverage.
+
 ## Universal vcpkg cache-key contract
 
 `scripts/ci/vcpkg-triplet-sentinel.sh` is the single source of truth for

--- a/docs/ci-architecture.md
+++ b/docs/ci-architecture.md
@@ -89,9 +89,13 @@ Resolution order inside the script:
    precondition: a PostgreSQL 16 Windows service with role `yuzu` /
    password `yuzu` / database `yuzu_test`, bootstrapped **once** per
    runner (installer or `choco install postgresql16`, then
-   `createuser`/`createdb` as above). Prefer the runner-level env
-   override (path 1) if the box already runs Postgres with different
-   credentials.
+   `createuser`/`createdb` as above). When `psql` is on PATH the script
+   authenticates the conventional DSN with `SELECT 1` before exporting
+   it — a TCP listener with the wrong credentials produces a `::warning`
+   and no DSN rather than a false "ready". Without `psql` it falls back
+   to the bare TCP probe with a loud unverified-credential warning.
+   Prefer the runner-level env override (path 1) if the box already runs
+   Postgres with different credentials.
 5. Nothing found → `::warning`, exit 0.
 
 **Non-fatal by design (for now):** no test consumes the DSN until #1320

--- a/docs/demo-environment.md
+++ b/docs/demo-environment.md
@@ -16,6 +16,7 @@ point it at a new release.
 | Tier | Image | Base |
 |------|-------|------|
 | Server | `ghcr.io/<owner>/yuzu-server-chisel:<version>` | chiselled Ubuntu 26.04, `FROM scratch` |
+| Postgres (server substrate, #1318) | `ghcr.io/<owner>/yuzu-postgres:<version>` | `postgres:16` + pgvector (no `-chisel` variant — same image production composes use) |
 | Gateway | `ghcr.io/<owner>/yuzu-gateway-chisel:<version>` | chiselled Ubuntu 26.04, `FROM scratch` |
 | Agents (×N, default 10) | `ghcr.io/<owner>/yuzu-agent-chisel:<version>` | chiselled Ubuntu 26.04, `FROM scratch` |
 
@@ -24,9 +25,10 @@ Files:
 - `deploy/docker/Dockerfile.server.chisel`
 - `deploy/docker/Dockerfile.gateway.chisel`
 - `deploy/docker/Dockerfile.agent.chisel`
-- `deploy/docker/docker-compose.demo.yml` — the three-tier stack
+- `deploy/docker/Dockerfile.postgres` (published by `docker-publish-postgres`, not the chisel job)
+- `deploy/docker/docker-compose.demo.yml` — the demo stack
 - `deploy/docker/demo-gateway-sys.config` — gateway upstream/listener config
-- `scripts/start-demo.sh` — the launcher (entry point)
+- `scripts/start-demo.sh` — the launcher (entry point; `--build` also builds/tags `yuzu-postgres`)
 
 ## Quick start
 

--- a/scripts/check-compose-versions.sh
+++ b/scripts/check-compose-versions.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Verify docker-compose files reference the expected Yuzu version.
 #
-# Enforces two rules for every `ghcr.io/<owner>/yuzu-{server,gateway,agent}[-chisel]:<tag>`
+# Enforces two rules for every
+# `ghcr.io/<owner>/yuzu-{server,gateway,agent,postgres}[-chisel]:<tag>`
 # reference in tracked compose files:
 #
 #   1. The tag must be parameterized as `${YUZU_VERSION:-<default>}` — bare
@@ -72,7 +73,7 @@ for f in "${FILES[@]}"; do
   while IFS=: read -r lineno rest; do
     [[ -z "$lineno" ]] && continue
     # Pull just the tag off the matched line.
-    if [[ "$rest" =~ ghcr\.io/[^/]+/yuzu-(server|gateway|agent)(-chisel)?:([^[:space:]\"\']+) ]]; then
+    if [[ "$rest" =~ ghcr\.io/[^/]+/yuzu-(server|gateway|agent|postgres)(-chisel)?:([^[:space:]\"\']+) ]]; then
       tag="${BASH_REMATCH[3]}"
     else
       continue
@@ -96,7 +97,7 @@ for f in "${FILES[@]}"; do
     fi
 
     # Anything else (latest, local, sha-*, ...) is intentional and allowed.
-  done < <(grep -nE 'ghcr\.io/[^/]+/yuzu-(server|gateway|agent)(-chisel)?:' "$f" || true)
+  done < <(grep -nE 'ghcr\.io/[^/]+/yuzu-(server|gateway|agent|postgres)(-chisel)?:' "$f" || true)
 done
 
 if [[ $fail -ne 0 ]]; then

--- a/scripts/check-release-artifacts.sh
+++ b/scripts/check-release-artifacts.sh
@@ -31,8 +31,9 @@
 #     yuzu-macos-arm64.cdx.json       + .spdx.json
 #
 #   Image SBOMs:
-#     yuzu-server-image.cdx.json  + .spdx.json
-#     yuzu-gateway-image.cdx.json + .spdx.json
+#     yuzu-server-image.cdx.json   + .spdx.json
+#     yuzu-gateway-image.cdx.json  + .spdx.json
+#     yuzu-postgres-image.cdx.json + .spdx.json   (#1318)
 #
 # Emits GitHub Actions `::error file=...` annotations so failures show
 # up inline on the release run summary.
@@ -96,6 +97,9 @@ SBOM_BASES=(
   "yuzu-macos-arm64"
   "yuzu-server-image"
   "yuzu-gateway-image"
+  # yuzu-postgres joined the release images in #1318; docker-publish-postgres
+  # is in the release job's needs, so its SBOM artifact must be present.
+  "yuzu-postgres-image"
 )
 
 for base in "${SBOM_BASES[@]}"; do

--- a/scripts/ci/ensure-postgres.sh
+++ b/scripts/ci/ensure-postgres.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# ensure-postgres.sh — idempotent "a PostgreSQL 16 is reachable for server
+# tests" step for every CI tier (ADR-0006 decision 8, #1318).
+#
+# Exports YUZU_TEST_POSTGRES_DSN via $GITHUB_ENV (or prints it when run
+# outside Actions, e.g. by the /test skill or a dev shell). Resolution
+# order:
+#
+#   1. Pre-set YUZU_TEST_POSTGRES_DSN — runner-level/env override, trusted
+#      as-is (the documented hook for a self-hosted box with a bespoke
+#      native install; see docs/ci-architecture.md "Postgres for server
+#      tests").
+#   2. Docker available -> idempotent `yuzu-ci-postgres` container on
+#      127.0.0.1:15432 (self-hosted Linux: yuzu-wsl2-linux / yuzu-shulgi —
+#      the same boxes run the docker-publish jobs, so docker is a given).
+#      Port 15432 deliberately avoids colliding with any native cluster or
+#      UAT rig on 5432. `--restart unless-stopped` + `docker start` makes
+#      this a one-time cost per runner.
+#   3. macOS (GHA-hosted, no docker): brew postgresql@16, throwaway
+#      trust-auth cluster under $RUNNER_TEMP on port 15432.
+#   4. Native cluster on 127.0.0.1:5432 (self-hosted Windows precondition —
+#      PostgreSQL 16 installed as a service with role yuzu / password yuzu
+#      / database yuzu_test; bootstrap once per runner, see
+#      docs/ci-architecture.md).
+#   5. Nothing found -> ::warning + exit 0.
+#
+# NON-FATAL (path 5) on purpose: no test consumes the DSN until #1320 lands
+# the server-side Postgres substrate. When the first Postgres-backed store
+# test ships, flip SOFT_EXIT to 1 so a missing database fails the job
+# instead of silently skipping coverage.
+set -euo pipefail
+
+SOFT_EXIT=0   # flip to 1 when #1320's tests consume YUZU_TEST_POSTGRES_DSN
+
+# Same pinned multi-arch image as deploy/docker/Dockerfile.postgres's base.
+PG_IMAGE="postgres:16.14-bookworm@sha256:da514b7d293c5e9126503f85ecd835f4fb0942a77e012fe74f016c114c3e25b8"
+CONTAINER="yuzu-ci-postgres"
+DOCKER_PORT=15432
+
+emit_dsn() {
+  local dsn="$1" how="$2"
+  if [[ -n "${GITHUB_ENV:-}" ]]; then
+    echo "YUZU_TEST_POSTGRES_DSN=${dsn}" >> "$GITHUB_ENV"
+  fi
+  # Always echo too — local invocations eval/grep this.
+  echo "YUZU_TEST_POSTGRES_DSN=${dsn}"
+  echo "ensure-postgres: ready (${how})" >&2
+}
+
+tcp_probe() { # host port — pure-bash, works in MSYS2 too
+  local host="$1" port="$2"
+  (exec 3<>"/dev/tcp/${host}/${port}") >/dev/null 2>&1
+}
+
+# ── 1. Pre-set DSN wins ──────────────────────────────────────────────────
+if [[ -n "${YUZU_TEST_POSTGRES_DSN:-}" ]]; then
+  emit_dsn "$YUZU_TEST_POSTGRES_DSN" "pre-set runner env"
+  exit 0
+fi
+
+# ── 2. Docker (self-hosted Linux) ────────────────────────────────────────
+if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+  if [[ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null || true)" != "true" ]]; then
+    docker start "$CONTAINER" >/dev/null 2>&1 || docker run -d \
+      --name "$CONTAINER" \
+      --restart unless-stopped \
+      -e POSTGRES_USER=yuzu -e POSTGRES_PASSWORD=yuzu -e POSTGRES_DB=yuzu_test \
+      -p "127.0.0.1:${DOCKER_PORT}:5432" \
+      "$PG_IMAGE" >/dev/null
+  fi
+  for _ in $(seq 1 30); do
+    # -h 127.0.0.1: the init-phase temporary server is unix-socket-only,
+    # so a TCP probe can't false-positive mid-init.
+    if docker exec "$CONTAINER" pg_isready -h 127.0.0.1 -U yuzu -d yuzu_test >/dev/null 2>&1; then
+      emit_dsn "postgresql://yuzu:yuzu@127.0.0.1:${DOCKER_PORT}/yuzu_test" "docker container ${CONTAINER}"
+      exit 0
+    fi
+    sleep 2
+  done
+  echo "::warning::ensure-postgres: ${CONTAINER} container did not become ready in 60s" >&2
+  exit "$SOFT_EXIT"
+fi
+
+# ── 3. GHA-hosted macOS — brew + throwaway cluster ───────────────────────
+if [[ "$(uname -s)" == "Darwin" ]] && command -v brew >/dev/null 2>&1; then
+  # Without a valid locale the macOS postmaster aborts with "postmaster
+  # became multithreaded during startup" (CoreFoundation locale lookup
+  # spawns a thread). Pin LC_ALL/LANG defensively — minimal shells (and
+  # this script's own CI smoke test under `env -i`) hit it.
+  export LC_ALL="${LC_ALL:-C}" LANG="${LANG:-C}"
+  brew list postgresql@16 >/dev/null 2>&1 || brew install --quiet postgresql@16
+  PGBIN="$(brew --prefix postgresql@16)/bin"
+  PGDATA="${RUNNER_TEMP:-/tmp}/yuzu-ci-pgdata"
+  PGLOG="${PGDATA}.log"
+  if [[ ! -s "${PGDATA}/PG_VERSION" ]]; then
+    # trust auth: throwaway per-job cluster on an ephemeral runner, bound
+    # to loopback only.
+    "$PGBIN/initdb" --username=yuzu --auth=trust --no-instructions -D "$PGDATA" >/dev/null
+  fi
+  if ! "$PGBIN/pg_ctl" -D "$PGDATA" status >/dev/null 2>&1; then
+    "$PGBIN/pg_ctl" -D "$PGDATA" -l "$PGLOG" \
+      -o "-p ${DOCKER_PORT} -c listen_addresses=127.0.0.1" start >/dev/null
+  fi
+  for _ in $(seq 1 15); do
+    if "$PGBIN/pg_isready" -h 127.0.0.1 -p "$DOCKER_PORT" -U yuzu >/dev/null 2>&1; then
+      "$PGBIN/createdb" -h 127.0.0.1 -p "$DOCKER_PORT" -U yuzu yuzu_test 2>/dev/null || true
+      emit_dsn "postgresql://yuzu@127.0.0.1:${DOCKER_PORT}/yuzu_test" "brew postgresql@16 cluster"
+      exit 0
+    fi
+    sleep 2
+  done
+  echo "::warning::ensure-postgres: brew postgresql@16 cluster did not become ready (log: ${PGLOG})" >&2
+  exit "$SOFT_EXIT"
+fi
+
+# ── 4. Native cluster on the conventional port (self-hosted Windows) ─────
+if tcp_probe 127.0.0.1 5432; then
+  # Convention documented in docs/ci-architecture.md: role yuzu / password
+  # yuzu / db yuzu_test, created once at runner bootstrap. A bespoke setup
+  # overrides via the pre-set-DSN path (1).
+  emit_dsn "postgresql://yuzu:yuzu@127.0.0.1:5432/yuzu_test" "native cluster on 5432"
+  exit 0
+fi
+
+# ── 5. Nothing available ─────────────────────────────────────────────────
+echo "::warning::ensure-postgres: no Postgres available (no docker, no brew, nothing on 127.0.0.1:5432) — YUZU_TEST_POSTGRES_DSN not set. Non-fatal until #1320; see docs/ci-architecture.md 'Postgres for server tests'." >&2
+exit "$SOFT_EXIT"

--- a/scripts/ci/ensure-postgres.sh
+++ b/scripts/ci/ensure-postgres.sh
@@ -118,7 +118,21 @@ if tcp_probe 127.0.0.1 5432; then
   # Convention documented in docs/ci-architecture.md: role yuzu / password
   # yuzu / db yuzu_test, created once at runner bootstrap. A bespoke setup
   # overrides via the pre-set-DSN path (1).
-  emit_dsn "postgresql://yuzu:yuzu@127.0.0.1:5432/yuzu_test" "native cluster on 5432"
+  NATIVE_DSN="postgresql://yuzu:yuzu@127.0.0.1:5432/yuzu_test"
+  # A TCP listener alone proves nothing about the app credential — when
+  # psql is on PATH, authenticate the exact DSN we are about to export
+  # (PR #1334 review, S5). Fall back to the bare TCP probe + warning when
+  # psql is unavailable.
+  if command -v psql >/dev/null 2>&1; then
+    if psql "$NATIVE_DSN" -tA -c 'SELECT 1' >/dev/null 2>&1; then
+      emit_dsn "$NATIVE_DSN" "native cluster on 5432 (psql SELECT 1 verified)"
+      exit 0
+    fi
+    echo "::warning::ensure-postgres: something listens on 127.0.0.1:5432 but the conventional DSN failed 'psql SELECT 1' — not exporting YUZU_TEST_POSTGRES_DSN. Fix the runner bootstrap (role yuzu / password yuzu / db yuzu_test) or pre-set YUZU_TEST_POSTGRES_DSN." >&2
+    exit "$SOFT_EXIT"
+  fi
+  echo "::warning::ensure-postgres: psql not on PATH — exporting the conventional DSN on a TCP probe only (credential UNVERIFIED). Install psql on the runner for an authenticated readiness check." >&2
+  emit_dsn "$NATIVE_DSN" "native cluster on 5432 (TCP probe only — psql unavailable)"
   exit 0
 fi
 

--- a/scripts/install-server-postgres.sh
+++ b/scripts/install-server-postgres.sh
@@ -59,9 +59,14 @@ write_env_file() {
     echo "ok: ${ENV_FILE} already carries YUZU_POSTGRES_DSN — leaving it untouched"
     return 0
   fi
+  # Pre-create at 0600 so the file NEVER exists world-readable, even for a
+  # sub-second window between write and chmod (PR #1334 review, S3).
+  if [[ ! -f "$ENV_FILE" ]]; then
+    install -m 0600 /dev/null "$ENV_FILE"
+  fi
+  chmod 0600 "$ENV_FILE"
   # Append-or-create so other variables in the file survive.
   printf 'YUZU_POSTGRES_DSN=%s\n' "$dsn" >> "$ENV_FILE"
-  chmod 0600 "$ENV_FILE"
   # The yuzu service user may not exist yet on a bare provisioning run.
   chown "${SVC_USER}:${SVC_USER}" "$ENV_FILE" 2>/dev/null || true
   echo "ok: wrote YUZU_POSTGRES_DSN to ${ENV_FILE} (0600)"
@@ -89,9 +94,20 @@ if ! command -v psql >/dev/null 2>&1 \
 fi
 
 # Generate a credential only if the role doesn't exist yet; never reset an
-# existing role's password (idempotency).
-role_exists=$(sudo -u postgres psql -At -c \
-  "SELECT 1 FROM pg_roles WHERE rolname = '${DB_USER}'" || true)
+# existing role's password (idempotency). The credential is freshly random
+# (openssl rand) — the app role NEVER shares a password with any superuser
+# (the local postgres superuser authenticates via peer auth, passwordless).
+#
+# Existence checks use psql -v / :'var' interpolation like the CREATEs —
+# never shell interpolation into SQL (PR #1334 review, S2). No `|| true`:
+# under `set -e` a failed query (cluster down, bad identifier) aborts the
+# script instead of masquerading as "role does not exist". psql variables
+# do not interpolate in -c strings, so the query comes via stdin.
+role_exists=$(sudo -u postgres psql -At -v ON_ERROR_STOP=1 \
+  -v yuzu_user="$DB_USER" <<'EOSQL'
+SELECT 1 FROM pg_roles WHERE rolname = :'yuzu_user'
+EOSQL
+)
 
 DB_PASSWORD=""
 if [[ "$role_exists" != "1" ]]; then
@@ -106,8 +122,11 @@ else
   echo "ok: role '${DB_USER}' already exists — password left unchanged"
 fi
 
-db_exists=$(sudo -u postgres psql -At -c \
-  "SELECT 1 FROM pg_database WHERE datname = '${DB_NAME}'" || true)
+db_exists=$(sudo -u postgres psql -At -v ON_ERROR_STOP=1 \
+  -v yuzu_db="$DB_NAME" <<'EOSQL'
+SELECT 1 FROM pg_database WHERE datname = :'yuzu_db'
+EOSQL
+)
 if [[ "$db_exists" != "1" ]]; then
   sudo -u postgres psql -v ON_ERROR_STOP=1 \
     -v yuzu_db="$DB_NAME" -v yuzu_user="$DB_USER" <<'EOSQL'

--- a/scripts/install-server-postgres.sh
+++ b/scripts/install-server-postgres.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# install-server-postgres.sh — optional Postgres provisioning for a native
+# (non-container) yuzu-server install (ADR-0006/0007, #1318).
+#
+# Two modes:
+#
+#   1. External / managed Postgres (first-class):
+#        sudo bash scripts/install-server-postgres.sh --dsn 'postgresql://yuzu:...@db.example.com:5432/yuzu'
+#      Writes the DSN to /etc/yuzu/yuzu-server.env (mode 0600, yuzu:yuzu),
+#      which the systemd unit loads via EnvironmentFile=. No local Postgres
+#      is touched.
+#
+#   2. Local Postgres (default): provisions the app role + database on an
+#      already-installed, running local PostgreSQL (16+ recommended) and
+#      writes the DSN env file. Idempotent — re-running never clobbers an
+#      existing role, database, or env file.
+#
+# NON-FATAL where Postgres is absent: until #1320 lands the server-side DSN
+# consumer, yuzu-server boots happily without Postgres, so a missing local
+# cluster prints install hints and exits 0. Flip SOFT_EXIT to 1 when #1320
+# makes the DSN mandatory (ADR-0007 fail-closed startup).
+#
+# Schemas are NOT created here — the server's migration runner owns those
+# at startup (ADR-0008), exactly like the container init script
+# (deploy/docker/postgres-init/10-create-yuzu-role-db.sh) which is this
+# script's compose-side twin.
+set -euo pipefail
+
+ENV_FILE="/etc/yuzu/yuzu-server.env"
+DB_USER="${YUZU_DB_USER:-yuzu}"
+DB_NAME="${YUZU_DB_NAME:-yuzu}"
+SVC_USER="yuzu"
+SOFT_EXIT=0   # see header — becomes a hard failure once #1320 lands
+EXTERNAL_DSN=""
+
+usage() {
+  echo "usage: $0 [--dsn <postgresql://...>]" >&2
+  echo "  --dsn   use an external/managed Postgres; only writes ${ENV_FILE}" >&2
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dsn) EXTERNAL_DSN="${2:?--dsn needs a value}"; shift 2 ;;
+    -h|--help) usage ;;
+    *) usage ;;
+  esac
+done
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "error: must run as root (writes ${ENV_FILE}; provisions the DB role)" >&2
+  exit 1
+fi
+
+write_env_file() {
+  local dsn="$1"
+  install -d -m 0750 /etc/yuzu
+  if [[ -f "$ENV_FILE" ]] && grep -q '^YUZU_POSTGRES_DSN=' "$ENV_FILE"; then
+    echo "ok: ${ENV_FILE} already carries YUZU_POSTGRES_DSN — leaving it untouched"
+    return 0
+  fi
+  # Append-or-create so other variables in the file survive.
+  printf 'YUZU_POSTGRES_DSN=%s\n' "$dsn" >> "$ENV_FILE"
+  chmod 0600 "$ENV_FILE"
+  # The yuzu service user may not exist yet on a bare provisioning run.
+  chown "${SVC_USER}:${SVC_USER}" "$ENV_FILE" 2>/dev/null || true
+  echo "ok: wrote YUZU_POSTGRES_DSN to ${ENV_FILE} (0600)"
+}
+
+# ── Mode 1: external DSN — write and done ────────────────────────────────
+if [[ -n "$EXTERNAL_DSN" ]]; then
+  write_env_file "$EXTERNAL_DSN"
+  exit 0
+fi
+
+# ── Mode 2: local provisioning ───────────────────────────────────────────
+# Soft-detect a running local cluster: psql present + the postgres
+# superuser can connect over the local socket.
+if ! command -v psql >/dev/null 2>&1 \
+   || ! sudo -u postgres psql -At -c 'SELECT 1' >/dev/null 2>&1; then
+  echo "warn: no running local PostgreSQL found — skipping provisioning (non-fatal until #1320)." >&2
+  echo "      Install one first, e.g.:" >&2
+  echo "        Debian/Ubuntu:  apt-get install postgresql-16   (or distro default)" >&2
+  echo "        RHEL/Fedora:    dnf install postgresql-server && postgresql-setup --initdb" >&2
+  echo "        macOS:          brew install postgresql@16 && brew services start postgresql@16" >&2
+  echo "      then re-run this script, or point at a managed database with:" >&2
+  echo "        $0 --dsn 'postgresql://...'" >&2
+  exit "$SOFT_EXIT"
+fi
+
+# Generate a credential only if the role doesn't exist yet; never reset an
+# existing role's password (idempotency).
+role_exists=$(sudo -u postgres psql -At -c \
+  "SELECT 1 FROM pg_roles WHERE rolname = '${DB_USER}'" || true)
+
+DB_PASSWORD=""
+if [[ "$role_exists" != "1" ]]; then
+  DB_PASSWORD="$(openssl rand -hex 24)"
+  sudo -u postgres psql -v ON_ERROR_STOP=1 \
+    -v yuzu_user="$DB_USER" -v yuzu_pass="$DB_PASSWORD" <<'EOSQL'
+SELECT format('CREATE ROLE %I LOGIN PASSWORD %L', :'yuzu_user', :'yuzu_pass')
+\gexec
+EOSQL
+  echo "ok: created role '${DB_USER}'"
+else
+  echo "ok: role '${DB_USER}' already exists — password left unchanged"
+fi
+
+db_exists=$(sudo -u postgres psql -At -c \
+  "SELECT 1 FROM pg_database WHERE datname = '${DB_NAME}'" || true)
+if [[ "$db_exists" != "1" ]]; then
+  sudo -u postgres psql -v ON_ERROR_STOP=1 \
+    -v yuzu_db="$DB_NAME" -v yuzu_user="$DB_USER" <<'EOSQL'
+SELECT format('CREATE DATABASE %I OWNER %I', :'yuzu_db', :'yuzu_user')
+\gexec
+EOSQL
+  echo "ok: created database '${DB_NAME}' owned by '${DB_USER}'"
+else
+  echo "ok: database '${DB_NAME}' already exists"
+fi
+
+# pgvector if available (the yuzu-postgres image always has it; a distro
+# cluster needs the postgresql-16-pgvector package). Non-fatal — only the
+# vuln-graph store (ADR-0004) needs it, and that lands later.
+if ! sudo -u postgres psql -v ON_ERROR_STOP=1 -d "$DB_NAME" \
+     -c 'CREATE EXTENSION IF NOT EXISTS vector' >/dev/null 2>&1; then
+  echo "warn: pgvector extension unavailable — install postgresql-16-pgvector (or distro equivalent) before the vuln-graph store migrates" >&2
+fi
+
+if [[ -n "$DB_PASSWORD" ]]; then
+  write_env_file "postgresql://${DB_USER}:${DB_PASSWORD}@127.0.0.1:5432/${DB_NAME}"
+else
+  # Role pre-existed so we don't know its password; only write a DSN if the
+  # env file doesn't already have one (write_env_file no-ops in that case),
+  # using a placeholder the operator must fill in.
+  if [[ -f "$ENV_FILE" ]] && grep -q '^YUZU_POSTGRES_DSN=' "$ENV_FILE"; then
+    echo "ok: existing DSN in ${ENV_FILE} retained"
+  else
+    echo "warn: role existed before this run, so its password is unknown here." >&2
+    echo "      Write the DSN yourself:  $0 --dsn 'postgresql://${DB_USER}:<password>@127.0.0.1:5432/${DB_NAME}'" >&2
+  fi
+fi
+
+echo "done. The systemd unit picks the DSN up via EnvironmentFile=${ENV_FILE} (server-side consumer: #1320)."

--- a/scripts/start-demo.sh
+++ b/scripts/start-demo.sh
@@ -90,6 +90,9 @@ dc() {
 # collide with the debian/alpine production images of the same version (whose
 # compose healthchecks assume a bash userland the chiselled images don't have).
 img() { printf '%s/yuzu-%s-chisel:%s' "$REGISTRY" "$1" "$YUZU_VERSION"; }
+# yuzu-postgres has no -chisel variant — the demo runs the same release-pinned
+# substrate image production composes use (#1318).
+img_pg() { printf '%s/yuzu-postgres:%s' "$REGISTRY" "$YUZU_VERSION"; }
 
 # ── Image acquisition ──────────────────────────────────────────────────────
 build_images() {
@@ -100,11 +103,13 @@ build_images() {
     -f deploy/docker/Dockerfile.agent.chisel   .
   DOCKER_BUILDKIT=1 docker build -t "$(img gateway)" \
     -f deploy/docker/Dockerfile.gateway.chisel .
-  ok "Built $(img server), $(img gateway), $(img agent)"
+  DOCKER_BUILDKIT=1 docker build -t "$(img_pg)" \
+    -f deploy/docker/Dockerfile.postgres       .
+  ok "Built $(img server), $(img gateway), $(img agent), $(img_pg)"
 }
 
 images_present_locally() {
-  docker image inspect "$(img server)" "$(img gateway)" "$(img agent)" >/dev/null 2>&1
+  docker image inspect "$(img server)" "$(img gateway)" "$(img agent)" "$(img_pg)" >/dev/null 2>&1
 }
 
 ensure_images() {

--- a/scripts/test/docker-compose.upgrade-test.yml
+++ b/scripts/test/docker-compose.upgrade-test.yml
@@ -46,6 +46,10 @@ services:
   server:
     image: ghcr.io/tr3kkr/yuzu-server:${YUZU_VERSION:-0.10.0}
     restart: "no"
+    environment:
+      # Postgres substrate DSN (ADR-0006, #1318). Inert on the old-release
+      # leg (and on the new leg until #1320 ships the consumer).
+      YUZU_POSTGRES_DSN: postgresql://yuzu:${YUZU_POSTGRES_PASSWORD:-yuzu}@postgres:5432/yuzu
     ports:
       - "8080"     # web dashboard + REST API (random host port via compose)
       - "50051"   # agent gRPC
@@ -82,6 +86,39 @@ services:
       timeout: 5s
       retries: 12
       start_period: 30s
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  # ── PostgreSQL (server storage substrate, ADR-0006, #1318) ───────────
+  # Built locally from Dockerfile.postgres (a ghcr yuzu-postgres pin can't
+  # work here: YUZU_VERSION is the OLD release on the first leg and a
+  # never-published -test tag on the second). The postgres service stays
+  # identical across both legs while the server image swaps around it —
+  # exactly the topology the ADR-0009 first-boot backfill upgrade
+  # assertions will exercise. The OLD release's server ignores
+  # YUZU_POSTGRES_DSN entirely; the env var below is inert until #1320.
+  postgres:
+    build:
+      context: ../..
+      dockerfile: deploy/docker/Dockerfile.postgres
+    image: yuzu-postgres:local
+    restart: "no"
+    environment:
+      POSTGRES_PASSWORD: ${YUZU_POSTGRES_PASSWORD:-yuzu}
+    volumes:
+      # Project-scoped like server-data, so the database also survives the
+      # old→new image swap but stays isolated between parallel runs.
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      # -h 127.0.0.1 forces TCP — the init-phase temporary server is
+      # unix-socket-only, so a socket probe could pass mid-init.
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
 
 volumes:
   server-data:
+  postgres-data:

--- a/scripts/test/docker-compose.upgrade-test.yml
+++ b/scripts/test/docker-compose.upgrade-test.yml
@@ -49,7 +49,9 @@ services:
     environment:
       # Postgres substrate DSN (ADR-0006, #1318). Inert on the old-release
       # leg (and on the new leg until #1320 ships the consumer).
-      YUZU_POSTGRES_DSN: postgresql://yuzu:${YUZU_POSTGRES_PASSWORD:-yuzu}@postgres:5432/yuzu
+      # ⚠ TEST-ONLY default password ('yuzu-app') — distinct from the
+      # superuser default by design (PR #1334 review, S1).
+      YUZU_POSTGRES_DSN: postgresql://yuzu:${YUZU_DB_PASSWORD:-yuzu-app}@postgres:5432/yuzu
     ports:
       - "8080"     # web dashboard + REST API (random host port via compose)
       - "50051"   # agent gRPC
@@ -110,15 +112,24 @@ services:
     pull_policy: build
     restart: "no"
     environment:
+      # ⚠ TEST-ONLY default passwords — superuser ('yuzu') and app role
+      # ('yuzu-app') must stay DISTINCT: first-boot init refuses to run if
+      # they are equal (PR #1334 review, S1).
       POSTGRES_PASSWORD: ${YUZU_POSTGRES_PASSWORD:-yuzu}
+      YUZU_DB_PASSWORD: ${YUZU_DB_PASSWORD:-yuzu-app}
     volumes:
       # Project-scoped like server-data, so the database also survives the
       # old→new image swap but stays isolated between parallel runs.
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
       # -h 127.0.0.1 forces TCP — the init-phase temporary server is
-      # unix-socket-only, so a socket probe could pass mid-init.
-      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu"]
+      # unix-socket-only, so a socket probe could pass mid-init. psql
+      # SELECT 1 over the app DSN proves the app credential authenticates
+      # ($$ defers expansion to the container's shell). The psql leg
+      # dials the container's own hostname, NOT loopback: initdb leaves
+      # 'trust' auth on 127.0.0.1, so only a non-loopback connection
+      # actually verifies the password (scram).
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu && psql \"postgresql://yuzu:$${YUZU_DB_PASSWORD}@$$(hostname):5432/yuzu\" -tA -c 'SELECT 1' >/dev/null"]
       interval: 5s
       timeout: 5s
       retries: 12

--- a/scripts/test/docker-compose.upgrade-test.yml
+++ b/scripts/test/docker-compose.upgrade-test.yml
@@ -103,6 +103,11 @@ services:
       context: ../..
       dockerfile: deploy/docker/Dockerfile.postgres
     image: yuzu-postgres:local
+    # pull_policy: build — without it, the harness's `docker compose pull`
+    # step exits 1 trying to pull the local-only yuzu-postgres:local tag
+    # from a registry (verified). With it, pull skips this service and
+    # `up -d` builds it when missing.
+    pull_policy: build
     restart: "no"
     environment:
       POSTGRES_PASSWORD: ${YUZU_POSTGRES_PASSWORD:-yuzu}

--- a/tests/shell/test_check_compose_versions.sh
+++ b/tests/shell/test_check_compose_versions.sh
@@ -39,6 +39,12 @@ f_ok_regvar="$(mkf ok_regvar.yml    '    image: ${YUZU_REGISTRY:-ghcr.io/tr3kkr}
 f_drift_chisel="$(mkf drift.yml     '    image: ghcr.io/tr3kkr/yuzu-server-chisel:${YUZU_VERSION:-0.11.0}')"
 f_hardcoded="$(mkf hardcoded.yml    '    image: ghcr.io/tr3kkr/yuzu-server:0.12.0')"
 f_floating="$(mkf floating.yml      '    image: ghcr.io/tr3kkr/yuzu-server:latest')"
+# yuzu-postgres joined the pin discipline in #1318 (F4/F5 of the Postgres
+# substrate program) — exercise all three behaviours for the new repo name.
+f_ok_pg="$(mkf ok_pg.yml            '    image: ghcr.io/tr3kkr/yuzu-postgres:${YUZU_VERSION:-0.12.0}')"
+f_drift_pg="$(mkf drift_pg.yml      '    image: ghcr.io/tr3kkr/yuzu-postgres:${YUZU_VERSION:-0.11.0}')"
+f_hard_pg="$(mkf hard_pg.yml        '    image: ghcr.io/tr3kkr/yuzu-postgres:0.12.0')"
+f_floating_pg="$(mkf float_pg.yml   '    image: yuzu-postgres:local')"
 
 echo "check-compose-versions.sh fixture tests:"
 expect 0 "parameterized non-chisel pin matches"          0.12.0 "$f_ok_plain"
@@ -47,6 +53,10 @@ expect 0 "parameterized pin under \${YUZU_REGISTRY}"     0.12.0 "$f_ok_regvar"
 expect 1 "-chisel pin drift is caught"                   0.12.0 "$f_drift_chisel"
 expect 1 "hardcoded numeric tag is rejected"             0.12.0 "$f_hardcoded"
 expect 0 "floating tag (latest) is ignored"              0.12.0 "$f_floating"
+expect 0 "parameterized yuzu-postgres pin matches"       0.12.0 "$f_ok_pg"
+expect 1 "yuzu-postgres pin drift is caught"             0.12.0 "$f_drift_pg"
+expect 1 "hardcoded yuzu-postgres tag is rejected"       0.12.0 "$f_hard_pg"
+expect 0 "non-ghcr local yuzu-postgres tag is ignored"   0.12.0 "$f_floating_pg"
 
 echo "  ---"
 echo "  ${pass} passed, ${fail} failed"


### PR DESCRIPTION
## Summary

The deploy + CI slice of the Postgres substrate program (ADR-0006/0007/0008): a release-pinned, signed `yuzu-postgres` image, Postgres bundled into every server-running compose, libpq5 in the server images, soft systemd ordering + install provisioning, and `YUZU_TEST_POSTGRES_DSN` backed by a real Postgres 16 on every CI tier that runs server tests. 7 commits, reviewable in order.

- **Image**: `deploy/docker/Dockerfile.postgres` — `postgres:16.14-bookworm` pinned by tag + multi-arch digest, pgvector **v0.8.2 built from source at the release tag** (PGDG apt pins rot — only latest revision is carried), `OPTFLAGS=""` (no `-march=native`), DESTDIR-captured install. Init script creates role/db + `CREATE EXTENSION vector`; **schemas deliberately not created** (runtime migration runner's job, ADR-0008).
- **Publish**: `docker-publish-postgres` release job mirroring `docker-publish` (SBOM CycloneDX+SPDX, SLSA attestation, cosign keyless), multi-arch amd64+arm64 (demo/viz rigs are arm64); `release:` gates on it.
- **Composes** (all 8): `postgres` service with `pg_isready -h 127.0.0.1` healthcheck (TCP probe is load-bearing — initdb's temp server is socket-only, a socket probe false-positives mid-init), `depends_on: service_healthy` on the server, `YUZU_POSTGRES_DSN` injected. Production reference compose **requires** `YUZU_POSTGRES_PASSWORD` (`:?` — no insecure default). `check-compose-versions.sh` + its test suite extended (10/10).
- **Server images**: `libsqlite3-0` → `libpq5` (ldd on the shipped 0.12.0 binary shows sqlite statically linked — the package was vestigial); chisel `libpq5_libs` slice verified on the ubuntu-26.04 branch.
- **systemd/install**: soft `After=/Wants=postgresql.service` + `EnvironmentFile=-/etc/yuzu/yuzu-server.env`; new `scripts/install-server-postgres.sh` (managed-DSN mode or idempotent local provisioning; non-fatal when PG absent).
- **CI**: shared `scripts/ci/ensure-postgres.sh` (pre-set DSN → persistent docker container on self-hosted Linux → brew throwaway cluster on GHA macOS → native probe on self-hosted Windows → warn), wired into ci.yml linux/windows/macos and nightly asan/tsan/coverage. **Warn-not-fail until #1320 lands its first consumer** (flip documented). No cache steps touched.

## Deviations from the issue text (deliberate)

1. `--postgres-dsn` flag → `YUZU_POSTGRES_DSN` env var: the binary doesn't accept the flag until #1320 and would refuse to boot. Env var is inert today; server still boots without Postgres.
2. No `services: postgres:` GHA block: no GHA-hosted Linux job runs server tests (linux/windows are self-hosted; the workflow canary skips tests) — the shared script covers every tier that actually does.
3. Upgrade-test compose builds its postgres locally (the `${YUZU_VERSION}` there is the *previous* release on leg 1 / an unpublished test tag on leg 2, so a release pin can never resolve).

## Validation (local, arm64 Mac)

- Image built + live boot smoke: `pg_isready`, app-role login, `CREATE SCHEMA`, vector(3) distance query on pgvector 0.8.2
- `docker compose config` on all 8 composes; reference compose verified to fail without the password
- `check-compose-versions.sh 0.12.0` pass; `0.11.0` correctly catches the new pin; shell test suite 10/10
- `ensure-postgres.sh` all four paths exercised with real psql connects (caught a real macOS `LC_ALL` postmaster bug); shellcheck clean; actionlint: pre-existing findings only
- Not verifiable locally: the signed publish itself (release-tag-only; structural mirror of the proven jobs), self-hosted boxes in situ — **`yuzu-local-windows` needs a one-time Postgres 16 bootstrap** (documented in `docs/ci-architecture.md`), chisel build (release-time only).

Closes #1318

🤖 Generated with [Claude Code](https://claude.com/claude-code)