### PR TITLE
fix(server): keep GC'd execution channels alive until their mutex is released (#1198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -700,6 +700,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **SSE channel GC no longer aborts the server (#1198).** `gc_terminal_channels()`
+  destroyed each collected execution channel — and the `std::mutex` inside it —
+  while a `lock_guard` still owned that mutex: the channel map held the only
+  `shared_ptr`, so the erase ran the destructor synchronously and the guard then
+  unlocked freed memory. On MSVC this aborted the whole server
+  (`mutex.cpp(150): unlock of unowned mutex`); on every toolchain it was UB.
+  Reachable from normal operator activity: any execution that completes, loses
+  its SSE subscribers (executions drawer closed), and ages past the 60 s
+  retention window triggered the bad path on the next publish-driven GC sweep.
+  Fixed by pinning each victim with an extra `shared_ptr` and deferring
+  destruction until all per-channel locks are released.
 - **Agents enrolling *through the gateway* now receive a per-agent client
   certificate (PKI PR5d).** Previously only direct-connect enrollment issued the
   per-agent mTLS leaf — `GatewayUpstreamServiceImpl::ProxyRegister` registered the

--- a/docs/executions-history-ladder.md
+++ b/docs/executions-history-ladder.md
@@ -123,6 +123,30 @@ terminal are GC'd by `gc_terminal_channels` once
 runs opportunistically from `publish` so no separate timer thread is
 required.
 
+### GC lock-ordering invariant (#1198)
+
+`channels_` holds the only `shared_ptr` to each idle channel, and each
+`Channel` carries its own `std::mutex`. **A `Channel` must never be
+destroyed — via `erase` or any other `channels_` mutation — while any lock
+on that channel's mutex is alive.** The required pattern, used by
+`gc_terminal_channels`:
+
+1. Pin the victim with a local `shared_ptr` copy *before* locking its mutex.
+2. Erase the map entry — the local copy keeps the `Channel` alive.
+3. Park the copy in a container declared *outside* the lock scopes (the
+   `dead` vector), so `~Channel` runs only after the per-channel guard and
+   the `map_mu_` write lock are both released.
+
+Violating this is UB on every toolchain and a hard server-wide abort on
+MSVC ("unlock of unowned mutex"). The Linux sanitizers cannot see a
+regression here (the bad unlock executes inside uninstrumented libpthread,
+and libstdc++/libc++ `~mutex` is trivial, so TSan gets no destroy hook) —
+the MSVC test legs are the enforcement point, via the `set_clock_fn`
+regression test in `test_execution_event_bus.cpp` (`[gc]` tag). Any
+successor PR that restructures `gc_terminal_channels` or adds a new path
+that erases from `channels_` while holding a channel mutex must preserve
+this ordering. Lock hierarchy is `map_mu_` → `ch->mu`, never reversed.
+
 ### Client-side bootstrap is data-attribute-driven
 
 The list-row markup carries `data-execution-id` and

--- a/server/core/src/execution_event_bus.cpp
+++ b/server/core/src/execution_event_bus.cpp
@@ -149,19 +149,30 @@ std::size_t ExecutionEventBus::gc_terminal_channels() {
     if (victims.empty()) return 0;
 
     std::size_t removed = 0;
-    std::unique_lock<std::shared_mutex> wl(map_mu_);
-    for (const auto& id : victims) {
-        auto it = channels_.find(id);
-        if (it == channels_.end()) continue;
-        // Re-check terminal+empty under the per-channel mutex — a late
-        // subscriber may have joined between the two passes.
-        std::lock_guard<std::mutex> g(it->second->mu);
-        if (it->second->terminal && it->second->terminal_at_ms <= deadline &&
-            it->second->listeners.empty()) {
-            channels_.erase(it);
-            ++removed;
+    // Channels collected here are the map's only owners (terminal, no
+    // listeners), so erase() would destroy the Channel — and the mutex
+    // the lock_guard below still holds — synchronously inside the loop.
+    // Park them in `dead` so destruction happens after every per-channel
+    // lock has been released (#1198).
+    std::vector<std::shared_ptr<Channel>> dead;
+    {
+        std::unique_lock<std::shared_mutex> wl(map_mu_);
+        for (const auto& id : victims) {
+            auto it = channels_.find(id);
+            if (it == channels_.end()) continue;
+            std::shared_ptr<Channel> keep = it->second; // outlives erase()
+            // Re-check terminal+empty under the per-channel mutex — a late
+            // subscriber may have joined between the two passes.
+            std::lock_guard<std::mutex> g(keep->mu);
+            if (keep->terminal && keep->terminal_at_ms <= deadline &&
+                keep->listeners.empty()) {
+                channels_.erase(it);
+                dead.push_back(std::move(keep));
+                ++removed;
+            }
         }
     }
+    // `dead` destroyed here, with no channel mutex held.
     if (removed > 0) {
         gc_channels_.fetch_add(removed, std::memory_order_relaxed);
     }

--- a/server/core/src/execution_event_bus.cpp
+++ b/server/core/src/execution_event_bus.cpp
@@ -149,17 +149,20 @@ std::size_t ExecutionEventBus::gc_terminal_channels() {
     if (victims.empty()) return 0;
 
     std::size_t removed = 0;
-    // Channels collected here are the map's only owners (terminal, no
-    // listeners), so erase() would destroy the Channel — and the mutex
-    // the lock_guard below still holds — synchronously inside the loop.
-    // Park them in `dead` so destruction happens after every per-channel
-    // lock has been released (#1198).
+    // The map holds the only shared_ptr to each channel collected here
+    // (terminal, no listeners), so erase() would destroy the Channel —
+    // and the mutex the lock_guard below still holds — synchronously
+    // inside the loop. Park victims in `dead` so destruction happens
+    // only after every per-channel lock has been released (#1198).
     std::vector<std::shared_ptr<Channel>> dead;
+    dead.reserve(victims.size()); // no alloc (throw path) under the write lock
     {
         std::unique_lock<std::shared_mutex> wl(map_mu_);
         for (const auto& id : victims) {
             auto it = channels_.find(id);
             if (it == channels_.end()) continue;
+            // `keep` must be declared before `g`: if anything below throws,
+            // unwinding unlocks `g` before `keep` can drop the last reference.
             std::shared_ptr<Channel> keep = it->second; // outlives erase()
             // Re-check terminal+empty under the per-channel mutex — a late
             // subscriber may have joined between the two passes.
@@ -172,7 +175,7 @@ std::size_t ExecutionEventBus::gc_terminal_channels() {
             }
         }
     }
-    // `dead` destroyed here, with no channel mutex held.
+    // `dead` is destroyed at function exit, after all locks are released.
     if (removed > 0) {
         gc_channels_.fetch_add(removed, std::memory_order_relaxed);
     }

--- a/tests/unit/server/test_execution_event_bus.cpp
+++ b/tests/unit/server/test_execution_event_bus.cpp
@@ -153,6 +153,44 @@ TEST_CASE("execution_event_bus — terminal flag and gc",
     }
 }
 
+TEST_CASE("execution_event_bus — GC collects an expired terminal channel "
+          "without destroying a locked mutex (#1198)",
+          "[execution_event_bus][pr3][gc]") {
+    // Regression for #1198: gc_terminal_channels() erased the channel —
+    // destroying the std::mutex inside it — while a lock_guard still owned
+    // that mutex (the map held the only shared_ptr). The unlock of the
+    // freed mutex aborted the whole server on MSVC and is UB everywhere.
+    // Under ASan this test flags the use-after-free directly; without
+    // sanitizers it pins the collection path the older gc tests never
+    // reached (they only exercised the not-collected branches).
+    ExecutionEventBus bus;
+    std::int64_t fake_now = 1'000'000; // past the throttle vs last_gc=0
+    bus.set_clock_fn([&] { return fake_now; });
+
+    // Terminal event, no subscribers — exactly the channel shape GC targets.
+    bus.publish("exec-1", "execution-completed", "{}", /*is_terminal=*/true);
+    REQUIRE(bus.channel_count() == 1);
+
+    // Advance past retention + GC throttle so the sweep both runs and
+    // finds exec-1 expired.
+    fake_now += ExecutionEventBus::kRetentionAfterTerminalSec * 1000 +
+                ExecutionEventBus::kMinGcIntervalMs + 1;
+
+    SECTION("direct gc_terminal_channels() call") {
+        CHECK(bus.gc_terminal_channels() == 1);
+        CHECK(bus.channel_count() == 0);
+        CHECK(bus.gc_channels_total() == 1);
+    }
+    SECTION("publish-driven opportunistic sweep (production trigger)") {
+        // In production the sweep fires from publish() on an unrelated
+        // execution — the crash signature from the UAT rig.
+        bus.publish("exec-2", "agent-transition", "{}");
+        CHECK(bus.channel_count() == 1); // exec-1 collected, exec-2 live
+        CHECK(bus.gc_channels_total() == 1);
+        CHECK(bus.snapshot("exec-1").empty());
+    }
+}
+
 TEST_CASE("execution_event_bus — listener invocation is synchronous within publish",
           "[execution_event_bus][pr3]") {
     ExecutionEventBus bus;

--- a/tests/unit/server/test_execution_event_bus.cpp
+++ b/tests/unit/server/test_execution_event_bus.cpp
@@ -24,6 +24,7 @@
                       // on MSVC's STL (Linux libstdc++ + libc++ both happen
                       // to include it indirectly, masking the omission).
 #include <atomic>
+#include <cstdint>
 #include <thread>
 #include <vector>
 
@@ -160,11 +161,15 @@ TEST_CASE("execution_event_bus — GC collects an expired terminal channel "
     // destroying the std::mutex inside it — while a lock_guard still owned
     // that mutex (the map held the only shared_ptr). The unlock of the
     // freed mutex aborted the whole server on MSVC and is UB everywhere.
-    // Under ASan this test flags the use-after-free directly; without
-    // sanitizers it pins the collection path the older gc tests never
-    // reached (they only exercised the not-collected branches).
-    ExecutionEventBus bus;
+    //
+    // Detection: only MSVC's STL fails this deterministically (its unlock
+    // validates ownership and aborts). On POSIX the bad unlock lands inside
+    // uninstrumented libpthread, so ASan and TSan both stay silent — the
+    // Windows CI leg is the enforcement point. Either way this pins the
+    // collection path the older gc tests never reached (they only exercised
+    // the not-collected branches).
     std::int64_t fake_now = 1'000'000; // past the throttle vs last_gc=0
+    ExecutionEventBus bus;             // declared after the clock state it borrows
     bus.set_clock_fn([&] { return fake_now; });
 
     // Terminal event, no subscribers — exactly the channel shape GC targets.
@@ -173,10 +178,12 @@ TEST_CASE("execution_event_bus — GC collects an expired terminal channel "
 
     // Advance past retention + GC throttle so the sweep both runs and
     // finds exec-1 expired.
-    fake_now += ExecutionEventBus::kRetentionAfterTerminalSec * 1000 +
-                ExecutionEventBus::kMinGcIntervalMs + 1;
+    constexpr std::int64_t kAdvance =
+        ExecutionEventBus::kRetentionAfterTerminalSec * 1000 +
+        ExecutionEventBus::kMinGcIntervalMs + 1;
 
     SECTION("direct gc_terminal_channels() call") {
+        fake_now += kAdvance;
         CHECK(bus.gc_terminal_channels() == 1);
         CHECK(bus.channel_count() == 0);
         CHECK(bus.gc_channels_total() == 1);
@@ -184,10 +191,41 @@ TEST_CASE("execution_event_bus — GC collects an expired terminal channel "
     SECTION("publish-driven opportunistic sweep (production trigger)") {
         // In production the sweep fires from publish() on an unrelated
         // execution — the crash signature from the UAT rig.
+        fake_now += kAdvance;
         bus.publish("exec-2", "agent-transition", "{}");
         CHECK(bus.channel_count() == 1); // exec-1 collected, exec-2 live
         CHECK(bus.gc_channels_total() == 1);
         CHECK(bus.snapshot("exec-1").empty());
+    }
+    SECTION("multi-victim sweep parks every collected channel") {
+        // The dead vector must keep ALL victims alive past their locks,
+        // not just the first.
+        bus.publish("exec-2", "execution-completed", "{}", /*is_terminal=*/true);
+        bus.publish("exec-3", "execution-completed", "{}", /*is_terminal=*/true);
+        REQUIRE(bus.channel_count() == 3);
+        fake_now += kAdvance;
+        CHECK(bus.gc_terminal_channels() == 3);
+        CHECK(bus.channel_count() == 0);
+        CHECK(bus.gc_channels_total() == 3);
+    }
+    SECTION("expired channel with a live subscriber survives the sweep") {
+        // Pins the listeners.empty() predicate that both GC passes share —
+        // the same condition the pass-2 re-check applies when a subscriber
+        // lands between the passes. (The true between-pass interleaving
+        // needs a thread race and is covered by the CH-1 chaos scenario.)
+        fake_now += kAdvance;
+        auto sub = bus.subscribe("exec-1", [](const ExecutionEvent&) {});
+        CHECK(bus.gc_terminal_channels() == 0);
+        CHECK(bus.channel_count() == 1);
+
+        bus.unsubscribe("exec-1", sub);
+        // Within kMinGcIntervalMs of the sweep above — throttled no-op.
+        CHECK(bus.gc_terminal_channels() == 0);
+        CHECK(bus.channel_count() == 1);
+
+        fake_now += ExecutionEventBus::kMinGcIntervalMs + 1;
+        CHECK(bus.gc_terminal_channels() == 1); // collected once unsubscribed
+        CHECK(bus.channel_count() == 0);
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #1198 — `ExecutionEventBus::gc_terminal_channels()` destroyed a per-execution `Channel` (and the `std::mutex` inside it) while a `std::lock_guard` still owned that mutex. GC targets exactly the channels whose only owner is the `channels_` map (terminal, past retention, zero listeners), so `channels_.erase(it)` ran `~Channel` synchronously inside the loop and the guard's destructor then unlocked freed memory. On MSVC this aborts the entire server (`mutex.cpp(150): unlock of unowned mutex`); on all toolchains it is UB. Reachable from normal operator activity (dispatch an instruction, close the drawer, wait >60s).

## Fix

Minimal, semantics-preserving (the proposed patch from the issue): pin each victim with an extra `shared_ptr` before locking its mutex, park collected channels in a `dead` vector that outlives the erase loop, and let destruction run only after every per-channel lock is released. The atomic re-check-and-erase behaviour is unchanged.

## Regression test

The existing GC tests only exercised the *not-collected* branches — the collection path had zero coverage, which is how this shipped. The new test (`[execution_event_bus][gc]`) uses the `set_clock_fn` seam to advance past `kRetentionAfterTerminalSec` + `kMinGcIntervalMs` and drives collection two ways: a direct `gc_terminal_channels()` call and the production publish-driven opportunistic sweep.

Detection caveat (verified by standalone A/B repro of old vs fixed code): the old code fails this test **deterministically on MSVC** (its STL validates mutex ownership and aborts). On POSIX the bad unlock lands inside uninstrumented system libpthread, so ASan and TSan both stay silent — the Windows CI leg is the enforcement point for this regression.

## Verification

- Full server suite green on macOS (`meson test --suite server`, 36s).
- New test passes both sections; 1047 assertions across 11 `[execution_event_bus]` cases.
- ASan/TSan A/B repro of the buggy vs fixed translation unit (see caveat above).

`execution_event_bus.{hpp,cpp}` is a routed governance concern (executions-history ladder) — governance pipeline being run on this range, findings will be posted as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)