### PR TITLE
feat(compose-wizard): provision + wire the PostgreSQL server substrate (#1397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Compose Wizard (`tools/compose-wizard/`) now provisions the PostgreSQL
+  server substrate** (ADR-0006/0008, #1397). The browser wizard predated the
+  Postgres substrate move and generated a server with no database to talk to.
+  It now has a PostgreSQL section on the Data step with two deployment modes:
+  **bundled** (emits a release-pinned `ghcr.io/tr3kkr/yuzu-postgres` service
+  with the reference healthcheck and gates server start on
+  `depends_on: condition: service_healthy`) and **external/managed** (the
+  operator supplies a DSN, no local container). Either way the server gets a
+  `YUZU_POSTGRES_DSN` env entry (consumed as an env var, not a CLI flag). Per
+  ADR-0010 the credentials/DSN live in the generated `.env`; the compose YAML
+  only references `${YUZU_POSTGRES_PASSWORD}` / `${YUZU_DB_PASSWORD}` /
+  `${YUZU_POSTGRES_DSN}` so no secret is baked into it. Bundled mode enforces
+  the image's distinct-credentials invariant (superuser ≠ app role) and offers
+  a Web-Crypto secret generator. The wizard's default version was also bumped
+  `0.10.0` → `0.12.0` so the bundled image tag resolves.
 - **CI server-test legs now require a reachable PostgreSQL 16**
   (`scripts/ci/ensure-postgres.sh` exits 1 instead of warning when it cannot
   provision or authenticate one — except the documented psql-less TCP-probe

--- a/tools/compose-wizard/README.md
+++ b/tools/compose-wizard/README.md
@@ -15,7 +15,10 @@ This wizard walks you through a step-by-step configuration and generates a produ
 
 | Issue | Fix |
 |-------|-----|
-| Missing `--data-dir` flag | Always included — SQLite stores fail silently without it |
+| Missing PostgreSQL substrate | Wizard provisions a bundled `yuzu-postgres` service (or wires an external DSN) — the server has a substrate to talk to (ADR-0006/0008) |
+| Postgres superuser == app password | Bundled mode enforces two distinct credentials; the image's first-boot init refuses equal passwords |
+| Secrets baked into compose | Postgres credentials/DSN live in `.env`; the compose YAML only references `${...}` |
+| Missing `--data-dir` flag | Always included — still needed for config, OTA binaries, and not-yet-migrated SQLite stores |
 | RBAC config doesn't enforce | Comment added noting this is a known issue |
 | Port conflicts detected | Wizard warns about common conflicts |
 | Hardcoded passwords | All credentials configurable, with production warnings |

--- a/tools/compose-wizard/css/style.css
+++ b/tools/compose-wizard/css/style.css
@@ -139,7 +139,8 @@ header .subtitle {
 }
 
 .field input[type="text"],
-.field input[type="number"] {
+.field input[type="number"],
+.field select {
   width: 100%;
   padding: 0.5rem 0.75rem;
   border: 1px solid var(--border);
@@ -150,10 +151,26 @@ header .subtitle {
   transition: border 0.2s;
 }
 
-.field input:focus {
+.field input:focus,
+.field select:focus {
   outline: none;
   border-color: var(--yuzu-orange);
   box-shadow: 0 0 0 3px var(--yuzu-orange-light);
+}
+
+/* Input + inline action button (e.g. the secret generators) */
+.input-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+}
+
+.input-row input[type="text"] {
+  flex: 1;
+}
+
+.input-row .btn {
+  white-space: nowrap;
 }
 
 .field label input[type="checkbox"] {

--- a/tools/compose-wizard/index.html
+++ b/tools/compose-wizard/index.html
@@ -36,7 +36,7 @@
         <h3>What you'll configure:</h3>
         <ul>
           <li>Yuzu version, admin credentials, and ports</li>
-          <li>Data storage and ClickHouse settings</li>
+          <li>PostgreSQL storage substrate (bundled or external), data dir, and ClickHouse analytics</li>
           <li>Prometheus &amp; Grafana observability stack</li>
           <li>Yuzu Gateway (Erlang/OTP) settings</li>
         </ul>
@@ -57,7 +57,7 @@
 
         <div class="field">
           <label for="yuzu-version">Yuzu Version</label>
-          <input type="text" id="yuzu-version" value="0.10.0" placeholder="0.10.0">
+          <input type="text" id="yuzu-version" value="0.12.0" placeholder="0.12.0">
           <small>The container image tag. Use <code>latest</code> for bleeding edge.</small>
         </div>
 
@@ -121,8 +121,63 @@
       <section id="step-3" class="step-panel">
         <h2>Data &amp; Storage</h2>
 
+        <div class="callout info">
+          <strong>PostgreSQL is the server's storage substrate (ADR-0006/0008).</strong>
+          As of v0.12 the server stores its state in PostgreSQL, not SQLite. The
+          server needs a database to talk to — choose a bundled local container or
+          point at an external/managed instance below.
+        </div>
+
+        <div class="field">
+          <label for="pg-mode">PostgreSQL Deployment</label>
+          <select id="pg-mode">
+            <option value="bundled" selected>Bundled — compose stands up a local Postgres container</option>
+            <option value="external">External / managed — supply a DSN, no local container</option>
+          </select>
+          <small>Bundled uses the release-pinned <code>yuzu-postgres</code> image (PostgreSQL&nbsp;16 + pgvector). External points the server at a managed database.</small>
+        </div>
+
+        <fieldset id="pg-bundled-fields">
+          <legend>Bundled PostgreSQL</legend>
+
+          <div class="callout warning">
+            <strong>⚠️ Two distinct credentials.</strong> The superuser and app-role
+            passwords <em>must differ</em> — the image's first-boot init refuses to
+            run if they are equal. They are written to <code>.env</code>, never baked
+            into the compose file. Generate strong values for any non-local deployment.
+          </div>
+
+          <div class="field">
+            <label for="pg-superuser-pass">Superuser Password (POSTGRES_PASSWORD)</label>
+            <div class="input-row">
+              <input type="text" id="pg-superuser-pass" value="" placeholder="set a strong value">
+              <button type="button" onclick="genSecret('pg-superuser-pass')" class="btn small">🎲 Generate</button>
+            </div>
+            <small>Stays inside the postgres container. Never carried by the server DSN.</small>
+          </div>
+
+          <div class="field">
+            <label for="pg-app-pass">App Role Password (YUZU_DB_PASSWORD)</label>
+            <div class="input-row">
+              <input type="text" id="pg-app-pass" value="" placeholder="set a strong value (distinct from superuser)">
+              <button type="button" onclick="genSecret('pg-app-pass')" class="btn small">🎲 Generate</button>
+            </div>
+            <small>The credential the server's <code>YUZU_POSTGRES_DSN</code> carries. Must differ from the superuser password.</small>
+          </div>
+        </fieldset>
+
+        <fieldset id="pg-external-fields" style="display:none">
+          <legend>External / Managed PostgreSQL</legend>
+
+          <div class="field">
+            <label for="pg-dsn">PostgreSQL DSN</label>
+            <input type="text" id="pg-dsn" value="" placeholder="postgresql://yuzu:password@db.example.com:5432/yuzu">
+            <small>Written to <code>.env</code> as <code>YUZU_POSTGRES_DSN</code>; the server reads it from the environment. Carry the app-role password here, never a superuser credential. No local Postgres container is generated.</small>
+          </div>
+        </fieldset>
+
         <div class="callout warning">
-          <strong>⚠️ Known gotcha:</strong> The <code>--data-dir</code> flag is <em>required</em> in the server command. Without it, SQLite stores fail silently and agents won't persist. This wizard includes it by default.
+          <strong>⚠️ Known gotcha:</strong> The <code>--data-dir</code> flag is <em>required</em> in the server command. Even on the Postgres substrate the server still uses this directory for its config file, OTA binaries, and the not-yet-migrated SQLite stores. This wizard includes it by default.
         </div>
 
         <div class="field">

--- a/tools/compose-wizard/js/generate.js
+++ b/tools/compose-wizard/js/generate.js
@@ -1,6 +1,28 @@
 /* ── Compose File Generator ── */
 
 function generate() {
+  const pgMode = val('pg-mode');
+  const pgSuperPass = val('pg-superuser-pass');
+  const pgAppPass = val('pg-app-pass');
+  const pgDsn = val('pg-dsn');
+
+  // Guard the load-bearing substrate invariants before emitting anything —
+  // a compose/.env pair that the postgres image will refuse to boot is worse
+  // than no output.
+  if (pgMode === 'bundled') {
+    if (!pgSuperPass || !pgAppPass) {
+      alert('Bundled PostgreSQL: set BOTH the superuser and app-role passwords on the Data step (use 🎲 Generate). The yuzu-postgres image refuses to boot without them.');
+      return;
+    }
+    if (pgSuperPass === pgAppPass) {
+      alert('Bundled PostgreSQL: the superuser and app-role passwords must be DISTINCT — the image\'s first-boot init refuses to run if they are equal.');
+      return;
+    }
+  } else if (!pgDsn) {
+    alert('External PostgreSQL: supply a DSN on the Data step, or switch to the bundled mode. The server needs a database to talk to.');
+    return;
+  }
+
   const config = {
     version: val('yuzu-version'),
     adminUser: val('admin-user'),
@@ -13,6 +35,11 @@ function generate() {
     tlsCert: val('tls-cert'),
     tlsKey: val('tls-key'),
     dataDir: val('data-dir'),
+    pgMode: pgMode,
+    pgBundled: pgMode === 'bundled',
+    pgSuperPass: pgSuperPass,
+    pgAppPass: pgAppPass,
+    pgDsn: pgDsn,
     clickhouse: chk('include-clickhouse'),
     chHttpPort: num('ch-http-port'),
     chNativePort: num('ch-native-port'),
@@ -57,6 +84,19 @@ YUZU_GRPC_PORT=${c.grpcPort}
 YUZU_MGMT_PORT=${c.mgmtPort}
 YUZU_GATEWAY_UPSTREAM_PORT=${c.gwUpstreamPort}
 YUZU_ADMIN_USER=${c.adminUser}
+${c.pgBundled ? `
+# ── PostgreSQL (server storage substrate, ADR-0006/0008) ──
+# Two DISTINCT credentials — keep both in a secrets manager, not in git.
+# The superuser password stays inside the postgres container; the app-role
+# password is what the server's DSN carries. They MUST differ (the image's
+# first-boot init refuses to run if they are equal). Rotate with:
+#   openssl rand -hex 24
+YUZU_POSTGRES_PASSWORD=${c.pgSuperPass}
+YUZU_DB_PASSWORD=${c.pgAppPass}` : `
+# ── PostgreSQL (external / managed substrate) ──
+# Full server DSN — carries the app-role password, never a superuser
+# credential. Keep it out of git; this file is the only place it lives.
+YUZU_POSTGRES_DSN=${c.pgDsn}`}
 ${c.clickhouse ? `YUZU_CLICKHOUSE_PASSWORD=${c.chPass}
 YUZU_CLICKHOUSE_DB=${c.chDb}
 YUZU_CLICKHOUSE_USER=${c.chUser}` : ''}
@@ -307,6 +347,18 @@ ${c.clickhouse ? `## ClickHouse:  http://localhost:${c.chHttpPort}  (${c.chUser}
   y += `    environment:\n`;
   y += `      - YUZU_LOG_LEVEL=info\n`;
   y += `      - YUZU_LOG_FORMAT=json\n`;
+  // Postgres substrate DSN (ADR-0006/0008). Consumed via env var, NOT a CLI
+  // flag — the server reads YUZU_POSTGRES_DSN from the environment. The DSN
+  // carries the APP role password (interpolated from .env), never the
+  // superuser's, so a leaked server environment can't disclose superuser creds.
+  if (c.pgBundled) {
+    y += `      # Postgres substrate DSN (ADR-0006/0008). App-role password comes\n`;
+    y += `      # from .env (YUZU_DB_PASSWORD) — never baked into this file.\n`;
+    y += `      - YUZU_POSTGRES_DSN=postgresql://yuzu:\${YUZU_DB_PASSWORD}@postgres:5432/yuzu\n`;
+  } else {
+    y += `      # External/managed Postgres — full DSN supplied via .env.\n`;
+    y += `      - YUZU_POSTGRES_DSN=\${YUZU_POSTGRES_DSN}\n`;
+  }
   y += `    command:\n`;
   y += `      - "--listen"\n`;
   y += `      - "0.0.0.0:50051"\n`;
@@ -362,10 +414,58 @@ ${c.clickhouse ? `## ClickHouse:  http://localhost:${c.chHttpPort}  (${c.chUser}
   y += `      interval: 10s\n`;
   y += `      timeout: 5s\n`;
   y += `      retries: 5\n`;
-  if (c.clickhouse) {
+  // Gate server start on Postgres (bundled mode) and ClickHouse readiness so
+  // migrations don't race an unready substrate.
+  if (c.pgBundled || c.clickhouse) {
     y += `    depends_on:\n`;
-    y += `      clickhouse:\n`;
-    y += `        condition: service_healthy\n`;
+    if (c.pgBundled) {
+      y += `      postgres:\n`;
+      y += `        condition: service_healthy\n`;
+    }
+    if (c.clickhouse) {
+      y += `      clickhouse:\n`;
+      y += `        condition: service_healthy\n`;
+    }
+  }
+
+  // PostgreSQL (server storage substrate) — bundled mode only. In external
+  // mode the server's YUZU_POSTGRES_DSN points at a managed instance and no
+  // local container is generated.
+  if (c.pgBundled) {
+    y += `\n  # ── PostgreSQL (server storage substrate, ADR-0006/0008) ─────────────\n`;
+    y += `  # Release-pinned yuzu-postgres image: PostgreSQL 16 + pgvector + a\n`;
+    y += `  # first-boot init that creates the app role/database. Per-store schemas\n`;
+    y += `  # are created at runtime by the server's migration runner. Using an\n`;
+    y += `  # external/managed Postgres instead is first-class — re-run the wizard\n`;
+    y += `  # and pick "External / managed".\n`;
+    y += `  postgres:\n`;
+    y += `    image: ghcr.io/tr3kkr/yuzu-postgres:\${YUZU_VERSION:-${c.version}}\n`;
+    y += `    container_name: yuzu-postgres\n`;
+    y += `    restart: unless-stopped\n`;
+    y += `    environment:\n`;
+    y += `      # Both passwords come from .env — the actual secrets never appear\n`;
+    y += `      # in this compose file. They MUST be distinct (first-boot init\n`;
+    y += `      # refuses to run otherwise); the superuser password stays inside\n`;
+    y += `      # this container and is never carried by the server DSN.\n`;
+    y += `      - POSTGRES_PASSWORD=\${YUZU_POSTGRES_PASSWORD}\n`;
+    y += `      - YUZU_DB_PASSWORD=\${YUZU_DB_PASSWORD}\n`;
+    y += `    volumes:\n`;
+    if (c.persistentVolumes) {
+      y += `      - postgres-data:/var/lib/postgresql/data\n`;
+    } else {
+      y += `      - /var/lib/postgresql/data\n`;
+    }
+    y += `    healthcheck:\n`;
+    // -h 127.0.0.1 forces a TCP probe (initdb's temporary server is socket-only
+    // mid-init); the psql leg dials the container hostname (not loopback, which
+    // initdb leaves on 'trust') so it actually verifies the app credential.
+    // $$ defers expansion to the container shell so the password never appears
+    // in `docker compose config` output.
+    y += `      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U yuzu -d yuzu && psql \\"postgresql://yuzu:$\${YUZU_DB_PASSWORD}@$$(hostname):5432/yuzu\\" -tA -c 'SELECT 1' >/dev/null"]\n`;
+    y += `      interval: 5s\n`;
+    y += `      timeout: 5s\n`;
+    y += `      retries: 12\n`;
+    y += `      start_period: 10s\n`;
   }
 
   // Gateway
@@ -475,6 +575,7 @@ ${c.clickhouse ? `## ClickHouse:  http://localhost:${c.chHttpPort}  (${c.chUser}
   if (c.persistentVolumes) {
     y += `\nvolumes:\n`;
     y += `  server-data:\n`;
+    if (c.pgBundled) y += `  postgres-data:\n`;
     if (c.prometheus) y += `  prometheus-data:\n`;
     if (c.grafana) y += `  grafana-data:\n`;
     if (c.clickhouse) y += `  clickhouse-data:\n`;

--- a/tools/compose-wizard/js/wizard.js
+++ b/tools/compose-wizard/js/wizard.js
@@ -32,6 +32,12 @@ document.getElementById('enable-tls').addEventListener('change', e => {
   document.querySelectorAll('.tls-field').forEach(f => f.style.display = e.target.checked ? '' : 'none');
 });
 
+document.getElementById('pg-mode').addEventListener('change', e => {
+  const bundled = e.target.value === 'bundled';
+  document.getElementById('pg-bundled-fields').style.display = bundled ? '' : 'none';
+  document.getElementById('pg-external-fields').style.display = bundled ? 'none' : '';
+});
+
 document.getElementById('include-clickhouse').addEventListener('change', e => {
   document.getElementById('clickhouse-fields').style.display = e.target.checked ? '' : 'none';
 });
@@ -53,6 +59,16 @@ document.getElementById('include-gateway').addEventListener('change', e => {
 function val(id) { return document.getElementById(id).value.trim(); }
 function num(id) { return parseInt(document.getElementById(id).value) || 0; }
 function chk(id) { return document.getElementById(id).checked; }
+
+// Fill a field with a cryptographically-random 24-byte hex secret. Used for
+// the Postgres credentials so operators can avoid weak / shared passwords —
+// the secret only ever lands in the generated .env, never in the compose YAML.
+function genSecret(id) {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  document.getElementById(id).value =
+    Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+}
 
 // ── Admin password hash ──
 // Yuzu uses: username:password:salt in a specific format
@@ -131,12 +147,14 @@ function detectPortConflicts() {
 
 // ── Review Summary ──
 function buildReview() {
+  const pgBundled = val('pg-mode') === 'bundled';
   const items = [
     ['Yuzu Version', val('yuzu-version')],
     ['Admin User', val('admin-user')],
     ['Dashboard Port', num('dashboard-port')],
     ['Agent gRPC Port', num('grpc-port')],
     ['TLS', chk('enable-tls') ? '✅ Enabled' : '❌ Disabled'],
+    ['PostgreSQL', pgBundled ? '✅ Bundled container' : '🔗 External / managed'],
     ['ClickHouse', chk('include-clickhouse') ? '✅ Included' : '❌ Skipped'],
     ['Prometheus', chk('include-prometheus') ? '✅ Included' : '❌ Skipped'],
     ['Grafana', chk('include-grafana') ? '✅ Included' : '❌ Skipped'],
@@ -151,8 +169,19 @@ function buildReview() {
   html += '</div>';
   document.getElementById('review-summary').innerHTML = html;
 
-  // Port warnings
+  // Port warnings + Postgres credential checks
   const warnings = detectPortConflicts();
+  if (pgBundled) {
+    const su = val('pg-superuser-pass');
+    const app = val('pg-app-pass');
+    if (!su || !app) {
+      warnings.push('⚠️ Bundled Postgres: set BOTH the superuser and app-role passwords (🎲 Generate) — the image refuses to boot without them.');
+    } else if (su === app) {
+      warnings.push('⚠️ Bundled Postgres: superuser and app-role passwords are identical — first-boot init refuses to run. Make them distinct.');
+    }
+  } else if (!val('pg-dsn')) {
+    warnings.push('⚠️ External Postgres selected but no DSN supplied — the server will have no database to talk to.');
+  }
   const warnEl = document.getElementById('port-warnings');
   if (warnings.length) {
     warnEl.innerHTML = warnings.join('<br>');


### PR DESCRIPTION
Closes #1397.

## Problem

The browser-based **Compose Wizard** (`tools/compose-wizard/`) predated the PostgreSQL server-storage-substrate move (ADR-0006/0008, substrate shipped in #1320) and generated a `docker-compose` deployment whose server had **no database to talk to** — no `postgres` service, no DSN.

## What changed

The Data step now has a PostgreSQL section with two deployment modes, mirroring the native installer (`scripts/install-server-postgres.sh`) and `deploy/docker/docker-compose.reference.yml`:

- **Bundled** — emits a release-pinned `ghcr.io/tr3kkr/yuzu-postgres` service (PostgreSQL 16 + pgvector, built from `Dockerfile.postgres` / `postgres-init/`) with the reference healthcheck, and gates server start on `depends_on: condition: service_healthy`.
- **External / managed** — the operator supplies a DSN; no local container is generated.

Either way the server gets a `YUZU_POSTGRES_DSN` **environment** entry (consumed as an env var, not a CLI flag — the binary rejects unknown flags).

### Secrets-at-rest (ADR-0010)

Credentials/DSN live only in the generated `.env`; the compose YAML references `${YUZU_POSTGRES_PASSWORD}` / `${YUZU_DB_PASSWORD}` / `${YUZU_POSTGRES_DSN}` so **no secret is baked into it**. Bundled mode enforces the image's distinct-credentials invariant (superuser ≠ app role) up front and offers a Web-Crypto secret generator (🎲).

The wizard's stale default version was bumped `0.10.0` → `0.12.0` so the bundled image tag resolves.

## Verification

- Generation logic run under Node (DOM stub) for bundled / external / minimal configs.
- Both modes validated with **`docker compose config`**; secrets interpolate correctly from `.env`.
- The bundled Postgres healthcheck matches `docker-compose.reference.yml` **byte-for-byte**, and its `$$`-escaping survives compose normalization (container shell sees `${YUZU_DB_PASSWORD}` / `$(hostname)`).
- Pre-flight guards abort generation on empty/equal bundled passwords or a missing external DSN.
- `scripts/check-compose-versions.sh 0.12.0` stays green — the wizard generates output at runtime, so there is no new *tracked* compose file to add to its `FILES` array.

## Notes

- No new tracked compose file; nothing to add to `check-compose-versions.sh`.
- The wizard is shipped as a release asset (`Package Compose Wizard` step in `release.yml`) — no build step, no impact there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)