### PR TITLE
chore(ci): retire scw-eager-lumiere runner from the inventory

### DIFF
--- a/.github/runner-inventory.json
+++ b/.github/runner-inventory.json
@@ -15,13 +15,6 @@
       "labels": ["self-hosted", "Windows", "X64"],
       "role": "Windows MSVC CI jobs — ci.yml windows matrix (release + debug), codeql Windows leg.",
       "installed": "2026-04-14"
-    },
-    {
-      "name": "scw-eager-lumiere",
-      "host": "Scaleway VPS (Ubuntu 24.04, 4 vCPU, 7.7 GB RAM, ~45 GB disk)",
-      "labels": ["self-hosted", "Linux", "X64", "yuzu-cloud-builder"],
-      "role": "Cloud-side Linux capacity sharing the [self-hosted, Linux, X64] label set with yuzu-wsl2-linux. The yuzu-cloud-builder label exists for future opt-in pinning of jobs that should land here specifically. Disk is tighter than the WSL2 box — sanitizer-tests.yml's ≥30 GB preflight will fail-fast if a sanitizer dispatch lands on this runner; that is intentional and the dispatch will retry on yuzu-wsl2-linux.",
-      "installed": "2026-05-04"
     }
   ]
 }

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,15 +5,15 @@ name: "CodeQL"
 #   - yuzu-wsl2-linux (labels: self-hosted/Linux/X64/yuzu-shulgi) — gcc-13 build
 #   - yuzu-local-windows (labels: self-hosted/Windows/X64) — MSVC build
 #
-# The Linux leg pins `yuzu-shulgi` explicitly so it can't drift to
-# `scw-eager-lumiere` (cloud builder, labels self-hosted/Linux/X64/
-# yuzu-cloud-builder). The cloud builder is sized for nightly Coverage
-# and routinely sits below the 40 GB disk threshold this workflow
-# requires; matching `[self-hosted, Linux, X64]` alone gives GH free
-# reign to assign whichever runner is idle, which produces non-
-# deterministic failures (run 25986790721 hit Scaleway at 23 GB free
-# and died at the disk check before any CodeQL work). Same selector
-# pattern nightly.yml uses for the equivalent meson workload.
+# The Linux leg pins `yuzu-shulgi` explicitly rather than matching the
+# bare `[self-hosted, Linux, X64]` label set. Today Shulgi is the only
+# Linux runner, but the pin is deliberate: any future overflow runner
+# sharing the bare label set must NOT receive this workload unless it
+# meets the 40 GB disk threshold CodeQL needs. (A retired Scaleway cloud
+# builder sized for nightly Coverage routinely sat below it — run
+# 25986790721 died at the disk check at 23 GB free before any CodeQL
+# work — which is why the pin exists.) Same selector pattern nightly.yml
+# uses for the equivalent meson workload.
 #
 # The two runs are separate matrix legs with `fail-fast: false`, so a
 # quirk on one platform doesn't kill the other. Each leg uploads SARIF
@@ -102,9 +102,8 @@ jobs:
       matrix:
         include:
           - os: linux
-            # yuzu-shulgi pin — see header comment. The cloud builder
-            # (scw-eager-lumiere) carries `yuzu-cloud-builder` instead;
-            # this list intentionally excludes it.
+            # yuzu-shulgi pin — see header comment (guards the 40 GB disk
+            # threshold against any future overflow Linux runner).
             runner: [self-hosted, Linux, X64, yuzu-shulgi]
             triplet: x64-linux
             vcpkg_bin: vcpkg

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,9 +40,10 @@ jobs:
     # is a forced cold-cache rebuild every run because per-instrumentation
     # vcpkg packages can't be safely shared with the standard triplet — so
     # the ASan job rebuilds the full dep tree from source on every nightly.
-    # On the small cloud runner (scw-eager-lumiere) that step alone runs
-    # 60+ minutes and routinely blows the 60-min job timeout. Shulgi
-    # (16-core 5950X) clears the same workload in ~15 min. TSan and
+    # On a small cloud runner that step alone runs 60+ minutes and
+    # routinely blows the 60-min job timeout; this is why the Linux legs
+    # pin Shulgi (16-core 5950X), which clears the same workload in
+    # ~15 min. TSan and
     # Coverage share the warm x64-linux triplet cache so they don't need
     # pinning and keep the runner pool flexible.
     runs-on: [self-hosted, Linux, X64, yuzu-shulgi]
@@ -173,9 +174,9 @@ jobs:
     # ASan job: the TSan triplet (x64-linux-tsan, issue #917) is a forced
     # cold-cache rebuild every run because per-instrumentation vcpkg
     # packages can't be safely shared with the standard or ASan triplets.
-    # On scw-eager-lumiere (small Scaleway VM) the from-source dep-tree
-    # rebuild blows the 60-min job timeout; Shulgi (16-core 5950X) clears
-    # the same workload in ~15 min.
+    # On a small cloud VM the from-source dep-tree rebuild blows the
+    # 60-min job timeout; Shulgi (16-core 5950X) clears the same workload
+    # in ~15 min, which is why this leg pins yuzu-shulgi.
     runs-on: [self-hosted, Linux, X64, yuzu-shulgi]
     timeout-minutes: 60
     env:

--- a/.github/workflows/runner-ops-upgrade-erlang.yml
+++ b/.github/workflows/runner-ops-upgrade-erlang.yml
@@ -1,8 +1,8 @@
 name: Runner ops — upgrade Erlang/OTP
 #
 # Operational workflow that upgrades the Erlang/OTP toolchain on a
-# specified self-hosted Linux runner (yuzu-wsl2-linux, scw-eager-lumiere,
-# or any future runner with the right matching label).
+# specified self-hosted Linux runner (e.g. yuzu-wsl2-linux, or any
+# future runner with the right matching label).
 #
 # Manual dispatch only — `workflow_dispatch` requires the workflow file
 # to live on the default branch (main), so this workflow is permanent and
@@ -22,14 +22,13 @@ on:
     inputs:
       target_runner_label:
         description: |
-          Custom runner label to target (e.g. yuzu-shulgi or yuzu-cloud-builder).
+          Custom runner label to target (e.g. yuzu-shulgi).
           The job runs-on `[self-hosted, Linux, X64, <this-label>]`, so this
           must be a label unique to the intended runner.
         required: true
         type: choice
         options:
           - yuzu-shulgi
-          - yuzu-cloud-builder
       otp_version:
         description: "Erlang/OTP release to install (e.g. 28.4.2)."
         required: true

--- a/scripts/runner-ops/upgrade-erlang-linux.sh
+++ b/scripts/runner-ops/upgrade-erlang-linux.sh
@@ -3,7 +3,7 @@
 # to a specified Erlang/OTP release globally.
 #
 # Works for any runner installed via the standard /opt/actions-runner layout
-# (yuzu-wsl2-linux, scw-eager-lumiere, …). Detects the runner directory,
+# (e.g. yuzu-wsl2-linux). Detects the runner directory,
 # the systemd User=, and the runner home automatically.
 #
 # What it does:


### PR DESCRIPTION
## Why

The Scaleway cloud-builder VPS `scw-eager-lumiere` is being decommissioned — it's slow and only ever shared the bare `[self-hosted, Linux, X64]` label as overflow capacity behind `yuzu-wsl2-linux`. I SSH'd in to confirm: the box is healthy (18d uptime) but the runner service **cleanly stopped on 2026-05-25**, and GitHub auto-removed the registration after its 14-day-offline window. So the `runner-inventory-sentinel` has been failing every 30 min on a `MISSING`-runner drift and spamming **#931**.

Correction to the record: this was **not** the #931 NAT-idle-timeout pattern — it was a clean service stop + GitHub's offline auto-removal.

## What

- Remove `scw-eager-lumiere` from `.github/runner-inventory.json` → turns the sentinel green, stops the #931 drift comments.
- Drop the dead `yuzu-cloud-builder` option from the runner-ops Erlang-upgrade dispatch menu; refresh example-runner comments in that workflow and `upgrade-erlang-linux.sh`.
- Refresh the `yuzu-shulgi`-pin rationale comments in `codeql.yml` and `nightly.yml`. **The pins stay** — they guard the 40 GB CodeQL disk threshold and sanitizer capacity against any *future* overflow runner; I only stripped the retired runner's name from the explanation.

## Blast radius

**Zero job-routing change.** No `runs-on` ever pinned `scw-eager-lumiere` — it only matched the bare Linux label set, so jobs have been landing on `yuzu-wsl2-linux` the whole time. The box has been gone 19 days with no CI impact, which is the strongest evidence it was redundant.

The GitHub runner registration is already auto-removed (nothing to deregister). The physical VPS is being deleted separately by the operator.

## Noted, not fixed (kept out to stay single-purpose)

`yuzu-wsl2-linux` actually carries a `yuzu-shulgi` label that the inventory doesn't declare (the codeql/nightly pins depend on it). The sentinel tolerates extra *actual* labels so it causes no drift — flagging for a future inventory-accuracy touch-up.

## Follow-up

`#931` should close as retired once this merges (I'll do that after merge, or say the word).

🤖 Generated with [Claude Code](https://claude.com/claude-code)