### PR TITLE
fix(gateway): end eunit ETS reap race that flaked Windows CI (#1403)

### DIFF
--- a/gateway/apps/yuzu_gw/test/yuzu_gw_agent_tests.erl
+++ b/gateway/apps/yuzu_gw/test/yuzu_gw_agent_tests.erl
@@ -48,28 +48,12 @@ agent_test_() ->
      ]}.
 
 setup() ->
-    %% Start pg and registry (real).
-    case whereis(yuzu_gw) of
-        undefined -> pg:start_link(yuzu_gw);
-        _ -> ok
-    end,
-    %% A bare whereis check is not enough — health_nf_tests leaves a
-    %% mock_loop process registered as yuzu_gw_registry on cleanup
-    %% (see #336). Detect that case and replace it with a real registry
-    %% so register_agent doesn't hang on a process that swallows calls.
-    case whereis(yuzu_gw_registry) of
-        undefined ->
-            {ok, _} = yuzu_gw_registry:start_link();
-        Existing ->
-            case proc_lib:initial_call(Existing) of
-                {gen_server, init_it, _} ->
-                    ok;
-                _NotAGenServer ->
-                    catch unregister(yuzu_gw_registry),
-                    catch exit(Existing, kill),
-                    {ok, _} = yuzu_gw_registry:start_link()
-            end
-    end,
+    %% Ensure pg + a real registry under its registered name. The helper
+    %% navigates both #336 hazards: a mock_loop impostor left by
+    %% health_nf_tests (which would hang register_agent), and the
+    %% orphaned-but-not-yet-reaped registry whose still-owned named ETS
+    %% tables crash a fresh start_link's init/1 (issue #1403).
+    yuzu_gw_test_registry:ensure(),
     %% Clean up stale mocks from prior modules.
     catch meck:unload(yuzu_gw_upstream),
     catch meck:unload(telemetry),

--- a/gateway/apps/yuzu_gw/test/yuzu_gw_gauge_tests.erl
+++ b/gateway/apps/yuzu_gw/test/yuzu_gw_gauge_tests.erl
@@ -68,15 +68,8 @@ gauge_tick_test_() ->
       {"tick emits vm process count event", fun tick_emits_process_count/0}]}.
 
 tick_setup() ->
-    %% Start pg scope.
-    case whereis(yuzu_gw) of
-        undefined -> pg:start_link(yuzu_gw);
-        _ -> ok
-    end,
-    case whereis(yuzu_gw_registry) of
-        undefined -> {ok, _} = yuzu_gw_registry:start_link();
-        _ -> ok
-    end,
+    %% pg + a real registry, race-safe across modules (#1403 / #336).
+    yuzu_gw_test_registry:ensure(),
     %% Use ETS to collect telemetry events (EUnit runs setup and tests
     %% in different processes, so mailbox messaging won't work).
     catch ets:delete(gauge_test_events),

--- a/gateway/apps/yuzu_gw/test/yuzu_gw_registration_replay_tests.erl
+++ b/gateway/apps/yuzu_gw/test/yuzu_gw_registration_replay_tests.erl
@@ -46,12 +46,8 @@ replay_test_() ->
      ]}.
 
 setup() ->
-    %% pg is needed by the registry.
-    case whereis(yuzu_gw) of
-        undefined -> pg:start_link(yuzu_gw);
-        _         -> ok
-    end,
-    ensure_registry(),
+    %% pg + a real registry, race-safe across modules (#1403 / #336).
+    yuzu_gw_test_registry:ensure(),
 
     %% Clean up stale mocks from prior modules.
     catch meck:unload(grpcbox_client),
@@ -301,82 +297,6 @@ proxy_register_count() ->
 %% Poll until exactly Expected ProxyRegister RPCs have been recorded.
 wait_for_proxy_register_count(Expected, Timeout) ->
     wait_until(fun() -> proxy_register_count() =:= Expected end, Timeout).
-
-%%%===================================================================
-%%% Helpers — registry lifecycle
-%%%===================================================================
-
-%% Ensure a real yuzu_gw_registry gen_server is available under its
-%% registered name.
-%%
-%% Two hazards have to be navigated, both rooted in #336:
-%%   1. A prior module (health_nf_tests) can leave a mock_loop process
-%%      registered as yuzu_gw_registry. That mock silently discards
-%%      gen_server:call, so register_agent/6 would hang. Detect a
-%%      non-gen_server via proc_lib:initial_call and evict it.
-%%   2. The registry is start_link-ed in every test module's setup, so
-%%      it dies with that module's transient EUnit group process. When
-%%      the next module's setup runs, the old registry may be dead but
-%%      *not yet reaped* — it still owns the named ETS tables, so a
-%%      fresh start_link's init/1 crashes on ets:new "table already
-%%      exists". Wait for those orphaned tables to clear before
-%%      (re)starting, and retry start_link a bounded number of times.
-ensure_registry() ->
-    case whereis(yuzu_gw_registry) of
-        undefined ->
-            start_fresh_registry(20);
-        Existing ->
-            case proc_lib:initial_call(Existing) of
-                {gen_server, init_it, _} ->
-                    %% Real registry from an earlier module — reuse it.
-                    ok;
-                _NotAGenServer ->
-                    catch unregister(yuzu_gw_registry),
-                    catch exit(Existing, kill),
-                    start_fresh_registry(20)
-            end
-    end.
-
-start_fresh_registry(Retries) ->
-    %% Trap exits for the duration of the start attempt(s). A
-    %% yuzu_gw_registry whose init/1 crashes on ets:new "table already
-    %% exists" is start_link-ed, so its EXIT signal would otherwise kill
-    %% this (the EUnit group) process before we ever see start_link's
-    %% {error, _} return. Trapping turns that EXIT into a drainable
-    %% message; we restore the flag once a registry is up.
-    Prev = process_flag(trap_exit, true),
-    Result = do_start_fresh_registry(Retries),
-    %% Drain any {'EXIT', _, _} left by failed start_link attempts so
-    %% the flag restore doesn't strand a signal in the mailbox.
-    drain_exits(),
-    process_flag(trap_exit, Prev),
-    Result.
-
-do_start_fresh_registry(Retries) when Retries =< 0 ->
-    %% Out of retries — surface the real failure rather than loop.
-    {ok, _} = yuzu_gw_registry:start_link(),
-    ok;
-do_start_fresh_registry(Retries) ->
-    %% Wait out any orphaned-but-not-yet-reaped registry that still owns
-    %% the named tables — once the tables are gone, start_link is clean.
-    _ = wait_until(fun() ->
-        ets:info(yuzu_gw_agents, size) =:= undefined andalso
-        ets:info(yuzu_gw_pending, size) =:= undefined
-    end, 1000),
-    case yuzu_gw_registry:start_link() of
-        {ok, _Pid} ->
-            ok;
-        {error, _Reason} ->
-            %% Orphan still alive — drain its EXIT, back off, retry.
-            drain_exits(),
-            timer:sleep(25),
-            do_start_fresh_registry(Retries - 1)
-    end.
-
-drain_exits() ->
-    receive {'EXIT', _, _} -> drain_exits()
-    after 0 -> ok
-    end.
 
 %%%===================================================================
 %%% Helpers — generic

--- a/gateway/apps/yuzu_gw/test/yuzu_gw_registry_tests.erl
+++ b/gateway/apps/yuzu_gw/test/yuzu_gw_registry_tests.erl
@@ -42,17 +42,12 @@ registry_test_() ->
      ]}.
 
 setup() ->
-    %% pg needs kernel to be started; it should be in test env.
-    case whereis(yuzu_gw) of
-        undefined -> pg:start_link(yuzu_gw);
-        _         -> ok
-    end,
-    case yuzu_gw_registry:start_link() of
-        {ok, Pid}                       -> Pid;
-        {error, {already_started, Pid}} -> Pid
-    end.
+    %% pg + a real registry, race-safe across modules. The naive
+    %% start_link here previously had no handling for the init/1 crash a
+    %% leaked-ETS-table orphan triggers (#1403 / #336).
+    yuzu_gw_test_registry:ensure().
 
-cleanup(_Pid) ->
+cleanup(_) ->
     %% Don't stop the registry — other test suites share it.
     ok.
 

--- a/gateway/apps/yuzu_gw/test/yuzu_gw_router_tests.erl
+++ b/gateway/apps/yuzu_gw/test/yuzu_gw_router_tests.erl
@@ -28,14 +28,8 @@ router_test_() ->
      ]}.
 
 setup() ->
-    case whereis(yuzu_gw) of
-        undefined -> pg:start_link(yuzu_gw);
-        _ -> ok
-    end,
-    case whereis(yuzu_gw_registry) of
-        undefined -> {ok, _} = yuzu_gw_registry:start_link();
-        _ -> ok
-    end,
+    %% pg + a real registry, race-safe across modules (#1403 / #336).
+    yuzu_gw_test_registry:ensure(),
     %% Clean up stale mocks from prior modules before creating new ones.
     catch meck:unload(telemetry),
     meck:new(telemetry, [passthrough, no_link]),

--- a/gateway/apps/yuzu_gw/test/yuzu_gw_scale_tests.erl
+++ b/gateway/apps/yuzu_gw/test/yuzu_gw_scale_tests.erl
@@ -63,21 +63,12 @@ scale_test_() ->
       ]}}.
 
 setup() ->
-    case whereis(yuzu_gw) of
-        undefined -> pg:start_link(yuzu_gw);
-        _ -> ok
-    end,
     %% Kill and restart the registry so we don't inherit a gen_server
-    %% mailbox full of DOWN messages from other test modules.
-    %% Must use exit/2 because gen_server:stop queues behind the DOWNs.
-    case whereis(yuzu_gw_registry) of
-        undefined -> ok;
-        Old ->
-            unlink(Old),
-            exit(Old, kill),
-            timer:sleep(100)
-    end,
-    {ok, _} = yuzu_gw_registry:start_link(),
+    %% mailbox full of DOWN messages from other test modules. ensure_fresh
+    %% evicts the old one and waits for its named ETS tables to be reaped
+    %% before start_link — the fixed-sleep version raced that reap on slow
+    %% runners (#1403 / #336).
+    yuzu_gw_test_registry:ensure_fresh(),
     meck:new(telemetry, [passthrough, no_link]),
     meck:expect(telemetry, execute, fun(_, _, _) -> ok end),
     ok.

--- a/gateway/apps/yuzu_gw/test/yuzu_gw_test_registry.erl
+++ b/gateway/apps/yuzu_gw/test/yuzu_gw_test_registry.erl
@@ -1,0 +1,152 @@
+%%%-------------------------------------------------------------------
+%%% @doc Shared EUnit helper: make a real `yuzu_gw_registry' available.
+%%%
+%%% Every gateway test module that exercises the registry `start_link's
+%%% it in its own `setup/0'. Because `start_link' links the registry to
+%%% the transient EUnit fixture process, the registry dies when that
+%%% module's fixture process exits — and ETS table destruction on owner
+%%% death is *asynchronous*. So when the next module's `setup/0' runs
+%%% there is a window where `whereis(yuzu_gw_registry) =:= undefined' but
+%%% the named tables the dead registry owned (`yuzu_gw_agents' /
+%%% `yuzu_gw_pending') are not yet reaped. A naive `start_link' in that
+%%% window crashes in `init/1' with
+%%%
+%%%     ets:new(yuzu_gw_pending, ...) → {badarg, ... table name already exists}
+%%%
+%%% which cancels the whole module's tests (`One or more tests were
+%%% cancelled') and reddens CI. The window is timing-dependent and widens
+%%% on the self-hosted Windows runner (slower scheduling + Defender I/O
+%%% serialisation), which is why it surfaced there intermittently and
+%%% cleared on re-run. Issue #1403; documented as `#336' hazard 2 in
+%%% `yuzu_gw_registration_replay_tests'.
+%%%
+%%% A second hazard (#336): `yuzu_gw_health_nf_tests' can leave a
+%%% non-gen_server "mock_loop" process registered under the name; reusing
+%%% it would hang the next `register_agent' call. `ensure/0' evicts it.
+%%%
+%%% This module centralises the proven navigation of both hazards so every
+%%% registry-using suite shares one correct implementation instead of
+%%% re-deriving it (the bug only ever got fixed in one of six setups).
+%%% @end
+%%%-------------------------------------------------------------------
+-module(yuzu_gw_test_registry).
+
+-export([ensure/0, ensure_fresh/0]).
+
+%% Tables owned by the registry gen_server (see yuzu_gw_registry:init/1).
+-define(AGENTS_TABLE,  yuzu_gw_agents).
+-define(PENDING_TABLE, yuzu_gw_pending).
+
+-define(START_RETRIES,    20).
+-define(REAP_TIMEOUT_MS, 1000).
+-define(RETRY_BACKOFF_MS,  25).
+
+%% @doc Idempotently ensure the `yuzu_gw' pg scope and a real
+%% `yuzu_gw_registry' are up under the registered name, reusing a live
+%% registry when one is present. Safe to call from every registry-using
+%% test module's `setup/0'. Returns `ok'.
+-spec ensure() -> ok.
+ensure() ->
+    ensure_pg(),
+    case whereis(yuzu_gw_registry) of
+        undefined ->
+            start_fresh(?START_RETRIES);
+        Existing ->
+            case proc_lib:initial_call(Existing) of
+                {gen_server, init_it, _} ->
+                    %% A real registry from an earlier module — reuse it.
+                    ok;
+                _NotAGenServer ->
+                    %% A mock_loop impostor (#336) — evict and replace.
+                    evict(Existing),
+                    start_fresh(?START_RETRIES)
+            end
+    end.
+
+%% @doc Like `ensure/0' but always replaces any existing registry with a
+%% brand-new one. Use where a suite must not inherit a shared registry's
+%% monitor/DOWN backlog (`yuzu_gw_scale_tests'). Returns `ok'.
+-spec ensure_fresh() -> ok.
+ensure_fresh() ->
+    ensure_pg(),
+    case whereis(yuzu_gw_registry) of
+        undefined -> ok;
+        Existing  -> evict(Existing)
+    end,
+    start_fresh(?START_RETRIES).
+
+%%%===================================================================
+%%% Internal
+%%%===================================================================
+
+ensure_pg() ->
+    case whereis(yuzu_gw) of
+        undefined -> pg:start_link(yuzu_gw);
+        _         -> ok
+    end,
+    ok.
+
+evict(Pid) ->
+    catch unlink(Pid),
+    catch unregister(yuzu_gw_registry),
+    catch exit(Pid, kill),
+    ok.
+
+%% `start_link' can race a dying registry that still owns the named ETS
+%% tables; the fresh `init/1' then crashes with a `{badarg, ...}' EXIT
+%% propagated through the link. Trap exits so that crash arrives as a
+%% drainable message rather than killing us, wait the tables out, and
+%% retry a bounded number of times.
+start_fresh(Retries) ->
+    Prev = process_flag(trap_exit, true),
+    Result = do_start_fresh(Retries),
+    %% Drain any {'EXIT', _, _} left by a failed start_link attempt so the
+    %% flag restore doesn't strand a signal in the mailbox.
+    drain_exits(),
+    process_flag(trap_exit, Prev),
+    Result.
+
+do_start_fresh(Retries) when Retries =< 0 ->
+    %% Out of retries — make one last attempt and let it surface the real
+    %% failure rather than loop silently.
+    {ok, _} = yuzu_gw_registry:start_link(),
+    ok;
+do_start_fresh(Retries) ->
+    %% Wait out any orphaned-but-not-yet-reaped registry that still owns
+    %% the named tables — once they are gone, start_link is clean.
+    _ = wait_until(fun() ->
+        ets:info(?AGENTS_TABLE, size) =:= undefined andalso
+        ets:info(?PENDING_TABLE, size) =:= undefined
+    end, ?REAP_TIMEOUT_MS),
+    case yuzu_gw_registry:start_link() of
+        {ok, _Pid} ->
+            ok;
+        {error, {already_started, _Pid}} ->
+            %% Another process won the race with a real registry — fine.
+            ok;
+        {error, _Reason} ->
+            %% Orphan still alive (tables not yet reaped) — drain its
+            %% EXIT, back off, retry.
+            drain_exits(),
+            timer:sleep(?RETRY_BACKOFF_MS),
+            do_start_fresh(Retries - 1)
+    end.
+
+drain_exits() ->
+    receive {'EXIT', _, _} -> drain_exits()
+    after 0 -> ok
+    end.
+
+%% Poll Pred every 10ms until it returns true or Timeout elapses.
+wait_until(Pred, Timeout) when Timeout =< 0 ->
+    case Pred() of
+        true  -> ok;
+        false -> {error, timeout}
+    end;
+wait_until(Pred, Timeout) ->
+    case Pred() of
+        true  -> ok;
+        false ->
+            timer:sleep(10),
+            wait_until(Pred, Timeout - 10)
+    end.

--- a/scripts/test_gateway.py
+++ b/scripts/test_gateway.py
@@ -77,18 +77,28 @@ cmd = ["rebar3", "as", "test", suite]
 if suite == "eunit":
     cmd += ["--dir", "apps/yuzu_gw/test"]
 
-    # eunit_surefire writes its XML report to the literal path declared
-    # in gateway/rebar.config eunit_opts (`{dir, "_build/test/eunit"}`),
-    # which resolves relative to the rebar3 CWD = gateway_dir. That
-    # path is NOT auto-created — `eunit_surefire:write_report/2` calls
-    # `file:open` directly and crashes with `{error,enoent}` if the
-    # directory is missing. On Linux runners with a long-lived gateway
-    # checkout the dir often pre-exists from older non-REBAR_BASE_DIR
-    # runs, hiding the bug. On the Windows runner — and on any fresh
-    # checkout — REBAR_BASE_DIR redirects rebar3's own `_build` to
-    # `_build_eunit`, so `_build/test/eunit` is never created and the
-    # surefire listener crashes after every test passes (exit 1 on the
-    # gateway eunit test even with 0 actual test failures).
+    # Pre-create the eunit_surefire report dir (gateway/rebar.config
+    # eunit_opts `{dir, "_build/test/eunit"}`, resolved relative to the
+    # rebar3 CWD = gateway_dir). Belt-and-suspenders only: OTP 26+
+    # eunit_surefire:init/1 already self-creates this dir via
+    # filelib:ensure_dir + file:make_dir, so the dir's existence is not
+    # the failure mode it was once thought to be (#1403).
+    #
+    # NOTE on the `eunit_surefire:write_report ... {error,enoent}` crash
+    # seen in Windows eunit logs: that is a SEPARATE, HARMLESS artifact,
+    # not a build-breaker. With `--dir`, eunit's top-level group is named
+    # `directory "<abs path>"`; eunit_surefire:escape_suitename/1 turns
+    # the path's `/` into `:`, producing a filename like
+    # `TEST-directory_C::...:test.xml`. `:` is illegal in a Windows
+    # filename, so file:open fails with enoent on every Windows run. It
+    # does NOT affect the exit code: eunit's result comes from the
+    # eunit_tty listener, and eunit:test waits for listeners to terminate
+    # with ANY exit reason (see lib/eunit/src/eunit.erl). The surefire XML
+    # is not consumed by CI, so the broken report is moot. The actual
+    # intermittent #1403 failure was an unrelated test-isolation ETS race
+    # (yuzu_gw_test_registry now serialises registry start across modules)
+    # — its crash cancelled tests, which DID fail the build, and happened
+    # to print alongside the always-present surefire noise.
     surefire_dir = Path(gateway_dir) / "_build" / "test" / "eunit"
     surefire_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
Fixes #1403.

## TL;DR
The intermittent Windows gateway-eunit failure is a **test-isolation ETS race**, not the surefire report dir the issue describes. The surefire `enoent` is harmless log noise. Fix extracts the one proven race-safe registry-start helper and applies it to all six registry-using setups.

## Diagnosis (from the failed log, run `27430849679`)
The log shows two independent things; only the first fails the build:

1. **Build-breaker — ETS reap race.** Every registry-using test module `start_link`s `yuzu_gw_registry`, linking it to the transient EUnit fixture process. When that process dies between modules the registry dies — but **ETS named-table destruction on owner death is asynchronous**. In the window where `whereis(yuzu_gw_registry) =:= undefined` yet `yuzu_gw_pending` is not yet reaped, a naive `start_link` crashes `init/1`:
   ```
   ets:new(yuzu_gw_pending,[named_table,...]) → already_exists   (yuzu_gw_registry.erl:224)
     ← yuzu_gw_agent_tests:setup/0
   ```
   → `One or more tests were cancelled` → `eunit:test` returns error → rebar3 exits 1 → red. The reap window widens on the Defender-serialized self-hosted Windows runner, hence Windows-only, intermittent, clears on re-run. Documented in-tree as "#336 hazard 2" but only ever fixed in **one** of six setups.

2. **Red herring — surefire `enoent`.** With `--dir`, eunit's top group is named `directory "<abs path>"`; `eunit_surefire:escape_suitename` turns `/`→`:`, producing `TEST-directory_C::...test.xml`. `:` is illegal in a Windows filename, so the write fails on **every** Windows run. It **cannot change the exit code** — eunit's result comes from the `eunit_tty` listener and `eunit:test` waits for listeners to exit with *any* reason (`lib/eunit/src/eunit.erl:248-252`) — and the XML is unused by CI. The `mkdir` "fix" (present since May 1) targets a dir OTP 26+ self-creates; it never could have fixed this.

## Change
- **New `yuzu_gw_test_registry`** helper (`ensure/0`, `ensure_fresh/0`): wait-for-reap + bounded retry + mock-impostor eviction (the proven logic previously private to `registration_replay_tests`).
- **All six registry-starting setups** routed through it (`agent`, `gauge`, `router`, `scale`, `registry`, `registration_replay`); racy/duplicated variants deleted. `scale_tests` uses `ensure_fresh/0` (its `exit(kill)` + fixed `sleep(100)` + `start_link` was the same race).
- **Corrected** the misleading surefire comment in `scripts/test_gateway.py`.

Test-infra only — no `src/`, proto, or wire change.

## Verification (local, OTP 28)
- **Targeted race repro** (kill→reap→start, ×400): old naive pattern **5/400** crashes with the exact `ets:new ... already_exists`; new helper **0/400**.
- **eunit**: green 5× — `All 210 tests passed`, 0 cancellations, 0 ETS crashes.
- **dialyzer**: default profile clean; new module adds 0 warnings (the test-profile `meck`/`eunit` "unknown function" warnings are pre-existing PLT noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)