### PR TITLE
fix(build): systemd_guard feature option (follow-up to #1424 review #3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,11 +180,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   error. Non-systemd Linux hosts (no system D-Bus) degrade gracefully: the guard
   does not arm and the rule reports unarmed rather than compliant. The watch
   reconnects automatically after a `systemctl daemon-reexec` / dbus restart.
-  **New runtime dependency on Linux agents:** `libsystemd.so.0` (package
-  `libsystemd0` on Debian/Ubuntu, `systemd-libs` on RHEL/Fedora). Systemd hosts
-  already have it; container and minimal Linux deployments must add `libsystemd0`
-  (runtime) and `libsystemd-dev` (build) — the shipped `Dockerfile.agent`,
-  `Dockerfile.agent.chisel`, and the asan/tsan images are updated accordingly.
+  **Build/runtime dependency on Linux agents:** `libsystemd` — build `libsystemd-dev`
+  (`systemd-devel` on RHEL/Fedora), runtime `libsystemd.so.0` (`libsystemd0` /
+  `systemd-libs`). The default build (`-Dsystemd_guard=enabled`) **requires** it so the
+  shipped agent always offers the guard — a build that has lost libsystemd fails loudly
+  rather than silently shipping a guard-less agent; the shipped `Dockerfile.agent`,
+  `Dockerfile.agent.chisel`, and the asan/tsan images install it and keep that default.
+  Pass `-Dsystemd_guard=auto` (use if present) or `disabled` to build the guard as a
+  no-op stub on musl/Alpine/non-systemd/minimal images that lack libsystemd.
 - **DEX: per-cohort performance gauges for Prometheus/Grafana (opt-in).**
   Settings → DEX alerts gains a **cohort export tag key**: when set (empty by
   default), `/metrics` publishes `yuzu_fleet_perf_cohort_{cpu_pct,commit_pct,

--- a/agents/core/meson.build
+++ b/agents/core/meson.build
@@ -10,16 +10,30 @@ agent_openssl_dep = dependency('openssl', required: true, include_type: 'system'
 agent_crypto_deps = [agent_openssl_dep]
 
 # Linux: the systemd service guard (guard_systemd.cpp) watches unit run-state over
-# sd-bus, which libsystemd provides. libsystemd exists only on Linux, so this
-# dependency is gated by host system — the source file is wrapped in
-# `#if defined(__linux__)` and compiles to an empty TU elsewhere (the dex_macos_*.cpp
-# pattern), so off-Linux nothing references sd-bus.h and no link dep is needed.
-# required: true on Linux because a Linux agent that cannot offer the service guard is
-# a regression (install libsystemd-dev / systemd-devel). The non-systemd runtime
-# fallback is a start()-time concern, handled inside the guard, not a build-time one.
+# sd-bus, which libsystemd provides. The sd-bus impl is wrapped in
+# `#if defined(__linux__) && defined(YUZU_HAVE_LIBSYSTEMD)` and compiles to a no-op
+# stub (start() returns false, like the off-Linux build) when libsystemd is not used.
+# The `systemd_guard` feature option (default `enabled`) controls the dependency:
+#   enabled  — require libsystemd, so the shipped agent always offers the guard and a
+#              build that has lost libsystemd-dev FAILS loudly instead of silently
+#              shipping a guard-less agent. Default ⇒ CI / Docker / release stay
+#              unchanged and keep the guarantee with no extra flags.
+#   auto     — use libsystemd if found, else build the no-op stub (no configure error).
+#   disabled — always build the no-op stub.
+# Pass `-Dsystemd_guard=auto` (or `disabled`) for musl/Alpine/non-systemd/minimal
+# images where libsystemd is absent.
 agent_platform_deps = []
+agent_platform_args = []
 if host_machine.system() == 'linux'
-  agent_platform_deps += dependency('libsystemd', required: true, include_type: 'system')
+  libsystemd_dep = dependency('libsystemd', required: get_option('systemd_guard'),
+                              include_type: 'system')
+  if libsystemd_dep.found()
+    agent_platform_deps += libsystemd_dep
+    agent_platform_args += '-DYUZU_HAVE_LIBSYSTEMD'
+  else
+    message('libsystemd not used (systemd_guard != enabled, and not found) — Linux '
+          + 'systemd service guard built as a no-op stub')
+  endif
 endif
 
 yuzu_agent_core_lib = shared_library(
@@ -30,7 +44,7 @@ yuzu_agent_core_lib = shared_library(
     include_directories('../../sdk/include'),
   ],
   dependencies: [yuzu_sdk_dep, yuzu_proto_dep, spdlog_dep, sqlite3_dep, nlohmann_dep] + agent_crypto_deps + agent_platform_deps,
-  cpp_args: ['-DYUZU_AGENT_CORE_BUILDING'],
+  cpp_args: ['-DYUZU_AGENT_CORE_BUILDING'] + agent_platform_args,
   install: true,
 )
 

--- a/agents/core/src/guard_systemd.cpp
+++ b/agents/core/src/guard_systemd.cpp
@@ -164,7 +164,7 @@ std::unique_ptr<IGuard> make_service_guard(ServiceGuard::Config cfg, GuardSink s
 
 } // namespace yuzu::agent
 
-#if defined(__linux__)
+#if defined(__linux__) && defined(YUZU_HAVE_LIBSYSTEMD)
 
 #include <systemd/sd-bus.h>
 
@@ -601,7 +601,7 @@ void SystemdServiceGuard::run() try {
 
 } // namespace yuzu::agent
 
-#else // ── Non-Linux: no-op (no sd-bus) ─────────────────────────────────────────
+#else // ── No sd-bus (non-Linux, or Linux built without libsystemd): no-op stub ──
 
 namespace yuzu::agent {
 

--- a/meson.options
+++ b/meson.options
@@ -2,6 +2,11 @@ option('build_agent',    type: 'boolean', value: true,  description: 'Build the 
 option('build_server',   type: 'boolean', value: true,  description: 'Build the server daemon')
 option('build_examples', type: 'boolean', value: true,  description: 'Build example plugins')
 option('build_tests',    type: 'boolean', value: false, description: 'Build unit and integration tests')
+option('systemd_guard',  type: 'feature', value: 'enabled',
+       description: 'Linux systemd service guard (libsystemd / sd-bus). '
+                  + 'enabled (default): require libsystemd so the shipped agent always offers the guard. '
+                  + 'auto: use libsystemd if present, else build a no-op stub. disabled: always stub. '
+                  + 'Use auto/disabled for musl/Alpine/minimal images without libsystemd.')
 option('enable_enterprise', type: 'boolean', value: false,
        description: 'Build commercial enterprise modules from enterprise/. '
                   + 'Requires a commercial license — see enterprise/LICENSE-ENTERPRISE.md. '


### PR DESCRIPTION
Follow-up to #1424 (merged) addressing fjarvis's review item **#3**, which was non-blocking and landed after the merge.

#1424 left `libsystemd` `required: true` on every Linux build, so musl/Alpine/non-systemd/minimal-image builds fail at configure even though the guard is capability-gated at runtime. This makes it a `systemd_guard` meson **feature option** (default `enabled`):

- **enabled** (default): require libsystemd + define `YUZU_HAVE_LIBSYSTEMD` so the real sd-bus guard compiles. A build that has lost `libsystemd-dev` **fails loudly** rather than silently shipping a guard-less agent — CI / Docker / release keep this default with no changes, so the shipped agent always offers the guard.
- **auto**: use libsystemd if present, else build the no-op stub (no configure error).
- **disabled**: always build the no-op stub.

The sd-bus impl is gated `#if defined(__linux__) && defined(YUZU_HAVE_LIBSYSTEMD)`; otherwise the existing no-op stub (`start()` returns false) compiles. Pass `-Dsystemd_guard=auto|disabled` for musl/Alpine/minimal images without libsystemd.

## Verification (Linux, consistent branch checkout)
- `enabled` → real guard, `[systemd]` 14 cases / 79 assertions + full agent suite 562 green
- `disabled` → stub compiles, `libyuzu_agent_core.so` links with **no** libsystemd, suite 562 green
- `enabled` + libsystemd absent → configure **fails loudly** (the guarantee)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
