### PR TITLE
fix(deploy/windows): lock server installer log-dir ACL (service-full invalid keyword)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Windows server installer locks its log-directory ACL.** `yuzu-server.iss`
+  set `Permissions: service-full` on `{app}\logs`, which is not a valid
+  InnoSetup permission group — ISCC silently ignores it, leaving the directory
+  with default ACLs (readable by authenticated users). Now `admins-full
+  system-full`, matching the installer's own data/cert directories. (The same
+  invalid keyword was fixed for the agent installer in #1425 / #1436.)
 - **macOS agents are no longer counted as Windows in DEX denominators.** The
   OS check used a substring match, and "darwin" contains "win" — so on mixed
   fleets every macOS agent inflated the Windows-online denominator behind the

--- a/deploy/packaging/windows/yuzu-server.iss
+++ b/deploy/packaging/windows/yuzu-server.iss
@@ -72,7 +72,7 @@ Source: "{#BuildDir}\server\core\*.dll"; DestDir: "{app}\bin"; Flags: ignorevers
 Source: "generate-config.ps1"; DestDir: "{tmp}"; Flags: deleteafterinstall
 
 [Dirs]
-Name: "{app}\logs"; Permissions: service-full
+Name: "{app}\logs"; Permissions: admins-full system-full
 Name: "{commonappdata}\Yuzu Server"; Permissions: admins-full system-full
 Name: "{commonappdata}\Yuzu Server\data"; Permissions: admins-full system-full
 Name: "{commonappdata}\Yuzu Server\certs"; Permissions: admins-full system-full


### PR DESCRIPTION
Twin of the agent-installer ACL fix from #1425 / #1436 (fjarvis caught the agent one in #1436 review).

`yuzu-server.iss` set `Permissions: service-full` on `{app}\logs`. `service` is not a valid InnoSetup permission group, so ISCC **silently ignores** it and the directory keeps default ACLs — readable by authenticated users. The server's own data/cert directories (`{commonappdata}\Yuzu Server[\data|\certs]`) already use the correct `admins-full system-full`; this aligns the log dir to match.

Severity is lower than the agent's (server logs, not the EDR-revealing boot trace `procboot.etl`) but it's the same class, and this is the last `service-full` instance in the repo.

**Verification:** ISCC-compiled locally — `[Dirs]` parses clean (compile aborts only at `[Files]` on the un-staged build artifact, as expected). `SYSTEM` retains full access, so the server (LocalSystem-equivalent) keeps writing logs.

One line + a `### Fixed` CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)