### PR TITLE
feat(network): fold the Network view under DEX as a sub-nav tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Network quality dashboard (`/network`).** A new top-level page surfaces
-  fleet-wide TCP network quality measured continuously on each endpoint from
-  kernel counters (no packet capture, no flow export) — a **device / local-link
-  health** view. Fleet-now cards show RTT p50/p90/max, the **interval retransmit
+- **Network quality dashboard (`/network`).** A new **Network** view — a sub-view
+  under DEX (the Network tab in the DEX sub-nav, also reachable directly at
+  `/network`), not a standalone top-level nav item — surfaces fleet-wide TCP
+  network quality measured continuously on each endpoint from kernel counters (no
+  packet capture, no flow export) — a **device / local-link health** view. Fleet-now cards show RTT p50/p90/max, the **interval retransmit
   rate**, and device throughput. The retransmit rate is ΔΣretransmits /
   ΔΣsegments smoothed over the last few heartbeats (recent-window loss), **not**
   the lifetime ratio — empirically the lifetime ratio is diluted to noise while

--- a/docs/user-manual/dex.md
+++ b/docs/user-manual/dex.md
@@ -11,12 +11,14 @@ only reads and aggregates.
 It is reached from the **DEX** link in the dashboard nav, or directly at
 `/dex`. Access requires the **`GuaranteedState:Read`** permission.
 
-## The five views
+## The six views
 
 DEX is organised as a **hub** (the Overview at `/dex`) that *summarises and
-links* into four deep pages. A shared sub-nav switches between **Overview ·
-Catalogue · Health score · Trends · Performance**; the window selector (below)
-applies to the signal views (Performance is a now-view — see below).
+links* into five deep pages. A shared sub-nav switches between **Overview ·
+Catalogue · Health score · Trends · Performance · Network**; the window selector
+(below) applies to the signal views (Performance and Network are now-views — see
+below). The Network view also has its own URL, `/network`, but it is a DEX
+sub-view, not a standalone top-level nav item.
 
 ### Overview (the hub)
 
@@ -104,6 +106,19 @@ server-side series store).
   metric; the Reporting card opens the devices *not* reporting; each cohort
   row opens that cohort's device list — and every device row opens the
   per-device drill-down.
+
+### Network
+
+The fleet's TCP **network quality**, measured on each endpoint from kernel
+counters (no packet capture, no flow export). A **now-view** like Performance:
+fleet-now cards for round-trip time, the interval retransmit rate, and device
+throughput — each with its own reporting population — plus a worst-devices
+drill. It is **device / local-link health**, not localization: a bad local link
+(Wi-Fi, congested uplink) shows up cleanly across every connection, but *which*
+destination or app is affected is a later per-destination slice. Linux agents
+report today; Windows and macOS collectors are later slices. Full detail,
+platform coverage, and the privacy model are on the
+[Network quality dashboard](network.md) page.
 
 **Window selector.** `24h / 7d / 30d / All` rescopes every signal view.
 Drill-downs opened from a panel inherit the window you were viewing, so the

--- a/docs/user-manual/network.md
+++ b/docs/user-manual/network.md
@@ -13,9 +13,10 @@ or app problem — something a network-only tool cannot do.
 
 ## Access
 
-Navigate to **Network** in the top navigation bar, or go to `/network` directly.
-Permission required: **`GuaranteedState:Read`** (the same permission that gates
-the Guardian and DEX read surfaces).
+Network is a **sub-view of DEX**, not a standalone top-level nav item: open
+**DEX** in the top navigation bar and choose the **Network** tab, or go to
+`/network` directly. Permission required: **`GuaranteedState:Read`** (the same
+permission that gates the Guardian and DEX read surfaces).
 
 ## Overview tab
 

--- a/server/core/src/dex_routes.cpp
+++ b/server/core/src/dex_routes.cpp
@@ -371,9 +371,12 @@ std::string dex_window_token(int window_days) {
     return window_days == 1 ? "24h" : window_days == 30 ? "30d" : window_days == 0 ? "all" : "7d";
 }
 
-// Shared DEX sub-nav (Overview · Catalogue · Health score · Trends). htmx core
-// attrs into the page mount — CSP-safe (no hx-on). Health/Trends are not built
-// yet → rendered as muted "soon" placeholders until their fragments exist.
+// Shared DEX sub-nav (Overview · Catalogue · Health score · Trends · Performance ·
+// Network). htmx core attrs into the page mount — CSP-safe (no hx-on). The Network
+// tab loads the /fragments/network/* renderers (network_ui.cpp), which render this
+// same sub-nav with "network" active — so Network sits UNDER DEX rather than as its
+// own top-level nav item. The network fragments ignore the threaded ?window= (the
+// quality view is a now-view with no window of its own).
 std::string dex_subnav(const std::string& active, int window_days) {
     const std::string w = dex_window_token(window_days);
     auto tab = [&](const char* id, const char* label, const char* frag) {
@@ -385,7 +388,8 @@ std::string dex_subnav(const std::string& active, int window_days) {
            tab("catalogue", "Catalogue", "/fragments/dex/catalogue") +
            tab("health", "Health score", "/fragments/dex/health") +
            tab("trends", "Trends", "/fragments/dex/trends") +
-           tab("perf", "Performance", "/fragments/dex/perf") + "</div>";
+           tab("perf", "Performance", "/fragments/dex/perf") +
+           tab("network", "Network", "/fragments/network/overview") + "</div>";
 }
 
 // Window chips for a given fragment path (reuses the overview pattern).

--- a/server/core/src/guardian_page_ui.cpp
+++ b/server/core/src/guardian_page_ui.cpp
@@ -233,7 +233,6 @@ extern const char* const kGuardianDetailPageHtml =
     <a href="/compliance" class="nav-link">Compliance</a>
     <a href="/guardian" class="nav-link active">Guardian</a>
     <a href="/dex" class="nav-link">DEX</a>
-    <a href="/network" class="nav-link">Network</a>
     <a href="/tar" class="nav-link">TAR</a>
     <a href="/viz/fleet" class="nav-link">Fleet Viz</a>
     <a href="/settings" class="nav-link" id="nav-settings-link">Settings</a>

--- a/server/core/src/network_routes.cpp
+++ b/server/core/src/network_routes.cpp
@@ -56,12 +56,14 @@ void NetworkRoutes::register_routes(HttpRouteSink& sink, AuthFn auth_fn, PermFn 
         };
         sub("{{TITLE}}", "Yuzu \xE2\x80\x94 Network");
         sub("{{FRAGMENT}}", "/fragments/network/overview");
-        // The shared shell marks Guardian active by default; on /network the
-        // Network link is the active one. Plain string swaps on static chrome.
+        // Network sits UNDER DEX (no standalone top-nav link), so /network marks
+        // the DEX nav item active; the overview fragment renders the DEX sub-nav
+        // with the Network tab active. The shared shell defaults Guardian active,
+        // so swap that off and DEX on. Plain string swaps on static chrome.
         sub("<a href=\"/guardian\" class=\"nav-link active\">Guardian</a>",
             "<a href=\"/guardian\" class=\"nav-link\">Guardian</a>");
-        sub("<a href=\"/network\" class=\"nav-link\">Network</a>",
-            "<a href=\"/network\" class=\"nav-link active\">Network</a>");
+        sub("<a href=\"/dex\" class=\"nav-link\">DEX</a>",
+            "<a href=\"/dex\" class=\"nav-link active\">DEX</a>");
         res.set_header("Cache-Control", "no-cache, no-store, must-revalidate");
         res.set_content(std::move(html), "text/html; charset=utf-8");
     });

--- a/server/core/src/network_routes.hpp
+++ b/server/core/src/network_routes.hpp
@@ -30,10 +30,6 @@ namespace yuzu::server {
 
 class HttpRouteSink;
 
-/// Shared /network sub-nav (Overview · Devices). htmx core attrs into the page
-/// mount (#guardian-detail) — CSP-safe (no hx-on).
-std::string network_subnav(const std::string& active);
-
 /// PURE: the /fragments/network/overview content — fleet-now quality cards
 /// (the same stats as the yuzu_fleet_net_* gauges, via the shared
 /// network_perf_rules) + the co-occurrence headline (network/device/app,

--- a/server/core/src/network_ui.cpp
+++ b/server/core/src/network_ui.cpp
@@ -22,6 +22,12 @@
 
 namespace yuzu::server {
 
+// The Network views sit UNDER DEX: they render the shared DEX sub-nav (with the
+// "network" tab active) rather than a sub-nav of their own. dex_subnav is defined
+// in dex_routes.cpp (same yuzu::server scope) — forward-declared here, the same
+// cross-TU pattern the Performance tab uses (dex_perf_ui.cpp).
+std::string dex_subnav(const std::string& active, int window_days);
+
 namespace {
 
 std::string esc(const std::string& s) { return html_escape(s); }
@@ -98,24 +104,15 @@ std::string cell(const std::optional<double>& v, Unit u) {
 
 } // namespace
 
-// Shared /network sub-nav (declared in network_routes.hpp).
-std::string network_subnav(const std::string& active) {
-    auto tab = [&](const char* id, const char* label, const char* frag) {
-        const std::string on = (active == id) ? " class=\"on\"" : "";
-        return "<a" + on + " hx-get=\"" + frag +
-               "\" hx-target=\"#guardian-detail\" hx-swap=\"innerHTML\">" + label + "</a>";
-    };
-    return "<div class=\"gp-subnav\">" +
-           tab("overview", "Overview", "/fragments/network/overview") +
-           tab("devices", "Devices", "/fragments/network/devices") + "</div>";
-}
-
 std::string render_network_overview_fragment(const NetPerfSnapshot& snap) {
     const auto now = net_perf_fleet_now(snap);
 
     std::string h;
     h += "<a class=\"gp-back\" href=\"/\">&larr; Dashboard</a>";
-    h += network_subnav("overview");
+    // The DEX sub-nav with "network" active (Network sits under DEX). This is a
+    // now-view with no window of its own, so the threaded window is the DEX
+    // default (7 = "7d") — it only governs which window a sibling signal tab opens.
+    h += dex_subnav("network", 7);
     h += "<div class=\"gp-head\"><div><div class=\"gp-titleline\"><h1>Network quality &mdash; fleet"
          "</h1></div><div class=\"gp-sub\">Device / <b>local-link</b> health, measured on each "
          "endpoint from kernel counters (no packet capture, no flow export) and rolled up across the "

--- a/tests/unit/server/test_network_perf_model.cpp
+++ b/tests/unit/server/test_network_perf_model.cpp
@@ -237,6 +237,12 @@ TEST_CASE("overview render: cards, co-occurrence, honesty", "[network][ui]") {
 
     const auto html = render_network_overview_fragment(snap);
     CHECK(html.find("Network quality") != std::string::npos);
+    // IA: Network is a DEX sub-view — the overview renders the shared DEX sub-nav
+    // (a sibling DEX tab link is present) with the Network tab marked active,
+    // rather than a standalone network sub-nav.
+    CHECK(html.find("/fragments/dex/catalogue") != std::string::npos); // DEX sub-nav rendered
+    CHECK(html.find("class=\"on\" hx-get=\"/fragments/network/overview") !=
+          std::string::npos); // Network tab is the active one
     CHECK(html.find("Round-trip time") != std::string::npos);
     CHECK(html.find("TCP_INFO") != std::string::npos);                // Linux/Windows honesty note
     // Measurement-first (4b.3): the retransmit fact is an INTERVAL rate, and the
@@ -336,6 +342,10 @@ TEST_CASE("network routes: perm gating + provider degradation", "[network][route
         REQUIRE(page);
         CHECK(page->status == 200);
         CHECK(page->body.find("/fragments/network/overview") != std::string::npos);
+        // IA: Network is a DEX sub-view — the /network page shell marks DEX active
+        // in the global nav, and there is NO standalone Network top-nav link.
+        CHECK(page->body.find("class=\"nav-link active\">DEX</a>") != std::string::npos);
+        CHECK(page->body.find("class=\"nav-link\">Network</a>") == std::string::npos);
     }
 }
 


### PR DESCRIPTION
## What

Network was a half-wired top-level nav item — the `/network` link existed only in the Guardian page shell, so it vanished on every other page. Network quality is a DEX concern by construction (edge-correlated with device perf + process signals in the same warehouse), and the shipped v1 is a measurement-first device / local-link health view. This moves Network **under DEX** as a 6th sub-nav tab, mirroring the Performance tab.

## Changes

- `dex_subnav()`: add a 6th **Network** tab → `/fragments/network/overview`.
- `network_ui.cpp`: the overview renders the shared DEX sub-nav (Network active) instead of its own; dead `network_subnav` removed; forward-declares `dex_subnav` (same cross-TU pattern as `dex_perf_ui.cpp`).
- `guardian_page_ui.cpp`: drop the orphaned `/network` top-nav link.
- `network_routes.cpp`: the `/network` page shell marks DEX active in the global nav.
- `network_routes.hpp`: drop the `network_subnav` declaration.
- Docs: `dex.md` (six views + a Network section), `network.md` (Access), CHANGELOG.
- Tests: pins for (a) the overview rendering the DEX sub-nav with Network active and (b) the `/network` page shell marking DEX active.

`/network` still works as a direct URL. REST `/api/v1/network/*` and the MCP tools are unchanged (IA-independent).

## Design notes (grilled)

- Network stays a **flat** sibling of the signal tabs (not regrouped) — Performance set this precedent.
- The device list is **drill-only** (click a metric card), matching Performance; the old Overview/Devices sub-tab is removed.
- Tab label kept as "Network".

## Verification

- Server suite green on Windows MSVC (1/1 OK, 0 fail).
- Live server: curl assertions + a headless-browser click of the Network tab from `/dex` — htmx swap clean, Network tab active, **zero CSP/page errors** (only a pre-existing `/favicon.ico` 404).
- `/governance` deliberately skipped: nav-markup-only change, no auth/data/input-parsing delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
