### PR TITLE
fix(tar): race-free, corruption-resilient source enable/disable (#538, #559, #560)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -286,6 +286,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **TAR source enable/disable is now race-free, corruption-resilient, and reports
+  a strict state (#538, #559, #560).** Three agent-side defects in the per-source
+  enable/disable lifecycle: (a) `configure` wrote `<source>_enabled=false` without
+  the collector mutex, so an in-flight collection cycle could commit one snapshot
+  *after* the operator disabled a source — and a later re-enable then diffed
+  against that frozen snapshot, fabricating "stopped" events for every process
+  that exited during the paused window (#538); (b) a corrupt `tar.db` was opened
+  and trusted, and since `get_config` returns the caller default on a read
+  failure, every `<source>_enabled` key read as its `true` default — silently
+  re-enabling sources an operator had paused for forensic preservation (#559);
+  (c) `status` echoed the raw stored enable value, so a garbage value (corruption,
+  tampering) was passed through instead of flagged. Fixes: `configure` now holds
+  the collector mutex across the transition and clears the source's diff-state on
+  disable (clean re-enable baseline); `TarDatabase::open` runs `PRAGMA
+  integrity_check` and quarantines a corrupt DB aside before re-initialising a
+  fresh one; `status` emits a strict tri-state (`true`/`false`/`errored`).
 - **Windows server installer locks its log-directory ACL.** `yuzu-server.iss`
   set `Permissions: service-full` on `{app}\logs`, which is not a valid
   InnoSetup permission group — ISCC silently ignores it, leaving the directory

--- a/agents/plugins/tar/src/tar_aggregator.cpp
+++ b/agents/plugins/tar/src/tar_aggregator.cpp
@@ -133,6 +133,28 @@ void apply_source_enabled_transition(TarDatabase& db,
     }
 }
 
+std::string_view diff_state_key_for_source(std::string_view source) {
+    // Keep in sync with collect_fast_impl's set_state() collector keys: the
+    // `tcp` source persists under "network", not "tcp".
+    if (source == "process")
+        return "process";
+    if (source == "tcp")
+        return "network";
+    if (source == "service")
+        return "service";
+    if (source == "user")
+        return "user";
+    return {}; // perf / procperf / netqual keep no snapshot diff-state
+}
+
+std::string_view canonical_source_enabled(std::string_view stored_value) {
+    if (stored_value == "true")
+        return "true";
+    if (stored_value == "false")
+        return "false";
+    return "errored"; // anything else was written outside the plugin
+}
+
 void run_retention(TarDatabase& db, int64_t now_epoch) {
     // M17: Wrap all retention deletes in a single transaction to amortize fsync cost
     db.execute_sql("BEGIN TRANSACTION");

--- a/agents/plugins/tar/src/tar_aggregator.hpp
+++ b/agents/plugins/tar/src/tar_aggregator.hpp
@@ -59,4 +59,26 @@ void apply_source_enabled_transition(TarDatabase& db,
                                       std::string_view new_value,
                                       int64_t now_epoch);
 
+/**
+ * Map a capture-source name to the `set_state`/`get_state` collector key its
+ * diff path uses, or "" for sources that keep no diff-state.
+ *
+ * NOTE the `tcp` source persists its snapshot under "network", NOT "tcp" — this
+ * mapping MUST stay in sync with collect_fast_impl's set_state() calls. The
+ * scalar samplers (`perf`, `procperf`, `netqual`) keep no snapshot diff and map
+ * to "". Used when disabling a source to clear the right state row so a later
+ * re-enable diffs against a clean baseline (#538).
+ */
+[[nodiscard]] std::string_view diff_state_key_for_source(std::string_view source);
+
+/**
+ * Canonicalise a stored `<source>_enabled` value to a strict tri-state for the
+ * `status` surface (#560). do_configure only ever persists "true"/"false", so
+ * any other stored value indicates the row was mutated outside the plugin
+ * (corruption, disk tampering, downgrade/upgrade) and is reported as the
+ * explicit "errored" sentinel — never coerced/guessed — so the dashboard can
+ * render a value-error badge instead of silently omitting the source.
+ */
+[[nodiscard]] std::string_view canonical_source_enabled(std::string_view stored_value);
+
 } // namespace yuzu::tar

--- a/agents/plugins/tar/src/tar_db.cpp
+++ b/agents/plugins/tar/src/tar_db.cpp
@@ -18,8 +18,11 @@
 
 #include <cctype>
 #include <chrono>
+#include <filesystem>
 #include <format>
 #include <memory>
+#include <optional>
+#include <string_view>
 
 namespace yuzu::tar {
 
@@ -109,6 +112,65 @@ constexpr const char* kCreateSchema = R"(
     );
 )";
 
+// #559 — self-test a freshly-opened tar.db with PRAGMA integrity_check. A
+// corrupt file (filesystem damage, partial restore, mid-write crash) must NOT
+// be silently trusted: get_config() returns the caller's default on a read
+// failure, so a corrupt DB would read every `<source>_enabled` key as its
+// "true" default and silently re-enable sources an operator deliberately paused
+// for forensic preservation — defeating the #539 retention guard with no
+// telemetry. Returns true only when the check reports the canonical "ok".
+bool integrity_ok(sqlite3* db) noexcept {
+    sqlite3_stmt* raw = nullptr;
+    if (sqlite3_prepare_v2(db, "PRAGMA integrity_check", -1, &raw, nullptr) != SQLITE_OK)
+        return false; // can't even read the DB → treat as corrupt
+    StmtPtr stmt(raw);
+    bool ok = false;
+    if (sqlite3_step(stmt.get()) == SQLITE_ROW) {
+        const auto* txt = reinterpret_cast<const char*>(sqlite3_column_text(stmt.get(), 0));
+        ok = txt && std::string_view{txt} == "ok";
+    }
+    return ok;
+}
+
+// Move a corrupt tar.db (and its -wal/-shm sidecars) aside to a timestamped
+// `.corrupt-<epoch>` path for forensic review, so open() can re-initialise a
+// fresh, trustworthy database rather than refusing to load TAR entirely.
+// Returns the quarantine path, or std::nullopt if the corrupt main file could
+// NOT be moved aside (read-only mount, locked file on Windows, permissions) —
+// in which case the caller MUST fail closed rather than re-open-and-trust the
+// still-corrupt file (#559 / UP-1). A sidecar that can't be moved is removed
+// instead, so the freshly-created DB can never adopt a stale -wal/-shm; the
+// caller's post-reopen integrity re-check is the backstop if even that fails.
+std::optional<std::filesystem::path>
+quarantine_corrupt_db(const std::filesystem::path& path) {
+    const auto epoch = std::chrono::duration_cast<std::chrono::seconds>(
+                           std::chrono::system_clock::now().time_since_epoch())
+                           .count();
+    std::filesystem::path dest = path;
+    dest += std::format(".corrupt-{}", epoch);
+    std::error_code ec;
+    std::filesystem::rename(path, dest, ec);
+    if (ec)
+        return std::nullopt; // could not move the corrupt DB aside — fail closed
+    for (const char* suffix : {"-wal", "-shm"}) {
+        std::filesystem::path side = path;
+        side += suffix;
+        std::error_code ec2;
+        if (std::filesystem::exists(side, ec2)) {
+            std::filesystem::path side_dest = dest;
+            side_dest += suffix;
+            std::filesystem::rename(side, side_dest, ec2);
+            if (ec2) {
+                // Couldn't preserve the sidecar — remove it so the fresh DB
+                // can't replay a stale WAL belonging to the quarantined file.
+                std::error_code ec3;
+                std::filesystem::remove(side, ec3);
+            }
+        }
+    }
+    return dest;
+}
+
 } // namespace
 
 // ── Construction / destruction ───────────────────────────────────────────────
@@ -167,6 +229,52 @@ std::expected<TarDatabase, std::string> TarDatabase::open(const std::filesystem:
         if (raw_db)
             sqlite3_close(raw_db);
         return std::unexpected(std::format("failed to open tar.db: {}", err));
+    }
+
+    // #559 — corruption self-test BEFORE we trust the DB. A fresh/empty file
+    // passes trivially; an existing corrupt one is quarantined aside and a clean
+    // DB is re-opened in its place, so the agent never silently serves garbage
+    // config (which would re-enable operator-paused sources, compounding #539).
+    if (!integrity_ok(raw_db)) {
+        sqlite3_close(raw_db);
+        raw_db = nullptr;
+        auto quarantined = quarantine_corrupt_db(path);
+        if (!quarantined) {
+            // FAIL CLOSED (UP-1): the corrupt DB could not be moved aside, so we
+            // must NOT re-open and trust it — doing so would silently serve the
+            // "true" get_config default for every `<source>_enabled` key and
+            // re-enable sources an operator paused for forensic preservation,
+            // the exact failure #559 guards against. Refuse to open; the
+            // operator must clear the underlying fault (read-only mount, locked
+            // file, permissions) and restart.
+            return std::unexpected(std::format(
+                "tar.db failed integrity_check and could not be quarantined "
+                "(corrupt and unmovable): {}",
+                path.string()));
+        }
+        spdlog::error("TAR: tar.db failed PRAGMA integrity_check (tar.db.corruption_detected) — "
+                      "quarantined to {} and re-initialising a fresh database",
+                      quarantined->string());
+        rc = sqlite3_open_v2(path.string().c_str(), &raw_db,
+                             SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX,
+                             nullptr);
+        if (rc != SQLITE_OK) {
+            std::string err = raw_db ? sqlite3_errmsg(raw_db) : "unknown error";
+            if (raw_db)
+                sqlite3_close(raw_db);
+            return std::unexpected(
+                std::format("failed to re-open tar.db after quarantine: {}", err));
+        }
+        // Backstop (UP-2): the freshly-created DB must itself be clean — this
+        // also catches the case where a -wal/-shm sidecar belonging to the
+        // quarantined file could neither be moved nor removed and was adopted by
+        // the new file. If even the fresh DB is corrupt, fail closed.
+        if (!integrity_ok(raw_db)) {
+            sqlite3_close(raw_db);
+            return std::unexpected(std::format(
+                "tar.db re-initialised after quarantine still fails integrity_check: {}",
+                path.string()));
+        }
     }
 
     // WAL mode for concurrent read performance -- required for correctness

--- a/agents/plugins/tar/src/tar_plugin.cpp
+++ b/agents/plugins/tar/src/tar_plugin.cpp
@@ -880,7 +880,14 @@ private:
         // from the per-source `*_live` table; an empty table reports 0 / 0.
         for (const auto& src : yuzu::tar::capture_sources()) {
             std::string enabled_key = std::format("{}_enabled", src.name);
-            auto enabled_val = db_->get_config(enabled_key, "true");
+            auto stored = db_->get_config(enabled_key, "true");
+            // #560 — emit a strict tri-state (true/false/errored). do_configure
+            // only ever persists "true"/"false"; any other stored value was
+            // written outside the plugin (corruption, disk tampering, a
+            // downgrade/upgrade) and is surfaced as the explicit "errored"
+            // sentinel so the dashboard renders a value-error badge instead of
+            // silently omitting the source. Never coerced/guessed.
+            auto enabled_val = yuzu::tar::canonical_source_enabled(stored);
             ctx.write_output(std::format("config|{}|{}", enabled_key, enabled_val));
 
             std::string paused_at_key = std::format("{}_paused_at", src.name);
@@ -1365,7 +1372,26 @@ private:
                 ctx.write_output(std::format("error|{} must be 'true' or 'false'", key));
                 return 1;
             }
-            yuzu::tar::apply_source_enabled_transition(*db_, src.name, v, now_epoch_seconds());
+            // #538 — serialise the enable/disable transition against in-flight
+            // collection by holding collect_mu_ (which collect_fast/slow hold for
+            // their whole enumerate→diff→insert→set_state sequence). Without it a
+            // collect cycle that read source_enabled()==true just before the
+            // disable write would still commit one post-disable snapshot. On
+            // DISABLE, clear the source's diff-state under the same lock so a
+            // later re-enable diffs against a clean baseline (emitting current
+            // processes as "started") instead of a frozen pre-disable snapshot,
+            // which would fabricate "stopped" events for everything that exited
+            // during the paused window (the ghost-death bug). Idempotent and
+            // crash-safe: the state row is simply emptied.
+            {
+                std::lock_guard<std::mutex> lk(collect_mu_);
+                yuzu::tar::apply_source_enabled_transition(*db_, src.name, v,
+                                                           now_epoch_seconds());
+                if (v == "false") {
+                    if (auto sk = yuzu::tar::diff_state_key_for_source(src.name); !sk.empty())
+                        db_->set_state(std::string{sk}, "");
+                }
+            }
             ctx.write_output(std::format("config|{}|{}", key, v));
             // Echo the resulting paused_at so the operator/dashboard sees the
             // transition timestamp without an extra status round-trip. We

--- a/docs/tar-implementer.md
+++ b/docs/tar-implementer.md
@@ -130,6 +130,7 @@ function, never in `applies_*` collectors.
 | **Uninstall** (`yuzu-agent --remove-service`, MSI uninstall) | tar.db is **left in place** by design. The data dir is operator-managed; uninstall removes the binary and service registration only. To wipe TAR data, delete `<data_dir>/tar.db` explicitly. |
 | **Reinstall over an existing data dir** | The new binary opens the existing tar.db, runs migration if the schema version differs, and resumes collection. State in `tar_state` may be stale (see §5). |
 | **`data_dir` change** (config update) | The new directory has no tar.db — the next collect_fast creates it from scratch. The old tar.db at the previous path is orphaned but not deleted. Operator concern, not TAR's. |
+| **Corruption detected at open** (#559) | `TarDatabase::open` runs `PRAGMA integrity_check`; on failure the corrupt file and its `-wal`/`-shm` sidecars are renamed to `tar.db.corrupt-<epoch>` in the same directory and a fresh database is initialised (a sidecar that can't be moved is removed so the new DB can't replay it). All `tar_state` (collector snapshots, `<source>_enabled` flags) resets to defaults; collection resumes against the empty DB. The agent logs `tar.db.corruption_detected`; the sidecar is **not** auto-deleted (operator recovers it). If the corrupt file can't be moved aside (read-only/locked/perms), open **fails closed** — TAR refuses to load rather than trust the corrupt DB. |
 
 The "leave data on uninstall" rule is identical to other Yuzu agent
 state stores. If a customer asks for "delete tar data on uninstall",

--- a/docs/user-manual/tar.md
+++ b/docs/user-manual/tar.md
@@ -214,7 +214,17 @@ config|user_oldest_ts|1710900100
 config|network_capture_method|polling
 ```
 
-The four `<source>_*` blocks are emitted per capture source. `<source>_paused_at` is `0` when the source has never been disabled and the wall-clock UTC seconds when it was last transitioned `enabled → disabled`. The reverse transition resets it to `0`. `<source>_live_rows` and `<source>_oldest_ts` are the count and minimum timestamp of the per-source `*_live` table at the moment of the status call. Agents older than v0.12.0 do not emit the per-source `paused_at` / `live_rows` / `oldest_ts` lines; the dashboard renders `—` in their absence.
+The four `<source>_*` blocks are emitted per capture source. `<source>_enabled` is one of three values: `true` (collector active), `false` (disabled via `configure`), or `errored`. `errored` means the stored value is not a recognised boolean — `configure` only ever writes `true`/`false`, so an `errored` value indicates the agent's `tar.db` was tampered with or was corrupt and re-initialised (see "Corrupt-database quarantine" below). Re-issue an explicit `configure` for the affected source on that device to clear it. `<source>_paused_at` is `0` when the source has never been disabled and the wall-clock UTC seconds when it was last transitioned `enabled → disabled`. The reverse transition resets it to `0`. `<source>_live_rows` and `<source>_oldest_ts` are the count and minimum timestamp of the per-source `*_live` table at the moment of the status call. Agents older than v0.12.0 do not emit the per-source `paused_at` / `live_rows` / `oldest_ts` lines; the dashboard renders `—` in their absence.
+
+### Corrupt-database quarantine
+
+When an agent's `tar.db` fails its `PRAGMA integrity_check` at startup, the agent quarantines the corrupt file rather than trusting it: the database and its `-wal`/`-shm` sidecars are renamed aside to `tar.db.corrupt-<epoch>` (etc.) in the same directory, a fresh empty database is initialised in its place, and the agent logs `tar.db.corruption_detected`. Consequences an operator should know:
+
+- **All TAR history on that device is reset** — the new database is empty; prior events live only in the `.corrupt-<epoch>` sidecar.
+- **Per-source enable/disable state is reset to defaults** — a source previously paused for forensic preservation is collecting again. After the agent recovers, re-issue any required `configure` toggles, and `status` may briefly show `errored` for a source whose value could not be read.
+- **The quarantined file is not auto-deleted.** Recover data from `tar.db.corrupt-<epoch>` with any SQLite tool before the new database's retention overwrites the device's storage budget; remove the sidecar manually once recovered.
+
+If `tar.db` is corrupt **and** cannot be moved aside (read-only mount, locked file, permissions), the agent fails closed — it refuses to load TAR rather than silently trusting the corrupt database — and logs the reason. Clear the underlying fault and restart the agent.
 
 ## TAR dashboard page
 

--- a/tests/unit/test_tar_aggregator.cpp
+++ b/tests/unit/test_tar_aggregator.cpp
@@ -248,3 +248,56 @@ TEST_CASE("TAR retention: disabling one source does not pause others",
     CHECK(tcp_remaining > 0);                       // enabled, partially aged
     CHECK(tcp_remaining < 48);
 }
+
+// ── #538/#560: source-lifecycle helpers ───────────────────────────────────
+
+TEST_CASE("TAR diff_state_key_for_source maps tcp→network and scalar sources→\"\"",
+          "[tar][source-lifecycle]") {
+    // The load-bearing subtlety: the `tcp` source persists its diff snapshot
+    // under the "network" collector key, NOT "tcp" — so disabling tcp must clear
+    // "network" state, not a non-existent "tcp" state (#538).
+    CHECK(diff_state_key_for_source("process") == "process");
+    CHECK(diff_state_key_for_source("tcp") == "network");
+    CHECK(diff_state_key_for_source("service") == "service");
+    CHECK(diff_state_key_for_source("user") == "user");
+    // Scalar samplers keep no snapshot diff-state → no key to clear.
+    CHECK(diff_state_key_for_source("perf").empty());
+    CHECK(diff_state_key_for_source("procperf").empty());
+    CHECK(diff_state_key_for_source("netqual").empty());
+    CHECK(diff_state_key_for_source("bogus").empty());
+}
+
+TEST_CASE("TAR canonical_source_enabled is a strict tri-state (#560)",
+          "[tar][source-lifecycle]") {
+    CHECK(canonical_source_enabled("true") == "true");
+    CHECK(canonical_source_enabled("false") == "false");
+    // Anything the plugin never writes is flagged, never coerced/guessed.
+    CHECK(canonical_source_enabled("FALSE") == "errored");
+    CHECK(canonical_source_enabled("0") == "errored");
+    CHECK(canonical_source_enabled(" false ") == "errored");
+    CHECK(canonical_source_enabled("yes") == "errored");
+    CHECK(canonical_source_enabled("") == "errored");
+}
+
+TEST_CASE("TAR disable clears the source diff-state for a clean re-enable baseline (#538)",
+          "[tar][source-lifecycle]") {
+    // Models do_configure's disable path: seed a source's diff snapshot, then
+    // apply the disable transition + clear the mapped state key. A subsequent
+    // re-enable must diff against an empty baseline (no ghost "stopped" events).
+    yuzu::test::TempDbFile tmp{std::string_view{"tar-538-clear-"}};
+    auto opened = TarDatabase::open(tmp.path);
+    REQUIRE(opened.has_value());
+    TarDatabase db = std::move(*opened);
+    REQUIRE(db.create_warehouse_tables());
+
+    db.set_state("network", R"([{"proto":"tcp"}])"); // tcp source persists as "network"
+    REQUIRE(!db.get_state("network").empty());
+
+    apply_source_enabled_transition(db, "tcp", "false", 1'735'689'600);
+    auto key = diff_state_key_for_source("tcp");
+    REQUIRE(key == "network");
+    db.set_state(std::string{key}, ""); // the clear do_configure performs under collect_mu_
+
+    CHECK(db.get_state("network").empty());            // clean baseline for re-enable
+    CHECK(db.get_config("tcp_enabled", "true") == "false");
+}

--- a/tests/unit/test_tar_store.cpp
+++ b/tests/unit/test_tar_store.cpp
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <filesystem>
+#include <fstream>
 #include <string>
 #include <vector>
 
@@ -817,6 +818,86 @@ TEST_CASE("TarDatabase: missing warehouse tables are re-created on reopen (upgra
         REQUIRE(db->insert_proc_perf_samples({r}));
     }
 
+    std::error_code ec;
+    fs::remove(tmp, ec);
+    fs::remove(fs::path{tmp.string() + "-wal"}, ec);
+    fs::remove(fs::path{tmp.string() + "-shm"}, ec);
+}
+
+// ── #559: corrupt-DB quarantine on open ────────────────────────────────────
+
+TEST_CASE("TarDatabase: a corrupt tar.db is quarantined and re-initialised fresh (#559)",
+          "[tar][store][lifecycle][corruption]") {
+    auto tmp = yuzu::test::unique_temp_path("tar_corrupt_");
+
+    // 1. Create a real DB and persist a deliberately-paused source. This is the
+    //    forensic-preservation state a corrupt read must NOT silently undo.
+    {
+        auto opened = TarDatabase::open(tmp);
+        REQUIRE(opened.has_value());
+        TarDatabase db = std::move(*opened);
+        REQUIRE(db.create_warehouse_tables());
+        db.set_config("process_enabled", "false");
+        CHECK(db.get_config("process_enabled", "true") == "false");
+    } // connection closed; WAL checkpointed into the main file on close
+
+    // 2. Corrupt it: drop any WAL/SHM sidecars and clobber the whole file with
+    //    non-SQLite bytes so PRAGMA integrity_check fails deterministically.
+    for (const char* suffix : {"-wal", "-shm"}) {
+        std::error_code ec;
+        fs::remove(fs::path{tmp.string() + suffix}, ec);
+    }
+    {
+        std::ofstream f(tmp, std::ios::binary | std::ios::trunc);
+        REQUIRE(f.is_open());
+        f << "this is not a valid sqlite database -- corrupt tar.db for #559";
+    }
+
+    // 3. Re-open: must succeed with a FRESH database (not refuse, not trust the
+    //    garbage), and quarantine the corrupt file aside for forensic review.
+    auto reopened = TarDatabase::open(tmp);
+    REQUIRE(reopened.has_value());
+    TarDatabase db2 = std::move(*reopened);
+    REQUIRE(db2.create_warehouse_tables());
+
+    // Fresh DB → the paused config is gone; the default "true" comes from a
+    // CLEAN database, not a silent read-failure default over corrupt bytes.
+    CHECK(db2.get_config("process_enabled", "true") == "true");
+
+    // A timestamped quarantine sidecar exists next to the original path.
+    bool found_quarantine = false;
+    const std::string prefix = tmp.filename().string() + ".corrupt-";
+    for (const auto& entry : fs::directory_iterator(tmp.parent_path())) {
+        if (entry.path().filename().string().rfind(prefix, 0) == 0) {
+            found_quarantine = true;
+            std::error_code ec;
+            fs::remove(entry.path(), ec); // tidy up the quarantine artifact
+        }
+    }
+    CHECK(found_quarantine);
+}
+
+TEST_CASE("TarDatabase: a valid DB opens cleanly with no quarantine and preserves data (#559)",
+          "[tar][store][lifecycle][corruption]") {
+    // The happy path: integrity_ok returns true, so a previously-written DB is
+    // re-opened in place with its data intact and NO `.corrupt-*` sidecar minted
+    // (guards against an integrity_ok that wrongly fails every open).
+    auto tmp = yuzu::test::unique_temp_path("tar_valid_");
+    {
+        auto opened = TarDatabase::open(tmp);
+        REQUIRE(opened.has_value());
+        TarDatabase db = std::move(*opened);
+        db.set_config("process_enabled", "false");
+    }
+    auto reopened = TarDatabase::open(tmp);
+    REQUIRE(reopened.has_value());
+    TarDatabase db = std::move(*reopened);
+    // Data survived — NOT reset to the default.
+    CHECK(db.get_config("process_enabled", "true") == "false");
+    // No quarantine sidecar was created for a healthy DB.
+    const std::string prefix = tmp.filename().string() + ".corrupt-";
+    for (const auto& entry : fs::directory_iterator(tmp.parent_path()))
+        CHECK(entry.path().filename().string().rfind(prefix, 0) != 0);
     std::error_code ec;
     fs::remove(tmp, ec);
     fs::remove(fs::path{tmp.string() + "-wal"}, ec);


### PR DESCRIPTION
## Summary

**PR 3 of the TAR bug-clearance sweep.** Three agent-side defects in the TAR per-source enable/disable lifecycle.

- **#538 — configure/collect race.** `do_configure` wrote `<source>_enabled=false` *without* `collect_mu_` (the mutex `collect_fast`/`slow` hold across their whole enumerate→diff→insert→`set_state` sequence). A cycle that read `source_enabled()==true` just before the disable could still commit one post-disable snapshot; a later re-enable then diffed against that frozen snapshot and fabricated "stopped" events for every process that exited during the paused window. Fix: hold `collect_mu_` across the transition and clear the source's diff-state on disable, so re-enable diffs against a clean baseline (current processes emit "started", none spurious "stopped").
- **#559 — corrupt DB silently re-enabled paused sources.** A corrupt `tar.db` was opened and trusted; since `get_config` returns the caller default on a read failure, every `<source>_enabled` read as its `true` default, silently re-enabling sources an operator paused for forensic preservation (compounding the #539 retention guard). Fix: `TarDatabase::open` runs `PRAGMA integrity_check` and, on failure, quarantines the corrupt file (+ `-wal`/`-shm`) to `tar.db.corrupt-<epoch>` and re-initialises a fresh DB; **fails closed** (refuses to load, never trusts) if the corrupt file can't be moved aside; re-checks the fresh handle as a backstop against a stale-WAL adoption.
- **#560 (agent half) — `status` echoed the raw enable value.** Now emits a strict tri-state (`true`/`false`/`errored`) via `canonical_source_enabled`, so a tampered/corrupt value is flagged for the dashboard's value-error badge (server render is PR 5) instead of silently passed through.

**#539** (retention-while-disabled) was already fixed on `dev` with a regression test — verified, no code change; closing it.

## Testing

`diff_state_key_for_source` (incl. the load-bearing `tcp`→`network` mapping) and `canonical_source_enabled` live in `tar_aggregator.cpp` (test-linked) and are unit-tested, alongside a disable-clears-state test, a corrupt-DB-quarantine test, and a valid-DB-no-quarantine test. Full TAR suite green (3006 assertions, 145 cases); tar plugin + agent compile clean.

## Governance

Full `/governance` — **PASS, no CRITICAL/HIGH/BLOCKING.** Gate 2 security PASS (forensic-integrity preserved, no injection). cpp-safety/cpp-expert/cross-platform PASS (Windows rename-while-closed confirmed safe; lock-ordering clean). The one Gate 4 BLOCKING — UP-1, quarantine-rename-failure re-trusting the corrupt DB — was fixed in-PR (fail-closed). SHOULD follow-ups filed: corruption observability/audit, `integrity_check` boot cost, sidecar reaper, atomic-disable, chaos/TSan harness.

Closes #538
Closes #559
Closes #560