### PR TITLE
fix(agent): join Run() worker threads on every exit path (#1434, #1420)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -286,6 +286,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Agent no longer crashes or crash-loops on permanent registration rejection
+  or clean shutdown with the TAR plugin loaded (#1434, #1420).** Three
+  `this`-capturing worker threads spawned by `AgentImpl::Run()` — the TAR
+  snapshot pump, the per-connection heartbeat, and the OTA updater — were not
+  joined on the early-`return` exit paths, and the snapshot pump was joined only
+  *after* `plugins_.clear()` on the normal shutdown path. A permanent
+  registration rejection (exhausted or expired enrollment token) left the pump
+  thread running against freed `AgentImpl` state — a use-after-free / SIGSEGV
+  crash loop on the released agent (#1434); on a clean shutdown the pump could
+  dispatch `tar.fleet_snapshot` into a plugin that `plugins_.clear()` had already
+  torn down, aborting on a clean exit path (#1420). A single
+  `quiesce_run_workers()` chokepoint now joins all three threads on every exit
+  path (early returns, exceptions, and normal shutdown), ordered before plugin
+  teardown. `Updater::stop()` additionally cancels its in-flight OTA RPC so a
+  stalled download cannot hang the shutdown join.
 - **Windows server installer locks its log-directory ACL.** `yuzu-server.iss`
   set `Permissions: service-full` on `{app}\logs`, which is not a valid
   InnoSetup permission group — ISCC silently ignores it, leaving the directory

--- a/agents/core/include/yuzu/agent/updater.hpp
+++ b/agents/core/include/yuzu/agent/updater.hpp
@@ -51,6 +51,13 @@ private:
     std::string arch_;
     std::filesystem::path exe_path_;
     std::atomic<bool> stop_requested_{false};
+    // In-flight OTA RPC context (a grpc::ClientContext*, held as void* so this
+    // public header stays free of the proto/grpc include — same reason the stub
+    // is passed as void*). Published by check_and_apply() around the blocking
+    // CheckForUpdate / DownloadUpdate calls and TryCancel'd by stop(), so a
+    // shutdown during a stalled OTA RPC unblocks the call rather than hanging
+    // the update-thread join (#1434 UP-1). Mirrors AgentImpl::heartbeat_ctx_.
+    std::atomic<void*> active_rpc_ctx_{nullptr};
 
 #ifndef _WIN32
     /// POSIX-only binary replacement with rollback on failure.

--- a/agents/core/src/agent.cpp
+++ b/agents/core/src/agent.cpp
@@ -809,6 +809,18 @@ public:
 
         // Scope guard: shutdown plugins and destroy thread pool on any exit path
         ScopeExit cleanup{[this]() {
+            // #1420 / #1434 — quiesce and join the Run()-spawned worker threads
+            // (snapshot pump, heartbeat, OTA updater) FIRST, before any plugin
+            // teardown. The snapshot pump dispatches `tar.fleet_snapshot` into
+            // the TAR plugin through a borrowed descriptor, so it must not
+            // outlive the plugins; and leaving any of these `this`-capturing
+            // threads joinable on an early `return` out of Run() (the hard
+            // registration rejection and the PKI persist/rebuild bail-outs)
+            // aborts the process via std::terminate. This guard runs on EVERY
+            // Run() exit — early returns and exceptions included — so it is the
+            // universal backstop. The reconnect-loop final teardown repeats the
+            // pump join to order it ahead of plugins_.clear() on the normal path.
+            quiesce_run_workers();
             // Stop the trigger engine FIRST — before plugins are torn down —
             // so an in-flight interval/file/service trigger can't dispatch
             // into a plugin that's mid-shutdown. stop() joins the worker
@@ -1990,15 +2002,26 @@ public:
                 if (heartbeat_thread_.joinable()) {
                     heartbeat_thread_.join();
                 }
-                // PR 10: the snapshot pump is intentionally NOT joined
-                // here. It is a Run()-lifetime thread that survives
-                // reconnects, so the heartbeat thread of the next
-                // connection cycle finds a warm latest_snapshot_ and
-                // ships it immediately. The pump joins only at final
-                // shutdown, below — see the Run()-exit cleanup.
+                // PR 10: the snapshot pump is intentionally NOT joined on a
+                // transient (non-final) disconnect. It is a Run()-lifetime
+                // thread that survives reconnects, so the heartbeat thread of
+                // the next connection cycle finds a warm latest_snapshot_ and
+                // ships it immediately. The pump is joined only on FINAL
+                // shutdown — by quiesce_run_workers() in the stop_requested_
+                // branch just below (and by the Run()-exit ScopeExit backstop).
 
                 // Only shutdown plugins on final exit — keep them loaded for reconnect
                 if (stop_requested_.load(std::memory_order_acquire)) {
+                    // #1420 — the snapshot pump borrows a descriptor into
+                    // `plugins_`; join it (and the other Run() workers) BEFORE
+                    // shutting the plugins down and clearing the vector below,
+                    // otherwise an in-flight pump cycle dispatches into freed
+                    // plugin state (use-after-free / abort on a clean exit).
+                    // This call's SOLE purpose is that ordering relative to
+                    // plugins_.clear(); the Run()-exit ScopeExit is the backstop
+                    // for every early-return/exception exit, and re-invoking the
+                    // helper there is a joinable()-guarded no-op.
+                    quiesce_run_workers();
                     for (auto& handle : plugins_) {
                         if (handle.descriptor()->shutdown) {
                             auto it = per_plugin_ctx_.find(handle.descriptor()->name);
@@ -2027,14 +2050,13 @@ public:
             break; // stop_requested
         }          // end while (reconnect loop)
 
-        // PR 10: snapshot pump joined here, post reconnect loop. The
-        // pump observes `stop_requested_` (set in stop() above) and
-        // exits at the next 2 s slice boundary; joining at final
-        // shutdown means the thread is collected before Run() returns
-        // and the AgentImpl dtor sees a default-constructed thread.
-        if (snapshot_pump_thread_.joinable()) {
-            snapshot_pump_thread_.join();
-        }
+        // #1420 / #1434: the snapshot pump, heartbeat, and OTA-updater threads
+        // are quiesced and joined by quiesce_run_workers() — invoked from the
+        // final-shutdown teardown above (before plugins_.clear(), so a pump
+        // cycle can't dispatch into freed plugin state) and, as the universal
+        // backstop for every exit path including the early-return rejections,
+        // from the Run()-exit ScopeExit `cleanup`. No separate post-loop join
+        // is needed here.
     }
 
     void stop() noexcept override {
@@ -2083,6 +2105,54 @@ private:
         std::lock_guard lock(stream_write_mu_);
         if (guardian_sink_stream_)
             guardian_sink_stream_->Write(resp, grpc::WriteOptions());
+    }
+
+    // #1420 / #1434 — single quiesce-and-join chokepoint for the three
+    // `this`-capturing worker threads Run() spawns: the Run()-lifetime snapshot
+    // pump, the per-connection heartbeat, and the OTA-updater thread. Every one
+    // of them must be stopped and joined before the agent's plugins are torn
+    // down and before AgentImpl is destroyed:
+    //   * the snapshot pump dispatches `tar.fleet_snapshot` into the TAR plugin
+    //     through a borrowed descriptor — a cycle that runs after plugin
+    //     teardown is a use-after-free (#1420);
+    //   * any Run() exit that leaves one of these threads joinable aborts the
+    //     process via std::terminate when the std::thread is destroyed (#1434,
+    //     e.g. the hard registration-rejection `return`).
+    // Invoked from EVERY Run() exit path: the Run()-exit ScopeExit `cleanup`
+    // (covers the early returns and exceptions) and the reconnect-loop final
+    // teardown (orders the pump join ahead of plugins_.clear()). Idempotent —
+    // the joinable() guards make repeat calls and the not-yet-started register
+    // loop returns (where heartbeat/updater don't exist yet) no-ops.
+    //
+    // Unblock-before-join keeps the joins bounded: the pump observes the stop
+    // flag on its ≤2 s sleep slices (worst case it finishes one in-flight local
+    // `fleet_snapshot` enumerate — no blocking I/O, so the join is bounded by a
+    // single capture, not a network wait); the heartbeat may be parked in a
+    // Heartbeat RPC and the updater in an OTA RPC, so we TryCancel the heartbeat
+    // context and stop() the updater first — `Updater::stop()` now TryCancels
+    // its in-flight OTA RPC too (#1434 UP-1), so a stalled download can't hang
+    // the join. This is a SUPERSET of what stop() unblocks (stop() additionally
+    // cancels the Subscribe stream and drains guardian_/dex_observer_, which are
+    // member-owned and joined by their own dtors — deliberately NOT joined here).
+    //
+    // TERMINAL-ONLY: this sets stop_requested_, so it must be called only on a
+    // path that is actually shutting the agent down (the Run()-exit ScopeExit,
+    // or the reconnect-loop teardown already gated on stop_requested_). Never
+    // call it on a transient-reconnect path — doing so would euthanise a healthy
+    // agent and break the across-reconnect warm-snapshot continuity (PR 10).
+    void quiesce_run_workers() noexcept {
+        stop_requested_.store(true, std::memory_order_release);
+        heartbeat_stop_.store(true, std::memory_order_release);
+        if (updater_)
+            updater_->stop();
+        if (auto* hctx = heartbeat_ctx_.load(std::memory_order_acquire))
+            hctx->TryCancel();
+        if (snapshot_pump_thread_.joinable())
+            snapshot_pump_thread_.join();
+        if (heartbeat_thread_.joinable())
+            heartbeat_thread_.join();
+        if (update_thread_.joinable())
+            update_thread_.join();
     }
 
     Config cfg_;

--- a/agents/core/src/updater.cpp
+++ b/agents/core/src/updater.cpp
@@ -69,6 +69,15 @@ namespace pb = ::yuzu::agent::v1;
 // AgentImpl::heartbeat_ctx_ pattern; gRPC TryCancel on a completed RPC is a
 // documented no-op.
 struct ActiveRpcCtxGuard {
+    // The slot type-erases a grpc::ClientContext* as void* so the public
+    // updater.hpp need not pull in grpc headers. stop() static_casts it back to
+    // the identical static type, which the standard guarantees round-trips for
+    // any object pointer regardless of width — the real precondition (store and
+    // load the same ClientContext* type, no base-class slicing) holds by
+    // construction. The width assert is belt-and-suspenders: it documents intent
+    // and trips only on a hypothetical non-flat-pointer ABI.
+    static_assert(sizeof(void*) == sizeof(grpc::ClientContext*),
+                  "void* slot cannot round-trip a grpc::ClientContext*");
     std::atomic<void*>& slot;
     ActiveRpcCtxGuard(std::atomic<void*>& s, grpc::ClientContext& ctx) : slot(s) {
         slot.store(&ctx, std::memory_order_release);

--- a/agents/core/src/updater.cpp
+++ b/agents/core/src/updater.cpp
@@ -59,6 +59,25 @@ namespace {
 
 namespace pb = ::yuzu::agent::v1;
 
+// RAII publisher for the in-flight OTA RPC context. Stores `&ctx` into the
+// Updater's `active_rpc_ctx_` slot for the lifetime of a blocking RPC (the
+// unary CheckForUpdate or the streaming DownloadUpdate read loop) and clears
+// the slot before `ctx` is destroyed (declared after `ctx`, so destroyed
+// first). stop() reads the slot and TryCancel()s the context, unblocking a
+// stalled OTA call so a shutdown can't hang the update-thread join (#1434
+// UP-1). The residual store/cancel/destroy window matches the long-standing
+// AgentImpl::heartbeat_ctx_ pattern; gRPC TryCancel on a completed RPC is a
+// documented no-op.
+struct ActiveRpcCtxGuard {
+    std::atomic<void*>& slot;
+    ActiveRpcCtxGuard(std::atomic<void*>& s, grpc::ClientContext& ctx) : slot(s) {
+        slot.store(&ctx, std::memory_order_release);
+    }
+    ~ActiveRpcCtxGuard() { slot.store(nullptr, std::memory_order_release); }
+    ActiveRpcCtxGuard(const ActiveRpcCtxGuard&) = delete;
+    ActiveRpcCtxGuard& operator=(const ActiveRpcCtxGuard&) = delete;
+};
+
 // ── SHA-256 incremental hasher ─────────────────────────────────────────────
 
 class Sha256Hasher {
@@ -278,6 +297,13 @@ Updater::Updater(UpdateConfig config, std::string agent_id, std::string current_
 
 void Updater::stop() noexcept {
     stop_requested_.store(true, std::memory_order_release);
+    // Unblock an in-flight OTA RPC. The stop flag alone is only observed
+    // BETWEEN download chunks (and not at all during a stalled CheckForUpdate),
+    // so a sick-but-not-dead server that withholds a chunk would otherwise park
+    // reader->Read() / CheckForUpdate() indefinitely and hang the update-thread
+    // join during shutdown (#1434 UP-1). TryCancel aborts the blocking call.
+    if (void* p = active_rpc_ctx_.load(std::memory_order_acquire))
+        static_cast<grpc::ClientContext*>(p)->TryCancel();
 }
 
 std::expected<bool, UpdateError> Updater::check_and_apply(void* raw_stub) {
@@ -307,7 +333,13 @@ std::expected<bool, UpdateError> Updater::check_and_apply(void* raw_stub) {
 
     grpc::ClientContext check_ctx;
     pb::CheckForUpdateResponse check_resp;
-    grpc::Status check_status = stub->CheckForUpdate(&check_ctx, check_req, &check_resp);
+    grpc::Status check_status;
+    {
+        // Publish check_ctx for the blocking unary call; cleared on block exit
+        // (before check_ctx is destroyed) so stop() never cancels a stale ctx.
+        ActiveRpcCtxGuard ctx_guard{active_rpc_ctx_, check_ctx};
+        check_status = stub->CheckForUpdate(&check_ctx, check_req, &check_resp);
+    }
 
     if (!check_status.ok()) {
         return std::unexpected(UpdateError{
@@ -480,6 +512,11 @@ std::expected<bool, UpdateError> Updater::check_and_apply(void* raw_stub) {
 
     grpc::ClientContext dl_ctx;
     auto reader = stub->DownloadUpdate(&dl_ctx, dl_req);
+    // Publish dl_ctx for the whole streaming read below. Declared after dl_ctx
+    // so it is destroyed first on ANY exit from here — including every
+    // cleanup_and_fail early return inside the loop — clearing the slot before
+    // dl_ctx dies. stop() TryCancels this to abort a stalled reader->Read().
+    ActiveRpcCtxGuard dl_guard{active_rpc_ctx_, dl_ctx};
 
     // Cleanup helper: on Windows the path-based fs::remove fails with
     // ERROR_SHARING_VIOLATION while h_guard holds the file with dwShareMode=0,


### PR DESCRIPTION
## Summary

Fixes two agent shutdown crashes caused by `this`-capturing worker threads spawned in `AgentImpl::Run()` not being joined on every exit path. **PR 1 of the TAR bug-clearance sweep.**

- **#1434 (crash-loop, released agent):** a *permanent* registration rejection (exhausted/expired enrollment token) hits an early `return` in `Run()` that skipped the `snapshot_pump_thread_` join. The leaked, still-running thread dereferences freed `AgentImpl` state → UAF/SIGSEGV, or is destroyed while joinable → `std::terminate`. On a dense fleet a re-registration storm turns this into a crash loop. Discovered on a 25-containers/host test fleet.
- **#1420 (abort on clean shutdown):** on the normal path the pump was joined only *after* `plugins_.clear()`, so it could dispatch `tar.fleet_snapshot` into an already-torn-down TAR plugin → abort on a clean exit.

## Fix

A single `quiesce_run_workers()` chokepoint: set the stop flags, unblock any RPC-parked worker (TryCancel the heartbeat context, `stop()` the updater), then join all three Run() worker threads (snapshot pump, heartbeat, OTA updater) under `joinable()` guards. Invoked from:
1. the reconnect-loop final teardown — **before** plugin shutdown/`plugins_.clear()` (fixes #1420 ordering), and
2. the Run()-exit `ScopeExit cleanup` — the universal backstop for every early return and exception (fixes #1434).

`std::jthread` was considered and rejected: its dtor-autojoin fires at `AgentImpl` destruction, *after* the ScopeExit has already torn down plugins — it cannot provide the join-before-teardown ordering #1420 needs.

**Hardening (from governance Gate 4 UP-1):** the OTA `CheckForUpdate`/`DownloadUpdate` ran on local `grpc::ClientContext`s with no deadline, and `Updater::stop()` only set a flag checked *between* chunks — so a sick-but-not-dead server stalling a chunk could hang the new update-thread join. `Updater` now publishes its in-flight RPC context (`active_rpc_ctx_`, held as `void*` to keep grpc out of the public header) and `Updater::stop()` `TryCancel`s it, mirroring the existing `heartbeat_ctx_` pattern. This also bounds the pre-existing in-loop update-thread join.

## Testing

- `meson compile -C build-macos` agent target — clean.
- Suites green locally: **agent** (95s), **server** (40s), **tar** (1.4s).
- No unit test added: `Run()` requires a live gRPC server + loaded plugins and has no test seam (tracked as a follow-up). The lifetime fix is exercised by the nightly ThreadSanitizer leg and the issue's integration repro (agent against a server with an exhausted token under `MALLOC_CHECK_=3`).

## Governance

Full `/governance` pipeline run — **PASS, no CRITICAL/HIGH/BLOCKING**. Gate 2 security + Gate 7 re-review PASS (the OTA-cancel TOCTOU is *narrower* than the accepted `heartbeat_ctx_` pattern); cpp-safety/cpp-expert/cross-platform PASS; Gate 6 compliance/sre/enterprise PASS. SHOULD findings filed as follow-up issues (registration-rejected metric, `fleet_snapshot` join deadline, systemd `TimeoutStopSec`, chaos verification CH-1/CH-2/CH-3, Run() test seam, operator troubleshooting doc).

Closes #1434
Closes #1420

🤖 Generated with [Claude Code](https://claude.com/claude-code)


🤖 Recreated after the `Doomgoose/Yuzu` fork was accidentally deleted in the GitHub UI (original PR #1489 auto-closed; branch + commits intact locally).
