### PR TITLE
fix(agent): join snapshot_pump_thread_ on all Run() exit paths

### DIFF
--- a/agents/core/src/agent.cpp
+++ b/agents/core/src/agent.cpp
@@ -1076,6 +1076,17 @@ public:
             }
         }
 
+        // Guard: join snapshot_pump_thread_ on every exit from Run(), including
+        // early returns (hard-rejection at 1218, PKI failures at 1263/1278) that
+        // would otherwise leave a joinable std::thread capturing `this` — causing
+        // UAF→SIGSEGV or std::terminate when AgentImpl is destroyed. Fires before
+        // the plugin cleanup guard (LIFO), so the pump stops before TAR is torn down.
+        ScopeExit pump_cleanup{[this]() {
+            stop_requested_.store(true, std::memory_order_release);
+            if (snapshot_pump_thread_.joinable())
+                snapshot_pump_thread_.join();
+        }};
+
         // 3. Register with server — with reconnect loop
         int reconnect_count = 0;
         constexpr int kMaxReconnectDelaySecs = 300; // 5 minutes max backoff


### PR DESCRIPTION
Fixes #1434.

## Problem

`snapshot_pump_thread_` is started before the registration loop and only joined at the bottom of `Run()`. Early-exit paths skip that join:

- **Line 1229** — hard rejection (`return; // Hard rejection — no retry`)
- **Line 1274** — PKI: channel rebuild failure after cert issuance
- **Line 1289** — PKI: cert persist failure (disk full / permissions)

When `AgentImpl` is destroyed with a joinable `std::thread` still alive and capturing `this`, the result is either UAF → SIGSEGV (heap corruption in malloc internals) or `std::terminate` (joinable thread destroyed). In fleet testing with exhausted enrollment tokens this becomes a deterministic crash loop — every rejected agent restarts, exhausts the token again, and crashes again.

## Fix

Add a `ScopeExit pump_cleanup` guard immediately after the pump thread is started, in the same scope as the existing plugin `cleanup` guard. On scope exit it sets `stop_requested_` and joins the thread if joinable, covering all three early-exit paths.

**LIFO ordering** means `pump_cleanup` fires before `cleanup` (the plugin shutdown guard), so the pump stops before the TAR plugin is torn down — correct because the pump calls `dispatcher.run(tar_descriptor, ...)`.

**Normal shutdown path** is unaffected: `stop_requested_` is already true and the thread already joined at the bottom of `Run()`, so `joinable()` returns false and the guard is a no-op.

## Test

Reproduce by pointing an agent at a server with an invalid/exhausted enrollment token. Before this fix: `std::terminate` (joinable thread destroyed) or SIGSEGV at shutdown. After: clean `[info] Yuzu agent stopped` with no abort.

`MALLOC_CHECK_=3` forces deterministic abort on the UAF path in glibc — useful for local verification.

---

_Re-issued from within `Tr3kkR/Yuzu` (collaborators shouldn't open PRs from a personal fork). Supersedes #1435 — identical single-commit change (`agent.cpp`, +11), now on an intra-repo branch against `dev`._
