### PR TITLE
docs(vuln-graph): fence auth/CA stores, honest 0005 substrate dep, G7 graph RBAC

### DIFF
--- a/docs/adr/0004-server-storage-substrate.md
+++ b/docs/adr/0004-server-storage-substrate.md
@@ -51,17 +51,18 @@ paths don't need a graph-native store).
   standalone server database, @lesault indifferent, Nathan decided; implementation is now
   unblocked. The agent-side SQLite edge warehouse (ADR-0003) is unchanged.
 - **Secrets caveat (load-bearing):** "off-box durable state" ≠ "secrets in a Postgres
-  column." Secrets require envelope encryption / KMS / `pgcrypto`, a separate decision and a
-  `security-guardian` review. Do not let this ADR quietly become "we put secrets in a table."
-- **Auth/CA stores stay SQLite (scope fence, load-bearing):** the identity and credential
-  stores — `auth.db` (AuthDB invariants: file-mode, migration, lifetime, seed-vs-live) and
-  `ca.db` (`CaStore` + the PKI `key_ref` / `KeyProvider` seam, where the CA root private key
-  is *never* in the DB) — are **explicitly out of scope** for this substrate. This ADR covers
-  the *derived scored graph + offline-state*, not identity or credentials. Any move of
-  `auth.db`/`ca.db` to Postgres is a **separate decision** requiring `authdb` +
-  `security-guardian` + PKI review. The "secrets want an off-box home" driver in the Context
-  motivates Postgres for the graph; it must **not** be read as license to migrate the auth/CA
-  stores by the side door.
+  column." Secrets require app-side envelope encryption behind the `KeyProvider` seam — see
+  ADR-0010 for the full model. Do not let this ADR quietly become "we put secrets in a table."
+- **Auth/CA stores — out of scope for this substrate decision (scope fence, load-bearing):**
+  the identity and credential stores — `auth.db` (AuthDB invariants: file-mode, migration,
+  lifetime, seed-vs-live) and `ca.db` (`CaStore` + the PKI `key_ref` / `KeyProvider` seam,
+  where the CA root private key is *never* in the DB) — are **out of scope for this ADR**.
+  This ADR covers the *derived scored graph + offline-state*, not identity or credentials.
+  The "secrets want an off-box home" driver in the Context motivates Postgres for the graph;
+  it must **not** be read as license to migrate the auth/CA stores as a side effect of
+  graph-substrate work. Any later migration of `auth.db`/`ca.db` follows ADR-0006/0007/0008
+  + a per-store decision requiring `authdb` + `security-guardian` + PKI review + ADR-0010
+  secret handling — it is a separate decision, not a consequence of this one.
 - Federated-pull + offline-answering tension is resolved here: the server persists
   **last-known summaries** so offline hosts still appear (stale-flagged); fresh detail is
   online-only.

--- a/docs/adr/0004-server-storage-substrate.md
+++ b/docs/adr/0004-server-storage-substrate.md
@@ -53,6 +53,15 @@ paths don't need a graph-native store).
 - **Secrets caveat (load-bearing):** "off-box durable state" ≠ "secrets in a Postgres
   column." Secrets require envelope encryption / KMS / `pgcrypto`, a separate decision and a
   `security-guardian` review. Do not let this ADR quietly become "we put secrets in a table."
+- **Auth/CA stores stay SQLite (scope fence, load-bearing):** the identity and credential
+  stores — `auth.db` (AuthDB invariants: file-mode, migration, lifetime, seed-vs-live) and
+  `ca.db` (`CaStore` + the PKI `key_ref` / `KeyProvider` seam, where the CA root private key
+  is *never* in the DB) — are **explicitly out of scope** for this substrate. This ADR covers
+  the *derived scored graph + offline-state*, not identity or credentials. Any move of
+  `auth.db`/`ca.db` to Postgres is a **separate decision** requiring `authdb` +
+  `security-guardian` + PKI review. The "secrets want an off-box home" driver in the Context
+  motivates Postgres for the graph; it must **not** be read as license to migrate the auth/CA
+  stores by the side door.
 - Federated-pull + offline-answering tension is resolved here: the server persists
   **last-known summaries** so offline hosts still appear (stale-flagged); fresh detail is
   online-only.

--- a/docs/adr/0005-attack-path-and-chokepoint-scoring.md
+++ b/docs/adr/0005-attack-path-and-chokepoint-scoring.md
@@ -2,6 +2,7 @@
 status: accepted
 date: 2026-06-08
 owner: "@lesault (Andy Younie)"
+depends-on: 0004 (storage substrate — still proposed; see Consequences)
 ---
 
 # 0005 — Attack-path & chokepoint scoring: bounded max-probability paths, ROI chokepoints
@@ -48,3 +49,10 @@ generic betweenness centrality is O(V·E) and answers the wrong question.
   propagation to the agents (true distributed Pregel). Documented; not v1.
 - Andy owns the model knobs (G4 probability function, depth bound, segmentation cost model,
   acceptance bar); Eng owns the algorithm choices, justified by tractability.
+- **Substrate dependency (status honesty):** the *algorithm* decisions here
+  (Dijkstra / Yen / cost-weighted min-cut / label-propagation) are `accepted` and
+  substrate-independent. But the scoring **join** (`edges ⨝ findings ⨝ value ⨝ guardian_state`)
+  and the in-memory adjacency it loads assume the **ADR-0004 storage substrate, which is still
+  `proposed`**. If 0004 is rejected or reshaped, only the load/join mechanics are revisited —
+  not the math. This ADR should not be read as having pre-approved server-side Postgres; that
+  buy-in lives in 0004.

--- a/docs/adr/0005-attack-path-and-chokepoint-scoring.md
+++ b/docs/adr/0005-attack-path-and-chokepoint-scoring.md
@@ -2,7 +2,7 @@
 status: accepted
 date: 2026-06-08
 owner: "@lesault (Andy Younie)"
-depends-on: 0004 (storage substrate — still proposed; see Consequences)
+depends-on: 0006/0007/0008 (server-side Postgres substrate chain — accepted 2026-06-09; see Consequences)
 ---
 
 # 0005 — Attack-path & chokepoint scoring: bounded max-probability paths, ROI chokepoints
@@ -52,7 +52,8 @@ generic betweenness centrality is O(V·E) and answers the wrong question.
 - **Substrate dependency (status honesty):** the *algorithm* decisions here
   (Dijkstra / Yen / cost-weighted min-cut / label-propagation) are `accepted` and
   substrate-independent. But the scoring **join** (`edges ⨝ findings ⨝ value ⨝ guardian_state`)
-  and the in-memory adjacency it loads assume the **ADR-0004 storage substrate, which is still
-  `proposed`**. If 0004 is rejected or reshaped, only the load/join mechanics are revisited —
-  not the math. This ADR should not be read as having pre-approved server-side Postgres; that
-  buy-in lives in 0004.
+  and the in-memory adjacency it loads assume the server-side Postgres substrate confirmed by
+  **ADR-0006/0007/0008** (accepted 2026-06-09). ADR-0004 introduced that substrate for the
+  vuln-graph; ADR-0006 widened it to all server stores. If the substrate architecture were
+  reshaped, only the load/join mechanics would be revisited — not the math. This ADR
+  documents the algorithm choices; the storage buy-in lives in the 0006/0007/0008 chain.

--- a/docs/vuln-scan-engine-design.md
+++ b/docs/vuln-scan-engine-design.md
@@ -246,7 +246,8 @@ graph/topology securable type**.
 - **Read** — the scored graph, attack paths, and chokepoint output get a **dedicated
   securable type**, gated *tighter* than findings. A path map is offensive intelligence; an
   operator who can read findings should not automatically read "here is the cheapest route to
-  the crown jewel."
+  the crown jewel." **Read access is audited** — every graph query carries a principal and
+  timestamp in the audit log (same envelope as findings access).
 - **Write** — authority to declare/edit **trust-zone CIDR-site tiers** and **crown-jewel
   values** is restricted to a privileged role and **audited**. Mis-declaring a tier or a
   jewel silently distorts *every* ranking (it moves entry points and value sinks), so these

--- a/docs/vuln-scan-engine-design.md
+++ b/docs/vuln-scan-engine-design.md
@@ -235,6 +235,26 @@ the **service**, rolled up to the host by **max**. Two uses of the same axis:
   jewel for landing on an unrelated service on the same box — strictly more honest, lower
   FP.
 
+### 3.6 Access control (graph + authoring surfaces) — G7
+
+The scored reachability graph is a **literal map of how to compromise the fleet** — strictly
+more sensitive than the findings it ranks — and the trust-zone (§3.4) and crown-jewel (§3.5)
+declarations are **new privileged authoring surfaces**. Both need RBAC before they ship, and
+neither exists today: RBAC is uniformly `(securable_type, operation)` and there is **no
+graph/topology securable type**.
+
+- **Read** — the scored graph, attack paths, and chokepoint output get a **dedicated
+  securable type**, gated *tighter* than findings. A path map is offensive intelligence; an
+  operator who can read findings should not automatically read "here is the cheapest route to
+  the crown jewel."
+- **Write** — authority to declare/edit **trust-zone CIDR-site tiers** and **crown-jewel
+  values** is restricted to a privileged role and **audited**. Mis-declaring a tier or a
+  jewel silently distorts *every* ranking (it moves entry points and value sinks), so these
+  are integrity-sensitive, not cosmetic, config.
+
+Owned by the **auth-and-authz workstream (G7)**, not the scoring model — tracked so it lands
+*with* the §3.4/§3.5 authoring surfaces rather than retrofitted after they ship.
+
 ---
 
 ## 4. Data sources & feasibility (audited 2026-06-08)
@@ -335,6 +355,7 @@ flag makes a node a **candidate**, not a finding.
 | **G4** | **Traversability probability function** (EPSS/CVSS-exploitability/KEV/auth → P) | **Andy** — heart of the model |
 | **G5** | **Depth bound, entry-point definition, segmentation cost model** | **Andy** |
 | **G6** | **Acceptance bar for rankings** (match expert intuition on a reference topology) | **Andy** |
+| **G7** | **Access control** — graph/chokepoint read securable + trust-zone/crown-jewel authoring authority & audit (§3.6) | **Auth-and-authz workstream** |
 
 ---
 


### PR DESCRIPTION
Documentation-only follow-up to the merged North Star vuln-graph design (#1298), from an **auth-and-authz review** of the five ADRs. No code, no behavior change — three clarifications that keep the auth/identity boundary and the ADR statuses honest.

## 1. ADR-0004 — auth/CA scope fence (new Consequences bullet)
0004 proposes server-side Postgres and cites "secrets want an off-box home" as a driver. Adds a load-bearing fence: **`auth.db` and `ca.db` are explicitly out of scope** for this substrate (AuthDB file-mode/migration/lifetime invariants; the PKI `key_ref`/`KeyProvider` seam where the CA root private key is never in the DB). Any move is a separate decision requiring `authdb` + `security-guardian` + PKI review — not a side-door consequence of the graph substrate.

## 2. ADR-0005 — status honesty (frontmatter + Consequences)
0005 was `accepted` while resting on `proposed` 0004. Adds `depends-on: 0004` and a note: the **algorithm** choices (Dijkstra / Yen / cost-weighted min-cut / label-propagation) are accepted and substrate-independent, but the scoring **join** (`edges ⨝ findings ⨝ value ⨝ guardian_state`) and the Postgres-loaded adjacency are contingent on 0004's buy-in. 0005 does not pre-approve server-side Postgres.

## 3. design doc — §3.6 Access control + G7 ownership row
The scored graph is a **literal map of how to compromise the fleet** — more read-sensitive than the findings it ranks — and the trust-zone (§3.4) / crown-jewel (§3.5) declarations are new privileged authoring surfaces. Neither has RBAC today (RBAC is uniformly `(securable_type, operation)`; there is no graph/topology securable). Adds §3.6 (dedicated read securable gated tighter than findings; audited write-authority on zone/jewel config) and a **G7** ownership row assigning it to the auth-and-authz workstream, so it lands *with* the authoring surfaces rather than retrofitted.

---
Identity edges (ADR-0002's "no identity graph") are deliberately **left untouched** — it's an intentional, clean BloodHound-differentiation boundary; revisiting it would be a new ADR, not a walk-back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_Re-issued from within `Tr3kkR/Yuzu` (collaborators shouldn't open PRs from a personal fork). Supersedes #1299 — identical changes (3 docs files), now on an intra-repo branch against `dev`._
