### PR TITLE
fix(server): honor RBAC-disabled posture in TAR fleet-scan visibility (#1453, #1454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,8 +294,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Device visibility now correctly returns the full enrolled set under
   RBAC-disabled, across the dashboard agent list, `/api/agents`, and the TAR
   fleet scan. When RBAC is **enabled**, the exact role-scoped behaviour is
-  preserved unchanged. The UAT rig additionally seeds an admin root-group role so
-  the environment is also correct if RBAC is later turned on.
+  preserved unchanged. A missing or corrupt RBAC store fails **closed** —
+  visibility stays role-scoped (a caller without a management-group role sees
+  nothing) rather than falling back to the full fleet, so an integrity failure
+  can never widen exposure; both the `/api/agents` list and the TAR fleet scan
+  share one `rbac_enforcement_in_effect` predicate and cannot disagree (#1498).
+  The UAT rig additionally seeds an admin root-group role so the environment is
+  also correct if RBAC is later turned on.
 - **Windows server installer locks its log-directory ACL.** `yuzu-server.iss`
   set `Permissions: service-full` on `{app}\logs`, which is not a valid
   InnoSetup permission group — ISCC silently ignores it, leaving the directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -286,6 +286,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **TAR fleet scan now shows all agents when RBAC is disabled (#1453, #1454).**
+  With RBAC enforcement globally off (the default posture), no per-user
+  management-group role assignments exist, so operators with full admin access
+  saw "no agents in scope" when running a TAR fleet scan — and had no in-product
+  way to recover (granting the first group role itself required holding one).
+  Device visibility now correctly returns the full enrolled set under
+  RBAC-disabled, across the dashboard agent list, `/api/agents`, and the TAR
+  fleet scan. When RBAC is **enabled**, the exact role-scoped behaviour is
+  preserved unchanged. The UAT rig additionally seeds an admin root-group role so
+  the environment is also correct if RBAC is later turned on.
 - **Windows server installer locks its log-directory ACL.** `yuzu-server.iss`
   set `Permissions: service-full` on `{app}\logs`, which is not a valid
   InnoSetup permission group — ISCC silently ignores it, leaving the directory

--- a/docs/user-manual/management-groups.md
+++ b/docs/user-manual/management-groups.md
@@ -49,6 +49,16 @@ When RBAC is enabled, the agent list shown in the dashboard and returned by the 
 
 For example, if `jane.ops` holds the Operator role on the "London Office" group, she sees only agents that are members of "London Office" or its child groups ("London Desktops", "London Servers").
 
+> **When RBAC is disabled (the default posture):** management-group role
+> assignments are **not** consulted. Every authenticated user sees the full
+> enrolled agent set, matching the legacy-admin "full access" behaviour. The
+> dashboard agent list, the `/api/agents` endpoint, and the TAR fleet scan all
+> draw from this path. If you later **enable** RBAC, visibility immediately
+> becomes role-scoped — ensure users have appropriate management-group role
+> assignments *before* enabling RBAC in production (see "Enabling RBAC" in
+> [`rbac.md`](rbac.md)), or operators without a role assignment will see no
+> agents.
+
 ## REST API
 
 All endpoints require authentication (session cookie or API token). Management group operations require appropriate RBAC permissions on the `ManagementGroup` securable type.

--- a/docs/user-manual/rbac.md
+++ b/docs/user-manual/rbac.md
@@ -13,6 +13,16 @@ Toggle RBAC via the Settings page or the server configuration file:
 enabled = true
 ```
 
+> **Before enabling RBAC in production:** ensure every operator who needs device
+> visibility has at least one management-group role assignment. With RBAC
+> **disabled**, all authenticated users see the full enrolled fleet. Turning RBAC
+> **on** immediately applies role-scoped visibility — a user without a
+> management-group role assignment will see **no agents** (including on the TAR
+> fleet scan), and the role-grant endpoints themselves require an existing group
+> role, which can be a chicken-and-egg lockout. The broadest grant is an
+> `ITServiceOwner` role on the root "All Devices" group; see
+> [`management-groups.md`](management-groups.md) for the delegation API.
+
 ## Concepts
 
 | Concept | Description |

--- a/docs/user-manual/rbac.md
+++ b/docs/user-manual/rbac.md
@@ -23,6 +23,15 @@ enabled = true
 > `ITServiceOwner` role on the root "All Devices" group; see
 > [`management-groups.md`](management-groups.md) for the delegation API.
 
+> **RBAC store integrity (fail-closed).** If the RBAC store cannot open or
+> migrate (e.g. a corrupt `rbac.db`), the server fails **closed**: device
+> visibility falls back to the role-scoped path for every caller, so agents stop
+> appearing in the dashboard list, `/api/agents`, and TAR fleet scans rather than
+> the whole fleet being exposed. A corrupt store therefore looks like "no agents
+> in scope," not a visibility leak — check the server startup log for `RbacStore`
+> errors and the `/health` store status, then restore or remove the file and
+> restart.
+
 ## Concepts
 
 | Concept | Description |

--- a/docs/user-manual/tar.md
+++ b/docs/user-manual/tar.md
@@ -237,7 +237,7 @@ The first frame surfaces every device × source pair where the collector has bee
 - Viewing the page and the retention-paused list requires `Infrastructure:Read`.
 - **Scan fleet** requires `Execution:Execute` (it dispatches a fleet-wide command).
 - **Re-enable** requires `Execution:Execute` (it dispatches a configure command to a single device).
-- Both Scan dispatch and the rendered list are scoped to your management-group visibility — agents outside your scope are neither queried nor rendered, and the Re-enable endpoint rejects out-of-scope `device_id` values with the same 404 response as a not-connected agent (no enumeration oracle).
+- Both Scan dispatch and the rendered list are scoped to your management-group visibility — agents outside your scope are neither queried nor rendered, and the Re-enable endpoint rejects out-of-scope `device_id` values with the same 404 response as a not-connected agent (no enumeration oracle). When RBAC is **disabled** (the default), "your scope" is the full enrolled fleet; when RBAC is **enabled**, scope is determined by your management-group role assignments.
 
 **State persistence:** Scan results are held in the server's memory keyed by your username. Restarting the server clears the last-scan reference; click **Scan fleet** again after a restart. Persistence across restarts and multi-server coordination are planned for Phase 15.G operational hardening.
 

--- a/scripts/start-UAT.sh
+++ b/scripts/start-UAT.sh
@@ -545,6 +545,29 @@ start_all() {
     info "Dashboard http://localhost:8080"
     info "Direct agent gRPC :50054  |  Gateway upstream :50055  |  Mgmt :50052"
 
+    # #1454 — seed a management-group role binding the admin to the root "All
+    # Devices" group. With #1453 the default RBAC-disabled rig already shows the
+    # full fleet to the admin (TAR fleet scan, /api/me), so this is NOT required
+    # out of the box; it is here so the rig is ALSO correct if an operator later
+    # ENABLES RBAC — without it the role-scoped visibility join would return
+    # "no agents in scope" under enforcement. The root group + the
+    # management_group_roles table are created during server init, which finishes
+    # before :8080 binds, so the DB is ready now. With no --data-dir, the
+    # server's db_dir() resolves to the --config parent (= $UAT_DIR).
+    local mgmt_db="$UAT_DIR/management-groups.db"
+    if command -v sqlite3 >/dev/null 2>&1 && [ -f "$mgmt_db" ]; then
+        if sqlite3 "$mgmt_db" \
+            "INSERT OR IGNORE INTO management_group_roles
+                 (group_id, principal_type, principal_id, role_name)
+             VALUES ('000000000000', 'user', '${ADMIN_USER}', 'ITServiceOwner');" 2>/dev/null; then
+            ok "Seeded admin → root-group ITServiceOwner role (#1454; for RBAC-enabled mode)"
+        else
+            warn "Could not seed admin management-group role (#1454) — TAR scan still works with RBAC disabled (#1453)"
+        fi
+    else
+        warn "sqlite3 not found or $mgmt_db missing — skipping admin role seed (#1454)"
+    fi
+
     # ── 3. Gateway ──────────────────────────────────────────────────────
     echo ""
     echo "[3/4] Starting Erlang gateway..."

--- a/server/core/src/management_group_store.cpp
+++ b/server/core/src/management_group_store.cpp
@@ -629,6 +629,14 @@ ManagementGroupStore::get_visible_agents(const std::string& username) const {
     std::vector<std::string> result;
     if (!db_)
         return result;
+    // #1453 — when RBAC enforcement is globally OFF, no per-user
+    // `management_group_roles` rows exist, so the role-scoped join below returns
+    // nothing and hides every agent from the legacy-admin superuser. Fall back
+    // to the full enrolled set in that case ONLY. When the probe is unset, or
+    // reports RBAC enabled, the role-scoped semantics below are preserved
+    // exactly — the fallback can never widen visibility while RBAC is on.
+    if (rbac_enabled_probe_ && !rbac_enabled_probe_())
+        return all_member_agents();
     // Find all groups where the user has any role assignment, then return their members
     sqlite3_stmt* s = nullptr;
     if (sqlite3_prepare_v2(db_,
@@ -638,6 +646,26 @@ ManagementGroupStore::get_visible_agents(const std::string& username) const {
                            -1, &s, nullptr) != SQLITE_OK)
         return result;
     sqlite3_bind_text(s, 1, username.c_str(), -1, SQLITE_TRANSIENT);
+    while (sqlite3_step(s) == SQLITE_ROW)
+        result.emplace_back(safe(reinterpret_cast<const char*>(sqlite3_column_text(s, 0))));
+    sqlite3_finalize(s);
+    return result;
+}
+
+void ManagementGroupStore::set_rbac_enabled_probe(std::function<bool()> probe) {
+    rbac_enabled_probe_ = std::move(probe);
+}
+
+std::vector<std::string> ManagementGroupStore::all_member_agents() const {
+    std::vector<std::string> result;
+    if (!db_)
+        return result;
+    sqlite3_stmt* s = nullptr;
+    if (sqlite3_prepare_v2(db_,
+                           "SELECT DISTINCT agent_id FROM management_group_members "
+                           "ORDER BY agent_id;",
+                           -1, &s, nullptr) != SQLITE_OK)
+        return result;
     while (sqlite3_step(s) == SQLITE_ROW)
         result.emplace_back(safe(reinterpret_cast<const char*>(sqlite3_column_text(s, 0))));
     sqlite3_finalize(s);

--- a/server/core/src/management_group_store.hpp
+++ b/server/core/src/management_group_store.hpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <expected>
 #include <filesystem>
+#include <functional>
 #include <optional>
 #include <string>
 #include <shared_mutex>
@@ -82,7 +83,35 @@ public:
     std::vector<GroupRoleAssignment> get_group_roles(const std::string& group_id) const;
 
     /// Which agents can a user see based on group-scoped role assignments?
+    ///
+    /// PRECONDITION: the caller must have already authenticated the session.
+    /// This method performs NO authentication and, when RBAC is not actively
+    /// enforced (below), returns the full enrolled set for ANY username — the
+    /// route-layer session/permission check is the access boundary.
+    ///
+    /// When RBAC enforcement is globally DISABLED (the default posture, and the
+    /// UAT rig), no per-user `management_group_roles` rows exist, so the
+    /// role-scoped inner join would return an empty set and hide every agent
+    /// from the legacy-admin superuser — even though it has full effective
+    /// access everywhere else (#1453). In that case this returns the full
+    /// enrolled set instead (every agent is auto-added to the root "All
+    /// Devices" group at enrollment). The branch is gated on the injected
+    /// `rbac_enabled_probe_`: when the probe reports RBAC ENABLED the exact
+    /// role-scoped semantics are preserved unchanged, so the fallback can never
+    /// widen visibility WHILE RBAC IS ON. When the probe is UNSET it also fails
+    /// CLOSED (role-scoped join only). The widened set is returned only when the
+    /// probe affirmatively reports RBAC off — which, consistent with the rest of
+    /// the dashboard (`check_permission`, `/api/me`), is the same posture under
+    /// which every authenticated user is a legacy superuser. (How a *failed*
+    /// RbacStore load should be treated — legacy-open vs fail-closed — is a
+    /// system-wide question tracked separately, not specific to visibility.)
     std::vector<std::string> get_visible_agents(const std::string& username) const;
+
+    /// Inject a predicate reporting whether RBAC enforcement is globally
+    /// enabled, wired once at startup from `RbacStore::is_rbac_enabled()`
+    /// (before the web server accepts requests). If never set,
+    /// `get_visible_agents` fails CLOSED — role-scoped inner join only.
+    void set_rbac_enabled_probe(std::function<bool()> probe);
 
     // ── Counting (for metrics / UI) ───────────────────────────────────────
     size_t count_groups() const;
@@ -95,9 +124,19 @@ public:
 private:
     sqlite3* db_{nullptr};
     mutable std::shared_mutex mtx_; // protects db_ access (G3-ARCH-003)
+    // Reports whether RBAC enforcement is globally enabled (see
+    // set_rbac_enabled_probe). Read by get_visible_agents to choose between the
+    // role-scoped inner join (RBAC on / probe unset) and the full enrolled set
+    // (RBAC off). Set once at startup before any request, so the unsynchronised
+    // read in get_visible_agents races nothing.
+    std::function<bool()> rbac_enabled_probe_;
 
     void create_tables();
     std::string generate_id() const;
+    // Full enrolled set: every agent that is a member of any management group.
+    // Every agent is auto-added to the root group at enrollment, so this is the
+    // RBAC-disabled "visible to the legacy-admin superuser" set (#1453).
+    std::vector<std::string> all_member_agents() const;
 };
 
 } // namespace yuzu::server

--- a/server/core/src/rbac_store.cpp
+++ b/server/core/src/rbac_store.cpp
@@ -499,6 +499,13 @@ void RbacStore::set_rbac_enabled(bool enabled) {
     }
 }
 
+bool rbac_enforcement_in_effect(const RbacStore* store) noexcept {
+    // Permit the full-fleet fallback (return false) ONLY for a store that is
+    // loaded AND explicitly disabled. Null / load-failed (!is_open()) fail
+    // CLOSED — see the header for the #1498 rationale.
+    return !(store && store->is_open() && !store->is_rbac_enabled());
+}
+
 // ── Roles CRUD ───────────────────────────────────────────────────────────────
 
 std::vector<RbacRole> RbacStore::list_roles() const {

--- a/server/core/src/rbac_store.hpp
+++ b/server/core/src/rbac_store.hpp
@@ -138,4 +138,20 @@ private:
                                const std::string& op) const;
 };
 
+/// Visibility policy for device-listing call sites (e.g. the TAR fleet scan via
+/// ManagementGroupStore::get_visible_agents) that fall back to the full enrolled
+/// fleet when RBAC enforcement is OFF.
+///
+/// Returns true when RBAC enforcement is IN EFFECT — the caller must use its
+/// role-scoped path, which fails closed (an unroled caller sees nothing).
+/// Returns false only to PERMIT the full-fleet fallback, and only for a store
+/// that is loaded AND explicitly disabled (`is_open() && !is_rbac_enabled()`).
+///
+/// #1498 — a null `store`, or one that failed to load (open/migration failure
+/// leaves `db_` null, so `is_open()` is false while the default-false enabled
+/// flag would otherwise be indistinguishable from an intentional disable),
+/// returns true and so fails CLOSED. A corrupt rbac.db can never widen
+/// fleet-scan visibility to the whole fleet.
+[[nodiscard]] bool rbac_enforcement_in_effect(const RbacStore* store) noexcept;
+
 } // namespace yuzu::server

--- a/server/core/src/server.cpp
+++ b/server/core/src/server.cpp
@@ -1594,10 +1594,15 @@ public:
             // return the full enrolled set in that case; when RBAC is enabled it
             // reports true and the exact role-scoped join is preserved. Reads the
             // live RbacStore flag at request time, so wiring order vs rbac_store_
-            // does not matter (and a null rbac_store_ reads as disabled, matching
-            // the is_rbac_enabled() convention used elsewhere in this file).
+            // does not matter.
+            //
+            // #1498 — the predicate fails CLOSED on a missing or load-failed
+            // store (open/migration failure leaves db_ null), so a corrupt
+            // rbac.db can never widen TAR fleet-scan visibility to the whole
+            // fleet; see rbac_enforcement_in_effect (rbac_store.hpp) for the
+            // full policy and its unit tests.
             mgmt_group_store_->set_rbac_enabled_probe(
-                [this]() { return rbac_store_ && rbac_store_->is_rbac_enabled(); });
+                [this]() { return rbac_enforcement_in_effect(rbac_store_.get()); });
             // Ensure root "All Devices" group exists
             if (mgmt_group_store_ && mgmt_group_store_->is_open()) {
                 auto root = mgmt_group_store_->get_group(ManagementGroupStore::kRootGroupId);
@@ -3451,8 +3456,18 @@ private:
     /// Return the agent list as JSON, filtered by RBAC visibility for the given user.
     nlohmann::json get_visible_agents_json(const std::string& username) {
         auto agents = registry_.to_json_obj();
-        if (rbac_store_ && rbac_store_->is_rbac_enabled() && mgmt_group_store_) {
-            bool global_read = rbac_store_->check_permission(username, "Infrastructure", "Read");
+        // #1498 — restrict whenever RBAC enforcement is in effect, which includes
+        // a missing/load-failed store (fail closed); only a loaded-and-explicitly-
+        // disabled store skips filtering and returns the full fleet. Shares the
+        // rbac_enforcement_in_effect predicate with the get_visible_agents probe
+        // so /api/agents and the TAR fleet scan can never disagree.
+        if (mgmt_group_store_ && rbac_enforcement_in_effect(rbac_store_.get())) {
+            // A global Infrastructure:Read grant sees the whole fleet even under
+            // RBAC-on. On a load-failed store check_permission is unavailable
+            // (is_open()==false), so this is false and visibility falls to the
+            // role-scoped join, which itself fails closed.
+            bool global_read = rbac_store_ && rbac_store_->is_open() &&
+                               rbac_store_->check_permission(username, "Infrastructure", "Read");
             if (!global_read) {
                 auto visible = mgmt_group_store_->get_visible_agents(username);
                 std::set<std::string> visible_set(visible.begin(), visible.end());

--- a/server/core/src/server.cpp
+++ b/server/core/src/server.cpp
@@ -1586,6 +1586,18 @@ public:
         {
             auto mgmt_db = cfg_.db_dir() / "management-groups.db";
             mgmt_group_store_ = std::make_unique<ManagementGroupStore>(mgmt_db);
+            // #1453 — make device visibility honor the RBAC-disabled posture.
+            // When RBAC is globally off there are no per-user
+            // management_group_roles rows, so get_visible_agents would return an
+            // empty set and the legacy-admin superuser would see no agents (TAR
+            // fleet scan, /api/me visible-agents). The probe lets the store
+            // return the full enrolled set in that case; when RBAC is enabled it
+            // reports true and the exact role-scoped join is preserved. Reads the
+            // live RbacStore flag at request time, so wiring order vs rbac_store_
+            // does not matter (and a null rbac_store_ reads as disabled, matching
+            // the is_rbac_enabled() convention used elsewhere in this file).
+            mgmt_group_store_->set_rbac_enabled_probe(
+                [this]() { return rbac_store_ && rbac_store_->is_rbac_enabled(); });
             // Ensure root "All Devices" group exists
             if (mgmt_group_store_ && mgmt_group_store_->is_open()) {
                 auto root = mgmt_group_store_->get_group(ManagementGroupStore::kRootGroupId);
@@ -8843,6 +8855,12 @@ private:
     std::unique_ptr<ScheduleEngine> schedule_engine_;
 
     // Phase 3: Security & RBAC
+    // ORDER IS LOAD-BEARING (#1453): rbac_store_ MUST be declared before
+    // mgmt_group_store_. The latter holds a `this`-capturing RBAC-enabled probe
+    // (set_rbac_enabled_probe) that reads rbac_store_; members destruct in
+    // reverse declaration order, so mgmt_group_store_ (and its probe) are torn
+    // down BEFORE rbac_store_, ensuring the probe can never read a freed store
+    // during shutdown. Do not reorder these two.
     std::unique_ptr<RbacStore> rbac_store_;
     std::unique_ptr<ManagementGroupStore> mgmt_group_store_;
     std::unique_ptr<ApiTokenStore> api_token_store_;

--- a/tests/unit/server/test_management_group_store.cpp
+++ b/tests/unit/server/test_management_group_store.cpp
@@ -265,6 +265,77 @@ TEST_CASE("ManagementGroupStore: group role assignments", "[mgmt][roles]") {
     CHECK(roles2.empty());
 }
 
+TEST_CASE("ManagementGroupStore: get_visible_agents honors RBAC-disabled posture (#1453)",
+          "[mgmt][roles][rbac]") {
+    TempDb tmp;
+    ManagementGroupStore store(tmp.path);
+
+    // Group A with two enrolled agents; Group B with a third. NO
+    // management_group_roles rows — the fresh-install / RBAC-disabled state that
+    // hid every agent from the legacy-admin superuser in #1453.
+    ManagementGroup ga;
+    ga.name = "Group A";
+    ga.membership_type = "static";
+    auto gid_a = store.create_group(ga);
+    REQUIRE(gid_a.has_value());
+    ManagementGroup gb;
+    gb.name = "Group B";
+    gb.membership_type = "static";
+    auto gid_b = store.create_group(gb);
+    REQUIRE(gid_b.has_value());
+    store.add_member(*gid_a, "agent-001");
+    store.add_member(*gid_a, "agent-002");
+    store.add_member(*gid_b, "agent-003");
+
+    SECTION("probe unset → fail-closed role-scoped join (empty without a role)") {
+        // No probe wired and no role for admin → strict, pre-#1453 behavior.
+        CHECK(store.get_visible_agents("admin").empty());
+    }
+
+    SECTION("RBAC enabled → role-scoped join, strict subset (no cross-group leak)") {
+        store.set_rbac_enabled_probe([] { return true; });
+        // admin has no role → still sees nothing; the fallback must NOT widen
+        // visibility while RBAC is on.
+        CHECK(store.get_visible_agents("admin").empty());
+        GroupRoleAssignment a;
+        a.group_id = *gid_a;
+        a.principal_type = "user";
+        a.principal_id = "admin";
+        a.role_name = "ITServiceOwner";
+        REQUIRE(store.assign_role(a).has_value());
+        auto visible = store.get_visible_agents("admin");
+        // Sees Group A's two agents and NOT Group B's agent-003 — the core
+        // security property the role-scoped join must preserve under RBAC-on.
+        CHECK(visible.size() == 2);
+        CHECK(std::find(visible.begin(), visible.end(), "agent-003") == visible.end());
+    }
+
+    SECTION("RBAC disabled → full enrolled set regardless of role rows") {
+        store.set_rbac_enabled_probe([] { return false; });
+        auto visible = store.get_visible_agents("admin");
+        // admin has NO role row, yet sees every enrolled agent across all groups.
+        REQUIRE(visible.size() == 3);
+        CHECK(std::find(visible.begin(), visible.end(), "agent-003") != visible.end());
+        // Route-level auth still gates access; this store method returns the
+        // full set for any username under the RBAC-off legacy-superuser posture.
+        CHECK(store.get_visible_agents("nobody").size() == 3);
+    }
+
+    SECTION("RBAC disabled → DISTINCT dedups an agent that is in multiple groups") {
+        store.add_member(*gid_b, "agent-001"); // agent-001 now in A and B
+        store.set_rbac_enabled_probe([] { return false; });
+        // Still 3 DISTINCT agents, not 4 — all_member_agents() must dedup.
+        CHECK(store.get_visible_agents("admin").size() == 3);
+    }
+
+    SECTION("RBAC disabled → an empty fleet yields an empty set") {
+        TempDb empty_tmp;
+        ManagementGroupStore empty_store(empty_tmp.path);
+        empty_store.set_rbac_enabled_probe([] { return false; });
+        CHECK(empty_store.get_visible_agents("admin").empty());
+    }
+}
+
 TEST_CASE("ManagementGroupStore: find_group_by_name", "[mgmt][crud]") {
     TempDb tmp;
     ManagementGroupStore store(tmp.path);

--- a/tests/unit/server/test_management_group_store.cpp
+++ b/tests/unit/server/test_management_group_store.cpp
@@ -3,39 +3,27 @@
  */
 
 #include "management_group_store.hpp"
+#include "rbac_store.hpp"
+
+#include "../test_helpers.hpp"
 
 #include <sqlite3.h>
 
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
-#include <chrono>
 #include <filesystem>
 #include <string>
-#include <thread>
 
 using namespace yuzu::server;
 
 namespace {
 
-// Per-instance unique path so tests are safe to run under parallel
-// meson test --num-processes N. The prior hardcoded path collided
-// between concurrent test cases and between the outer constructor and
-// destructor in the injected-cycle test below.
-struct TempDb {
-    std::filesystem::path path;
-    TempDb()
-        : path(std::filesystem::temp_directory_path() /
-               ("test_mgmt_groups-" +
-                std::to_string(std::hash<std::thread::id>{}(std::this_thread::get_id()) ^
-                               static_cast<size_t>(std::chrono::steady_clock::now()
-                                                       .time_since_epoch()
-                                                       .count())) +
-                ".db")) {
-        std::filesystem::remove(path);
-    }
-    ~TempDb() { std::filesystem::remove(path); }
-};
+// Per-test SQLite temp file. yuzu::test::TempDbFile carries the collision-safe
+// naming (process salt + atomic counter) and -wal/-shm cleanup — never the
+// std::hash<std::thread::id> ^ steady_clock idiom CLAUDE.md bans after the
+// Windows-runner flake #473.
+using TempDb = yuzu::test::TempDbFile;
 
 } // namespace
 

--- a/tests/unit/server/test_rbac_store.cpp
+++ b/tests/unit/server/test_rbac_store.cpp
@@ -9,6 +9,8 @@
 #include "management_group_store.hpp"
 #include "rbac_store.hpp"
 
+#include "../test_helpers.hpp"
+
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
@@ -121,6 +123,43 @@ TEST_CASE("RbacStore: enable and disable RBAC", "[rbac_store]") {
     CHECK(store.is_rbac_enabled());
     store.set_rbac_enabled(false);
     CHECK_FALSE(store.is_rbac_enabled());
+}
+
+// #1498 — the device-visibility fallback must distinguish a store that is
+// loaded-and-explicitly-disabled (full-fleet fallback OK) from one that is
+// missing or failed to load (fail CLOSED). The probe wired into
+// ManagementGroupStore is exactly rbac_enforcement_in_effect(rbac_store_.get()),
+// so this exercises the real predicate, not a stand-in lambda.
+TEST_CASE("rbac_enforcement_in_effect fails closed on null / load-failed store",
+          "[rbac_store][visibility]") {
+    SECTION("null store → enforcement in effect (fail closed)") {
+        CHECK(rbac_enforcement_in_effect(nullptr));
+    }
+
+    SECTION("load-failed store (is_open()==false) → fail closed, not full-fleet") {
+        // A db path whose PARENT directory does not exist: sqlite3_open_v2 with
+        // SQLITE_OPEN_CREATE creates the file but never the parent, so the open
+        // fails and db_ is left null — the same state an open/migration failure
+        // produces, and indistinguishable by the enabled flag alone.
+        const auto bogus = yuzu::test::unique_temp_path("rbac-loadfail-") / "rbac.db";
+        RbacStore broken(bogus);
+        REQUIRE_FALSE(broken.is_open());
+        CHECK(rbac_enforcement_in_effect(&broken)); // must fail closed
+    }
+
+    SECTION("loaded + explicitly disabled → full-fleet fallback permitted") {
+        RbacStore store(":memory:");
+        REQUIRE(store.is_open());
+        REQUIRE_FALSE(store.is_rbac_enabled()); // disabled by default
+        CHECK_FALSE(rbac_enforcement_in_effect(&store));
+    }
+
+    SECTION("loaded + enabled → enforcement in effect (role-scoped path)") {
+        RbacStore store(":memory:");
+        store.set_rbac_enabled(true);
+        REQUIRE(store.is_rbac_enabled());
+        CHECK(rbac_enforcement_in_effect(&store));
+    }
 }
 
 // ── Role CRUD ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

**PR 2 of the TAR bug-clearance sweep.** Fixes the TAR fleet scan reporting "no agents in scope" on the default RBAC-disabled posture.

`ManagementGroupStore::get_visible_agents` resolved a user's visible devices via a strict `management_group_members ⋈ management_group_roles` inner join that never consulted `rbac_config.enabled`. With RBAC enforcement globally disabled — the default posture and the UAT rig — nothing seeds a per-user role row, so the join returned empty and the legacy-admin superuser (full effective access everywhere else) got **"You have no agents in scope to scan"** with no in-product recovery (granting the first group role itself requires holding one — a chicken-and-egg lockout).

## Fix

- **#1453** — `get_visible_agents` is now RBAC-aware via an injected `std::function<bool()>` probe, wired once at startup from `RbacStore::is_rbac_enabled()`. RBAC **off** → returns the full enrolled set (`all_member_agents()`; every agent is auto-added to the root "All Devices" group at enrollment). RBAC **on**, or probe unset → the existing role-scoped inner join is preserved **byte-identical** — the fallback can never widen visibility under enforcement (fail-closed). Putting the decision in the store fixes every caller uniformly with no call-site drift (the three dashboard TAR sites + `get_visible_agents_json`).
- **#1454** — `start-UAT.sh` seeds an admin → root-group `ITServiceOwner` role after server boot. With #1453 the default RBAC-off rig already works; the seed makes the rig correct if an operator later enables RBAC. Defensive (skips with a warning if sqlite3/DB absent).

## Testing

- `[mgmt][rbac]` test (5 sections, 20 assertions): probe-unset fails closed; **RBAC-on preserves the role-scoped join as a strict subset (no cross-group leak)**; RBAC-off returns the full set for any user; `DISTINCT` dedups multi-group agents; empty fleet → empty.
- Server suite green (37s); `start-UAT.sh` `bash -n` clean.

## Governance

Full `/governance` — **PASS, no CRITICAL/HIGH/BLOCKING.** Gate 2 security confirmed the **fail-open invariant holds** (the `all_member_agents()` branch is unreachable when RBAC is enabled); architect/cpp-safety/consistency PASS (lifetime safe via documented `rbac_store_`-before-`mgmt_group_store_` decl order). The one docs BLOCKING (management-groups.md drift) is fixed here, plus rbac.md/tar.md operator notes. SHOULD findings filed as follow-ups: RBAC-enable lockout safeguard/observability, fleet-scan fan-out cap, system-wide RBAC-load-failure posture, checked enrollment `add_member`, test-fixture migration, SOC 2 CC6.1 narrative.

Closes #1453
Closes #1454

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_Re-issued from within `Tr3kkR/Yuzu` (collaborators shouldn't open PRs from a personal fork). Supersedes fork PR #1516 — same branch + commits, now intra-repo against `dev`._