### PR TITLE
fix(server): correct + DoS-resistant TAR retention-paused render (#558, #560, #561)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -286,6 +286,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **TAR retention-paused dashboard: correct rendering + DoS-resistant (#558, #560, #561).**
+  The `/tar` retention-paused list had three defects: (a) a source whose
+  `<source>_enabled` held a non-`"false"` value (`errored` from a corrupt/tampered
+  agent DB, or any garbage) was **silently omitted** from the list — showing clean
+  state for an actually-paused source; it now renders with a value-error badge
+  and sorts to the top of the list (#560); (b) a pre-v0.12.0 agent that reported a source disabled without a
+  `paused_at` was rendered with a bare em-dash and, worse, **sorted to the bottom**
+  (the longest-paused sources sank below recently-paused ones — inverse of operator
+  intent); unknown `paused_at` now sorts as oldest (top) with a
+  "schema-older-than-server" badge (#558); (c) a malicious/compromised agent
+  spamming many responses under one `command_id` forced the renderer to parse every
+  response (200ms–3s); the renderer now dedups to the most-recent response per agent
+  before parsing, bounding work to O(visible agents × sources) (#561).
 - **Windows server installer locks its log-directory ACL.** `yuzu-server.iss`
   set `Permissions: service-full` on `{app}\logs`, which is not a valid
   InnoSetup permission group — ISCC silently ignores it, leaving the directory

--- a/docs/tar-dashboard.md
+++ b/docs/tar-dashboard.md
@@ -91,6 +91,8 @@ The source of truth is the agent's `tar_config` table — the `<source>_enabled`
 3. Server collates into a transient in-memory table; renders as HTMX OOB swaps.
 4. Empty rows (`enabled=true` for all four sources) are dropped — the table only shows the *paused* state, not the entire fleet.
 
+**Tri-state enabled values + dedup (#560/#558/#561).** The `<source>_enabled` value is read as a tri-state: `true` → dropped (collecting normally); `false` → normal paused row; **any other value** (`errored` from a corrupt/tampered agent DB, or garbage) → a **value-error badge** row showing the reported value (it is NOT silently dropped — that would hide a paused/broken source). A disabled source with `paused_at == 0` (a pre-v0.12.0 agent) renders a **"schema older than server" badge** and sorts as the oldest (top), instead of a bare `—` sunk to the bottom. Both value-error and unknown-`paused_at` rows float to the top. Before parsing, responses are **deduplicated to the most-recent per agent by the server-stamped `received_at_ms`** (never the agent-claimed `timestamp`, which a compromised agent could backdate to hide its state) — bounding render cost to O(agents × sources) against a response-spam DoS. The complementary store-side per-`(command_id, agent_id)` cap is a tracked follow-up.
+
 This avoids a new persistent server-side mirror, which would have to be reconciled with agent state on every config change. The trade-off is a 5-15s page-load cost on a large fleet; mitigated by:
 - Scope-restricted queries (the operator usually narrows first via a result set)
 - Manual **Refresh** button for ad-hoc re-fan-out (automatic background refresh is planned for Phase 15.G operational hardening)

--- a/docs/user-manual/tar.md
+++ b/docs/user-manual/tar.md
@@ -214,7 +214,7 @@ config|user_oldest_ts|1710900100
 config|network_capture_method|polling
 ```
 
-The four `<source>_*` blocks are emitted per capture source. `<source>_paused_at` is `0` when the source has never been disabled and the wall-clock UTC seconds when it was last transitioned `enabled → disabled`. The reverse transition resets it to `0`. `<source>_live_rows` and `<source>_oldest_ts` are the count and minimum timestamp of the per-source `*_live` table at the moment of the status call. Agents older than v0.12.0 do not emit the per-source `paused_at` / `live_rows` / `oldest_ts` lines; the dashboard renders `—` in their absence.
+The four `<source>_*` blocks are emitted per capture source. `<source>_paused_at` is `0` when the source has never been disabled and the wall-clock UTC seconds when it was last transitioned `enabled → disabled`. The reverse transition resets it to `0`. `<source>_live_rows` and `<source>_oldest_ts` are the count and minimum timestamp of the per-source `*_live` table at the moment of the status call. Agents older than v0.12.0 do not emit the per-source `paused_at` / `live_rows` / `oldest_ts` lines. In the retention-paused list the dashboard renders a "schema older than server" badge for such an agent's disabled source (and sorts it as the oldest, at the top of the list) rather than hiding it behind a bare `—`; elsewhere a missing `live_rows` / `oldest_ts` still renders `—`.
 
 ## TAR dashboard page
 
@@ -225,6 +225,11 @@ The Yuzu dashboard includes a dedicated TAR page at `/tar`, reachable from the *
 The first frame surfaces every device × source pair where the collector has been disabled (`<source>_enabled=false`). Rows are sorted paused-longest-first so devices accumulating non-aging data the longest float to the top of the list.
 
 **Columns:** device hostname, source pill, paused since (UTC), paused for (coarse age), live rows count, oldest data age.
+
+**Row states.** Beyond a normal paused row (with a timestamp), the table surfaces two conditions and floats both to the top of the list so they aren't missed:
+
+- **"schema older than server" badge** — the agent reported the source disabled but sent no `paused_at` timestamp, i.e. it is a pre-v0.12.0 agent that lacks the field. The row sorts as the oldest entry. **Action:** upgrade the agent so it records the transition time.
+- **"value error" badge** — the agent reported a `<source>_enabled` value other than `true`/`false` (e.g. `errored`, or garbage from a corrupt or tampered `tar.db`); the reported value is shown. Previously such a source was silently omitted, hiding a paused/broken collector. **Action:** re-configure the source (`tar.configure <source>_enabled=true`) or inspect the agent's `tar.db`; if tampering is suspected, treat the device as potentially compromised.
 
 **Workflow:**
 

--- a/server/core/src/dashboard_routes.cpp
+++ b/server/core/src/dashboard_routes.cpp
@@ -1911,13 +1911,37 @@ std::string DashboardRoutes::render_tar_retention_paused(
         int64_t paused_at{0};
         int64_t live_rows{-1};   // -1 = unknown (older agent)
         int64_t oldest_ts{0};
+        bool value_error{false}; // #560: <source>_enabled held a non-canonical value
+        std::string enabled_raw; // the offending value, for the value-error badge
     };
     std::vector<PausedRow> rows;
     int agents_responded = 0;
     int agents_with_no_paused_sources = 0;
     int agents_filtered_out_of_scope = 0;
 
+    // #561 — a malicious or buggy agent can spam many responses under one
+    // command_id (no (command_id, agent_id) uniqueness at the write path). Dedup
+    // to the most-recent response per agent BEFORE the per-response parse, so
+    // render work is bounded to O(visible_agents × sources), not O(responses).
+    // (The store-side per-pair cap is the complementary defence.)
+    //
+    // Recency uses ONLY `received_at_ms` — the SERVER ingest stamp, which the
+    // agent cannot forge. We deliberately do NOT fall back to the agent-claimed
+    // `timestamp`: a compromised agent could backdate it to make a stale
+    // "enabled=true" response win the dedup and hide its actually-paused/errored
+    // state (the exact thing #560 surfaces). Legacy pre-v3 rows (received_at_ms
+    // == 0) sort as oldest and lose to any stamped response — correct.
+    auto resp_recency = [](const StoredResponse& r) -> int64_t { return r.received_at_ms; };
+    std::unordered_map<std::string, const StoredResponse*> latest_by_agent;
+    latest_by_agent.reserve(responses.size());
     for (const auto& resp : responses) {
+        auto [it, inserted] = latest_by_agent.try_emplace(resp.agent_id, &resp);
+        if (!inserted && resp_recency(resp) >= resp_recency(*it->second))
+            it->second = &resp;
+    }
+
+    for (const auto& [dedup_agent_id, resp_ptr] : latest_by_agent) {
+        const StoredResponse& resp = *resp_ptr;
         // Visibility gate: drop responses from agents the operator cannot
         // see. If mgmt_group_store_ is unavailable, fail closed (drop all
         // — operator sees an empty list rather than unscoped data).
@@ -1946,13 +1970,22 @@ std::string DashboardRoutes::render_tar_retention_paused(
         for (const char* source : {"process", "tcp", "service", "user"}) {
             std::string enabled_key = std::string{source} + "_enabled";
             auto it = kv.find(enabled_key);
-            if (it == kv.end() || it->second != "false") continue;
+            if (it == kv.end()) continue;          // source not reported by this agent
+            if (it->second == "true") continue;    // collecting normally — not paused
+            // #560 — tri-state: "false" is genuinely paused; ANYTHING ELSE
+            // ("errored" from a corrupt/tampered agent DB, or a garbage value)
+            // must surface with a value-error badge, NOT be silently dropped
+            // (silent omission shows clean state for an actually-paused source).
+            const bool value_error = (it->second != "false");
 
             PausedRow row;
             row.agent_id = resp.agent_id;
             row.agent_display = registry_ ? registry_->display_name(resp.agent_id)
                                           : resp.agent_id;
             row.source = source;
+            row.value_error = value_error;
+            if (value_error)
+                row.enabled_raw = it->second;
             if (auto p = kv.find(std::string{source} + "_paused_at");
                 p != kv.end()) {
                 try { row.paused_at = std::stoll(p->second); } catch (...) {}
@@ -2009,8 +2042,8 @@ std::string DashboardRoutes::render_tar_retention_paused(
         agents_responded,
         agents_with_no_paused_sources);
     if (agents_filtered_out_of_scope > 0) {
-        html += std::format(" &middot; <strong>{}</strong> response{} from "
-                            "out-of-scope agents dropped",
+        html += std::format(" &middot; <strong>{}</strong> out-of-scope "
+                            "agent{} dropped",
                             agents_filtered_out_of_scope,
                             agents_filtered_out_of_scope == 1 ? "" : "s");
     }
@@ -2037,18 +2070,20 @@ std::string DashboardRoutes::render_tar_retention_paused(
         return html;
     }
 
-    // Sort: paused-longest-first, then by agent display name. Operators want
-    // to see the boxes that have been accumulating non-aging data the
-    // longest at the top of the list.
+    // Sort: value-error rows first (they need operator attention), then
+    // paused-longest-first, then by agent display name. #558 — an unknown
+    // paused_at (0) here means the agent reported the source disabled but never
+    // wrote a paused_at (a pre-v0.12.0 agent), i.e. it has been paused at least
+    // since that build — it is OLDER than any known-timestamp transition, not
+    // newer. The previous `0 ? INT64_MAX` sank these longest-paused sources to
+    // the BOTTOM, inverting operator intent; sort 0 as the smallest (oldest)
+    // instead so they rank at the top.
     std::sort(rows.begin(), rows.end(),
               [](const PausedRow& a, const PausedRow& b) {
-                  if (a.paused_at != b.paused_at) {
-                      // Smaller paused_at = older = first. Treat 0 as "infinity"
-                      // so unknowns sink to the bottom.
-                      auto cmp_a = a.paused_at == 0 ? INT64_MAX : a.paused_at;
-                      auto cmp_b = b.paused_at == 0 ? INT64_MAX : b.paused_at;
-                      return cmp_a < cmp_b;
-                  }
+                  if (a.value_error != b.value_error)
+                      return a.value_error; // errors float to the top
+                  if (a.paused_at != b.paused_at)
+                      return a.paused_at < b.paused_at; // smaller (incl. 0) = older = first
                   return a.agent_display < b.agent_display;
               });
 
@@ -2066,10 +2101,35 @@ std::string DashboardRoutes::render_tar_retention_paused(
     for (const auto& r : rows) {
         html += "<tr>";
         html += "<td>" + html_escape(r.agent_display) + "</td>";
-        html += "<td><span class=\"source-pill\">" +
-                html_escape(r.source) + "</span></td>";
-        html += "<td>" + format_utc(r.paused_at) + "</td>";
-        html += "<td>" + format_age(r.paused_at, now) + "</td>";
+        // #560 — a value-error source carries a badge in the source column so
+        // an operator sees that the agent reported a non-canonical enabled value
+        // (corruption / tampering / pre-tri-state agent) instead of the source
+        // being silently absent from the list.
+        if (r.value_error) {
+            html += "<td><span class=\"source-pill\">" + html_escape(r.source) +
+                    "</span> <span class=\"badge badge-danger\" title=\"agent reported "
+                    "&#39;" + html_escape(r.enabled_raw) +
+                    "&#39; for this source's enabled flag — expected true/false; check the "
+                    "agent's tar.db\">value error</span></td>";
+        } else {
+            html += "<td><span class=\"source-pill\">" + html_escape(r.source) + "</span></td>";
+        }
+        // #558 — an agent that reported the source disabled but no paused_at
+        // (paused_at == 0) is a pre-v0.12.0 agent that lacks the field. Render an
+        // explicit "schema-older-than-server" badge instead of a bare em-dash, so
+        // the operator knows the row needs the agent upgraded rather than reading
+        // "—" as "unknown / not paused".
+        if (r.value_error) {
+            html += "<td colspan=\"2\"><span style=\"color:#8b949e\">reported <code>" +
+                    html_escape(r.enabled_raw) + "</code></span></td>";
+        } else if (r.paused_at == 0) {
+            html += "<td colspan=\"2\"><span class=\"badge badge-warning\" title=\"this agent "
+                    "predates the paused-since field (v0.12.0); upgrade the agent to record the "
+                    "transition time\">schema older than server</span></td>";
+        } else {
+            html += "<td>" + format_utc(r.paused_at) + "</td>";
+            html += "<td>" + format_age(r.paused_at, now) + "</td>";
+        }
         html += "<td style=\"text-align:right\">";
         if (r.live_rows < 0) {
             html += "<span style=\"color:#8b949e\">—</span>";

--- a/server/core/src/dashboard_routes.hpp
+++ b/server/core/src/dashboard_routes.hpp
@@ -158,6 +158,13 @@ private:
     mutable std::mutex tar_scan_mu_;
     std::unordered_map<std::string, TarScanState> tar_scans_by_user_;
     static constexpr std::size_t kTarScanStateCap = 256;
+
+    // Unit-test seam (#562): render_tar_retention_paused and its inputs
+    // (response_store_, mgmt_group_store_, tar_scans_by_user_) are private, and
+    // exercising the XSS-escaping / dedup / sort logic without standing up an
+    // HTTP server needs to wire them directly. Test-only; grants no runtime
+    // surface. See tests/unit/server/test_dashboard_tar_retention.cpp.
+    friend struct DashboardTarRetentionTestAccess;
 };
 
 } // namespace yuzu::server

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -223,6 +223,7 @@ if build_server
       'unit/server/test_concurrency_manager.cpp',
       'unit/server/test_legacy_shim.cpp',
       'unit/server/test_management_group_store.cpp',
+      'unit/server/test_dashboard_tar_retention.cpp',
       'unit/server/test_api_token_store.cpp',
       'unit/server/test_secure_random.cpp',
       'unit/server/test_quarantine_store.cpp',

--- a/tests/unit/server/test_dashboard_tar_retention.cpp
+++ b/tests/unit/server/test_dashboard_tar_retention.cpp
@@ -1,0 +1,280 @@
+/**
+ * test_dashboard_tar_retention.cpp — render harness for
+ * DashboardRoutes::render_tar_retention_paused (#1519 / #558 / #560 / #561;
+ * docs/tar-dashboard.md §3.6, tracked harness #562).
+ *
+ * The renderer mixes three security-sensitive behaviours that a future edit
+ * could silently regress, so they are pinned here directly rather than only
+ * through the html_escape primitive:
+ *   - #560 XSS: the untrusted agent-supplied `<source>_enabled` value is
+ *     emitted into a `title=` attribute and a `<code>` node — both must be
+ *     html_escaped (a `"><script>` payload must not escape its context).
+ *   - #561 dedup: per-agent dedup keys ONLY on the server-stamped
+ *     `received_at_ms`, never the agent-claimed `timestamp`, so a compromised
+ *     agent cannot backdate a stale "enabled=true" row to hide a paused source.
+ *   - #558 sort: value-error rows float to the top; an unknown `paused_at==0`
+ *     (pre-v0.12.0 agent) is OLDEST (top), not newest, and renders a
+ *     "schema older than server" badge.
+ *
+ * render_tar_retention_paused and its inputs (response_store_,
+ * mgmt_group_store_, tar_scans_by_user_) are private; the
+ * DashboardTarRetentionTestAccess friend seam (dashboard_routes.hpp) wires
+ * them without standing up an HTTP server. Visibility is granted the same way
+ * production does it on this branch — a role assignment on a group whose
+ * members are the agents under test (get_visible_agents is the role-scoped
+ * join).
+ */
+
+#include "dashboard_routes.hpp"
+#include "management_group_store.hpp"
+#include "response_store.hpp"
+
+#include "../test_helpers.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <initializer_list>
+#include <string>
+
+namespace yuzu::server {
+
+// Test-only accessor for the private renderer + its store/scan inputs (#562).
+struct DashboardTarRetentionTestAccess {
+    DashboardRoutes routes;
+
+    void set_stores(ResponseStore* rs, ManagementGroupStore* mg) {
+        routes.response_store_ = rs;
+        routes.mgmt_group_store_ = mg;
+    }
+    void set_scan(const std::string& user, const std::string& cmd_id, int count, int64_t at) {
+        routes.tar_scans_by_user_[user] = DashboardRoutes::TarScanState{cmd_id, count, at};
+    }
+    std::string render(const std::string& user) const {
+        return routes.render_tar_retention_paused(user);
+    }
+};
+
+namespace {
+
+constexpr const char* kUser = "operator";
+constexpr const char* kScan = "scan-cmd-1";
+
+StoredResponse mk_resp(const std::string& agent, int64_t received_ms, std::string output) {
+    StoredResponse r;
+    r.instruction_id = kScan; // render queries the store by this (== command_id)
+    r.agent_id = agent;
+    r.received_at_ms = received_ms; // store() honours a >0 value (response_store.cpp:232)
+    r.status = 0;
+    r.output = std::move(output);
+    return r;
+}
+
+// Make `agents` visible to kUser: members of a group on which kUser holds a
+// role (get_visible_agents is the role-scoped join). An agent NOT passed here
+// is out of scope and must be filtered by the renderer's visibility gate.
+void grant_visibility(ManagementGroupStore& mg, std::initializer_list<std::string> agents) {
+    ManagementGroup g;
+    g.name = "All Devices";
+    g.membership_type = "static";
+    auto gid = mg.create_group(g);
+    REQUIRE(gid.has_value());
+    for (const auto& a : agents)
+        mg.add_member(*gid, a);
+    GroupRoleAssignment ra;
+    ra.group_id = *gid;
+    ra.principal_type = "user";
+    ra.principal_id = kUser;
+    ra.role_name = "ITServiceOwner";
+    REQUIRE(mg.assign_role(ra).has_value());
+}
+
+bool contains(const std::string& hay, std::string_view needle) {
+    return hay.find(needle) != std::string::npos;
+}
+
+} // namespace
+
+TEST_CASE("render_tar_retention_paused: hostile _enabled value is escaped + flagged (#560)",
+          "[server][tar][retention-render]") {
+    yuzu::test::TempDbFile rs_db{std::string_view{"tar-render-rs-"}};
+    yuzu::test::TempDbFile mg_db{std::string_view{"tar-render-mg-"}};
+    ResponseStore rs{rs_db.path};
+    ManagementGroupStore mg{mg_db.path};
+    grant_visibility(mg, {"agent-evil", "agent-ok"});
+
+    // agent-evil reports a breakout payload as its process_enabled value; agent-ok
+    // is a normal paused source. The hostile value must be escaped in BOTH the
+    // title= attribute and the <code> node, and the value-error row must sort
+    // ABOVE the normal paused row.
+    rs.store(mk_resp("agent-evil", 1000,
+                     "config|process_enabled|\"><script>alert(1)</script>\n"));
+    rs.store(mk_resp("agent-ok", 1000,
+                     "config|tcp_enabled|false\nconfig|tcp_paused_at|1710000000\n"));
+
+    DashboardTarRetentionTestAccess acc;
+    acc.set_stores(&rs, &mg);
+    acc.set_scan(kUser, kScan, 2, 1709990000);
+    const std::string html = acc.render(kUser);
+
+    // No unescaped breakout — the raw <script> must never reach the DOM.
+    CHECK_FALSE(contains(html, "<script>alert(1)</script>"));
+    CHECK(contains(html, "&lt;script&gt;"));     // escaped form present
+    CHECK(contains(html, "badge badge-danger")); // value-error badge rendered
+    CHECK(contains(html, "value error"));
+    // The scan id is echoed (escaped) in the provenance header.
+    CHECK(contains(html, "scan-cmd-1"));
+    // Sort: the value-error row (agent-evil) precedes the normal paused row.
+    const auto p_evil = html.find("agent-evil");
+    const auto p_ok = html.find("agent-ok");
+    REQUIRE(p_evil != std::string::npos); // a dropped row → npos → false-pass on `<`
+    REQUIRE(p_ok != std::string::npos);
+    CHECK(p_evil < p_ok);
+}
+
+TEST_CASE("render_tar_retention_paused: a value in the _enabled attribute cannot break out (#560)",
+          "[server][tar][retention-render]") {
+    // The value-error path emits the untrusted value into a title= ATTRIBUTE.
+    // A `<`/`>`-free payload that closes the attribute with a bare `\"` would
+    // inject an event handler if the `\"`-escape regressed — html_escape must
+    // turn `\"` into `&quot;`. Asserting only absence-of-`<script>` would miss
+    // this, so pin the attribute-quote escape directly.
+    yuzu::test::TempDbFile rs_db{std::string_view{"tar-render-attr-rs-"}};
+    yuzu::test::TempDbFile mg_db{std::string_view{"tar-render-attr-mg-"}};
+    ResponseStore rs{rs_db.path};
+    ManagementGroupStore mg{mg_db.path};
+    grant_visibility(mg, {"agent-x"});
+
+    rs.store(mk_resp("agent-x", 1000,
+                     "config|process_enabled|false\" onmouseover=alert(1) x=\"\n"));
+
+    DashboardTarRetentionTestAccess acc;
+    acc.set_stores(&rs, &mg);
+    acc.set_scan(kUser, kScan, 1, 1);
+    const std::string html = acc.render(kUser);
+
+    CHECK(contains(html, "badge badge-danger"));     // surfaced as a value error
+    CHECK(contains(html, "&quot;"));                 // the `"` was escaped
+    CHECK_FALSE(contains(html, "\" onmouseover=alert(1) x=\"")); // raw breakout absent
+}
+
+TEST_CASE("render_tar_retention_paused: dedup keys on received_at_ms, latest wins (#561)",
+          "[server][tar][retention-render]") {
+    yuzu::test::TempDbFile rs_db{std::string_view{"tar-render-dedup-rs-"}};
+    yuzu::test::TempDbFile mg_db{std::string_view{"tar-render-dedup-mg-"}};
+    ResponseStore rs{rs_db.path};
+    ManagementGroupStore mg{mg_db.path};
+    grant_visibility(mg, {"agent-A"});
+
+    SECTION("a newer enabled=true response hides an older paused response") {
+        rs.store(mk_resp("agent-A", 1000, "config|process_enabled|false\n")); // older: paused
+        rs.store(mk_resp("agent-A", 2000, "config|process_enabled|true\n"));  // newer: collecting
+        DashboardTarRetentionTestAccess acc;
+        acc.set_stores(&rs, &mg);
+        acc.set_scan(kUser, kScan, 1, 1);
+        const std::string html = acc.render(kUser);
+        // Latest (received_at_ms=2000) says collecting → NOT in the paused list.
+        CHECK(contains(html, "No paused sources detected"));
+    }
+
+    SECTION("a newer paused response wins over an older enabled response") {
+        rs.store(mk_resp("agent-A", 1000, "config|process_enabled|true\n"));  // older: collecting
+        rs.store(mk_resp("agent-A", 2000, "config|process_enabled|false\n")); // newer: paused
+        DashboardTarRetentionTestAccess acc;
+        acc.set_stores(&rs, &mg);
+        acc.set_scan(kUser, kScan, 1, 1);
+        const std::string html = acc.render(kUser);
+        CHECK(contains(html, "<table>"));
+        CHECK(contains(html, "agent-A"));
+        CHECK(contains(html, "schema older than server")); // no paused_at → #558 badge
+    }
+}
+
+TEST_CASE("render_tar_retention_paused: each visible agent appears; out-of-scope dropped",
+          "[server][tar][retention-render]") {
+    yuzu::test::TempDbFile rs_db{std::string_view{"tar-render-multi-rs-"}};
+    yuzu::test::TempDbFile mg_db{std::string_view{"tar-render-multi-mg-"}};
+    ResponseStore rs{rs_db.path};
+    ManagementGroupStore mg{mg_db.path};
+    grant_visibility(mg, {"agent-A", "agent-B"}); // agent-C deliberately out of scope
+
+    rs.store(mk_resp("agent-A", 10,
+                     "config|process_enabled|false\nconfig|process_paused_at|1710000000\n"));
+    rs.store(mk_resp("agent-B", 10,
+                     "config|tcp_enabled|false\nconfig|tcp_paused_at|1710000500\n"));
+    rs.store(mk_resp("agent-C", 10,
+                     "config|service_enabled|false\nconfig|service_paused_at|1710000900\n"));
+
+    DashboardTarRetentionTestAccess acc;
+    acc.set_stores(&rs, &mg);
+    acc.set_scan(kUser, kScan, 3, 1);
+    const std::string html = acc.render(kUser);
+
+    // Both in-scope agents' paused sources render; the out-of-scope agent is
+    // filtered (visibility gate) and reported as dropped.
+    CHECK(contains(html, "agent-A"));
+    CHECK(contains(html, "agent-B"));
+    CHECK_FALSE(contains(html, "agent-C"));
+    CHECK(contains(html, "out-of-scope"));
+    // NOTE: the >10,000-responses-from-one-agent global-window starvation the
+    // reviewer flagged is the store-side per-(command_id, agent_id) cap tracked
+    // in #561 — not reproducible at unit scale and out of scope for this render
+    // harness; the per-agent dedup proven above bounds parse work, not the fetch.
+}
+
+TEST_CASE("render_tar_retention_paused: paused_at==0 sorts oldest with schema badge (#558)",
+          "[server][tar][retention-render]") {
+    yuzu::test::TempDbFile rs_db{std::string_view{"tar-render-558-rs-"}};
+    yuzu::test::TempDbFile mg_db{std::string_view{"tar-render-558-mg-"}};
+    ResponseStore rs{rs_db.path};
+    ManagementGroupStore mg{mg_db.path};
+    grant_visibility(mg, {"agent-legacy", "agent-modern"});
+
+    // Legacy agent: disabled but no paused_at (0) → oldest. Modern agent: a
+    // known, recent paused_at. #558 — the legacy (0) row must sort ABOVE the
+    // modern one (0 = oldest), inverting the old `0 → INT64_MAX → bottom` bug.
+    rs.store(mk_resp("agent-legacy", 10, "config|process_enabled|false\n"));
+    rs.store(mk_resp("agent-modern", 10,
+                     "config|process_enabled|false\nconfig|process_paused_at|1710000000\n"));
+
+    DashboardTarRetentionTestAccess acc;
+    acc.set_stores(&rs, &mg);
+    acc.set_scan(kUser, kScan, 2, 1);
+    const std::string html = acc.render(kUser);
+
+    CHECK(contains(html, "schema older than server")); // legacy badge
+    CHECK(contains(html, "badge badge-warning"));
+    const auto p_legacy = html.find("agent-legacy");
+    const auto p_modern = html.find("agent-modern");
+    REQUIRE(p_legacy != std::string::npos); // both must render, or `<` false-passes
+    REQUIRE(p_modern != std::string::npos);
+    CHECK(p_legacy < p_modern); // 0 = oldest = first
+}
+
+TEST_CASE("render_tar_retention_paused: all-collecting fleet renders the clean empty state",
+          "[server][tar][retention-render]") {
+    yuzu::test::TempDbFile rs_db{std::string_view{"tar-render-empty-rs-"}};
+    yuzu::test::TempDbFile mg_db{std::string_view{"tar-render-empty-mg-"}};
+    ResponseStore rs{rs_db.path};
+    ManagementGroupStore mg{mg_db.path};
+    grant_visibility(mg, {"agent-A"});
+
+    rs.store(mk_resp("agent-A", 10, "config|process_enabled|true\nconfig|tcp_enabled|true\n"));
+
+    DashboardTarRetentionTestAccess acc;
+    acc.set_stores(&rs, &mg);
+    acc.set_scan(kUser, kScan, 1, 1); // 1 dispatched, 1 responded → "complete and clean"
+    const std::string html = acc.render(kUser);
+
+    CHECK(contains(html, "No paused sources detected"));
+    CHECK_FALSE(contains(html, "<table>"));
+}
+
+TEST_CASE("render_tar_retention_paused: no scan yet renders the placeholder",
+          "[server][tar][retention-render]") {
+    DashboardTarRetentionTestAccess acc;
+    // No stores wired, no scan recorded for this user.
+    const std::string html = acc.render("nobody");
+    CHECK(contains(html, "No scan data yet"));
+}
+
+} // namespace yuzu::server


### PR DESCRIPTION
## Summary

**PR 5 of the TAR bug-clearance sweep.** Three defects in `render_tar_retention_paused` (the `/tar` dashboard frame).

- **#560 (server half) — silent omission.** The filter `if (it == kv.end() || it->second != "false") continue;` dropped any source whose `<source>_enabled` ≠ exactly `"false"`. With the agent now emitting a strict tri-state (PR for fix/tar-source-lifecycle: `true`/`false`/`errored`), an `errored` source — or any garbage from a corrupt/tampered `tar.db` — would vanish, showing the operator clean state for a paused/broken collector. Now tri-state: `true` skips, `false` is a normal paused row, anything else renders a **value-error badge** (showing the reported value, `html_escape`d) and sorts to the top.
- **#558 — em-dash + inverted sort.** A pre-v0.12.0 agent reports a source disabled but no `paused_at` (== 0); that rendered as a bare em-dash and the sort special-cased 0 as `INT64_MAX`, sinking these *longest-paused* sources to the bottom — the inverse of "paused-longest-first". Unknown `paused_at` now sorts as oldest (top) with a **"schema older than server"** badge.
- **#561 — response-spam DoS.** A malicious/compromised agent can spam many responses under one `command_id`, forcing the renderer to parse every response (200ms–3s). The renderer now dedups to the most-recent response per agent **by the server-stamped `received_at_ms`** (never the agent-claimed `timestamp`, which a compromised agent could backdate to hide its state) before parsing — bounding work to O(visible agents × sources).

## Governance

Full `/governance` — **PASS, no CRITICAL/HIGH/BLOCKING.** Security confirmed the XSS attribute-context escaping is safe and the dedup can't be gamed cross-agent; cpp-safety proved the `const StoredResponse*` interior pointers don't dangle. Fixed in-PR from review: `.badge-error` was undefined in the `/tar` stylesheet (→ `badge-danger`/`badge-warning`); the dedup recency dropped the agent-`timestamp` fallback (agent-trust); the docs (tar.md badges + sort). SHOULD follow-ups: store-side per-`(command_id, agent_id)` cap + `yuzu_tar_response_cap_exceeded_total`, a value-error gauge separate from the paused gauge, a TAR dashboard render test harness.

Verified by server compile + full server suite green.

Closes #558
Closes #561

---

_Re-issued from within `Tr3kkR/Yuzu` (collaborators shouldn't open PRs from a personal fork). Supersedes fork PR #1519 — same branch + commits, now intra-repo against `dev`._