### PR TITLE
ci(runners): register BigTam Linux pool + pool-gate the Linux jobs

### DIFF
--- a/.github/runner-inventory.json
+++ b/.github/runner-inventory.json
@@ -15,6 +15,34 @@
       "labels": ["self-hosted", "Windows", "X64"],
       "role": "Windows MSVC CI jobs — ci.yml windows matrix (release + debug), codeql Windows leg.",
       "installed": "2026-04-14"
+    },
+    {
+      "name": "yuzu-bigtam-0",
+      "host": "BigTam (Threadripper 9970X, native Ubuntu 26.04)",
+      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam"],
+      "role": "Linux CI pool (shared label yuzu-bigtam) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
+      "installed": "2026-06-19"
+    },
+    {
+      "name": "yuzu-bigtam-1",
+      "host": "BigTam (Threadripper 9970X, native Ubuntu 26.04)",
+      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam"],
+      "role": "Linux CI pool (shared label yuzu-bigtam) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
+      "installed": "2026-06-19"
+    },
+    {
+      "name": "yuzu-bigtam-2",
+      "host": "BigTam (Threadripper 9970X, native Ubuntu 26.04)",
+      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam"],
+      "role": "Linux CI pool (shared label yuzu-bigtam) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
+      "installed": "2026-06-19"
+    },
+    {
+      "name": "yuzu-bigtam-3",
+      "host": "BigTam (Threadripper 9970X, native Ubuntu 26.04)",
+      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam"],
+      "role": "Linux CI pool (shared label yuzu-bigtam) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
+      "installed": "2026-06-19"
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,11 @@ jobs:
   # Output names are slugified runner names from .github/runner-inventory.json:
   #   yuzu-wsl2-linux  → yuzu_wsl2_linux_healthy
   #   yuzu-local-windows → yuzu_local_windows_healthy
+  # Plus a pool gate:
+  #   linux_pool_healthy → true iff >=1 [self-hosted, Linux, X64] runner is online
+  #     (any yuzu-bigtam-* OR the yuzu-wsl2-linux Shulgi fallback). The Linux jobs
+  #     gate on the pool, not a single named runner, so a free pool member keeps
+  #     them running and a fully-offline pool still skips them fast.
   #
   # If RUNNER_INVENTORY_TOKEN is missing, the script writes
   # all runners as `false` and exits 0 (fail-closed): downstream jobs
@@ -91,6 +96,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
+      # Pool gate for the [self-hosted, Linux, X64] jobs (proto-compat, linux):
+      # true iff >=1 eligible Linux runner (any yuzu-bigtam-* OR the yuzu-wsl2-linux
+      # Shulgi fallback) is online. Replaces the old single-named yuzu_wsl2_linux gate.
+      linux_pool_healthy: ${{ steps.health.outputs.linux_pool_healthy }}
       yuzu_wsl2_linux_healthy: ${{ steps.health.outputs.yuzu_wsl2_linux_healthy }}
       yuzu_local_windows_healthy: ${{ steps.health.outputs.yuzu_local_windows_healthy }}
       all_healthy: ${{ steps.health.outputs.all_healthy }}
@@ -131,7 +140,9 @@ jobs:
   proto-compat:
     name: "Proto backward-compat"
     needs: [preflight]
-    if: needs.preflight.outputs.yuzu_wsl2_linux_healthy == 'true'
+    # Pool gate: runs if any [self-hosted, Linux, X64] runner is online
+    # (yuzu-bigtam-* or the Shulgi fallback). Fail-closed `== 'true'`.
+    if: needs.preflight.outputs.linux_pool_healthy == 'true'
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 5
     steps:
@@ -152,9 +163,10 @@ jobs:
   linux:
     name: "Linux ${{ matrix.compiler }} ${{ matrix.build_type }}"
     needs: [preflight]
-    # PR-7 of CI overhaul plan: skip if the self-hosted Linux runner is
-    # unhealthy or unknown. Fail-closed `== 'true'` (NOT `!= 'false'`).
-    if: needs.preflight.outputs.yuzu_wsl2_linux_healthy == 'true'
+    # PR-7 of CI overhaul plan: skip if the self-hosted Linux job pool is
+    # unhealthy or unknown. Pool = any [self-hosted, Linux, X64] runner online
+    # (yuzu-bigtam-* or the Shulgi fallback). Fail-closed `== 'true'` (NOT `!= 'false'`).
+    if: needs.preflight.outputs.linux_pool_healthy == 'true'
     # Self-hosted: Shulgi 5950X WSL2 Ubuntu. Persistent ccache + vcpkg
     # state between runs on the same workspace amortizes the install
     # cost. Trade-off: the single runner process serializes this 4-way

--- a/scripts/ci/runner-health-check.py
+++ b/scripts/ci/runner-health-check.py
@@ -13,6 +13,11 @@ Two consumers (do not duplicate the logic):
    $GITHUB_OUTPUT as <name>_healthy=true|false (slugified) and exits 0
    regardless. Downstream jobs gate on these outputs with explicit `==
    'true'` checks (fail-closed: an absent or false value skips the job).
+   Also emits `linux_pool_healthy` — true iff >=1 runner eligible for the
+   [self-hosted, Linux, X64] job pool is online (see LINUX_POOL_LABELS). The
+   proto-compat + linux jobs gate on the pool rather than a single named runner,
+   so any free pool member (yuzu-bigtam-* or the Shulgi fallback) keeps them
+   running, while a wholly-offline pool still skips them fast.
 
 The fall-closed contract is intentional: a degraded sentinel must NOT
 silently accept "I don't know" as healthy. Always check `== 'true'`,
@@ -38,6 +43,26 @@ from typing import Any
 
 
 INVENTORY_PATH = ".github/runner-inventory.json"
+
+# The self-hosted Linux job pool. ci.yml's proto-compat + linux jobs use
+# runs-on: [self-hosted, Linux, X64], so any declared runner whose labels are a
+# superset of this set is eligible to run them. In preflight mode the script
+# emits `linux_pool_healthy=true` iff >=1 such runner is online+labelled
+# (fail-closed: zero online -> the Linux jobs skip fast, exactly as the old
+# single-named gate did when that one runner was down). This includes Shulgi
+# (yuzu-wsl2-linux) as a fallback during the BigTam cutover; Shulgi drops out of
+# the pool automatically when it is later removed from the inventory, leaving the
+# yuzu-bigtam-* runners as the pool. Per-runner `<slug>_healthy` outputs are still
+# emitted unchanged (the sentinel and any pinned-runner gates rely on them).
+LINUX_POOL_LABELS = frozenset({"self-hosted", "Linux", "X64"})
+
+
+def linux_pool_members(expected: dict[str, Any]) -> list[str]:
+    """Declared runners eligible for the [self-hosted, Linux, X64] job pool."""
+    return [
+        name for name, exp in expected.items()
+        if LINUX_POOL_LABELS.issubset(set(exp["labels"]))
+    ]
 
 
 def slug(name: str) -> str:
@@ -153,6 +178,7 @@ def main() -> int:
         print(" runner unavailability via normal queue timeout.)")
         for name in expected:
             write_output(f"{slug(name)}_healthy", "true")
+        write_output("linux_pool_healthy", "true")
         write_output("all_healthy", "true")
         return 0
 
@@ -162,6 +188,7 @@ def main() -> int:
             # Fail closed — every gated job sees healthy=false and skips.
             for name in expected:
                 write_output(f"{slug(name)}_healthy", "false")
+            write_output("linux_pool_healthy", "false")
             write_output("all_healthy", "false")
             return 0
         return 1
@@ -220,6 +247,12 @@ def main() -> int:
             write_output(f"{slug(name)}_healthy", v)
             if v != "true":
                 all_healthy = False
+        # Pool gate: the [self-hosted, Linux, X64] job pool is healthy iff >=1
+        # eligible runner is online (fail-closed). proto-compat + linux gate on
+        # this instead of a single named runner.
+        pool = linux_pool_members(expected)
+        pool_ok = any(healthy_map.get(n, False) for n in pool)
+        write_output("linux_pool_healthy", "true" if pool_ok else "false")
         write_output("all_healthy", "true" if all_healthy else "false")
         if drift:
             print("=== HEALTH ISSUES (preflight mode — non-fatal) ===")


### PR DESCRIPTION
## Summary

Registers the new **BigTam** self-hosted Linux CI box (Threadripper 9970X, native **Ubuntu 26.04**, running **four** runner agents) in the repo's runner machinery, and moves the `ci.yml` Linux health gate from a single named runner to **pool gating**.

## ⚠️ Merge-coordination note (read before merging)

This is fail-closed infrastructure. The `runner-inventory-sentinel` cron compares GitHub's actual `/actions/runners` listing to `runner-inventory.json` every ~30 min and **opens a `runner-inventory-drift` issue on any mismatch** (`strict_unknown_runners: true`).

**Merge this PR at the same time as you register the four runners on the box** — not before. If merged while the runners aren't yet registered+online, the sentinel fires within 30 min with `MISSING: expected runner 'yuzu-bigtam-N' not registered`. (Conversely, registering them before this merges trips `UNKNOWN: unexpected runner …`.) Do not start/register the runners from here — that's your manual step on BigTam.

## Task A — inventory

Adds four entries to `.github/runner-inventory.json`, mirroring the existing field structure exactly (`name`, `host`, `labels`, `role`, `installed`):

| name | labels | host |
|---|---|---|
| `yuzu-bigtam-0` | `self-hosted, Linux, X64, yuzu-bigtam` | BigTam (Threadripper 9970X, native Ubuntu 26.04) |
| `yuzu-bigtam-1` | `self-hosted, Linux, X64, yuzu-bigtam` | " |
| `yuzu-bigtam-2` | `self-hosted, Linux, X64, yuzu-bigtam` | " |
| `yuzu-bigtam-3` | `self-hosted, Linux, X64, yuzu-bigtam` | " |

`yuzu-bigtam` is the shared pool label so GitHub schedules across whichever agent is free. **Shulgi entries (`yuzu-wsl2-linux`, `yuzu-local-windows`) are retained** as fallback during cutover.

## Task B — pool gating

- `runner-health-check.py` now emits **`linux_pool_healthy`** = `true` iff ≥1 runner eligible for the `[self-hosted, Linux, X64]` job pool is online (any `yuzu-bigtam-*` **or** the `yuzu-wsl2-linux` Shulgi fallback). Per-name `<slug>_healthy` outputs and the sentinel drift path are unchanged.
- `ci.yml` `proto-compat` + `linux` now gate on `linux_pool_healthy == 'true'` instead of `yuzu_wsl2_linux_healthy`.
- **Fail-closed preserved:** offline pool / missing PAT → `false` → Linux jobs skip fast, exactly as today. Fork-PR short-circuit → `true` (unchanged).
- **Windows gating untouched** (`yuzu_local_windows_healthy`).
- Pool membership is the runs-on label set, so Shulgi drops out of the pool automatically when it's retired later — no code change needed at that point.

## Validation

Offline: inventory parses; pool membership = the 5 Linux runners, excludes Windows; preflight emission verified across only-bigtam-up / all-Linux-down / only-Shulgi-up / PAT-fail / fork-PR scenarios; `ci.yml` is valid YAML; script `py_compile` clean. (actionlint/zizmor not run locally — repo `zizmor.yml` covers that in CI.)

## Things I want to flag (not changed here)

- **`scw-eager-lumiere` is not in the inventory** — there were only two entries before this PR (`yuzu-wsl2-linux`, `yuzu-local-windows`). The only Scaleway trace is a comment in `codeql.yml` ("a retired Scaleway cloud…"), so it appears already retired; there's no cloud-builder gating in these files to preserve. Flagging in case your mental model expected it present.
- **`yuzu-shulgi`-pinned jobs are out of scope** (the separate cutover): `nightly.yml:49` (sanitizers) & `:180` (coverage), `sanitizer-tests.yml:58` & `:206`, `codeql.yml:107` (Linux CodeQL leg). They pin `[…, yuzu-shulgi]`, so they stay on Shulgi until that migration; the BigTam runners won't match that label. Also `runner-ops-upgrade-erlang.yml` offers `yuzu-shulgi` as a target label.
- The `linux` job has a now-slightly-stale comment ("single runner process serializes this 4-way matrix") — true for the Shulgi-only past, less so with BigTam's 4 agents. Left untouched to keep scope tight; worth a tidy in the later cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
