### PR TITLE
ci(runners): align main inventory with live (add Big Tam pool, drop retired scw-eager-lumiere)

### DIFF
--- a/.github/runner-inventory.json
+++ b/.github/runner-inventory.json
@@ -17,11 +17,32 @@
       "installed": "2026-04-14"
     },
     {
-      "name": "scw-eager-lumiere",
-      "host": "Scaleway VPS (Ubuntu 24.04, 4 vCPU, 7.7 GB RAM, ~45 GB disk)",
-      "labels": ["self-hosted", "Linux", "X64", "yuzu-cloud-builder"],
-      "role": "Cloud-side Linux capacity sharing the [self-hosted, Linux, X64] label set with yuzu-wsl2-linux. The yuzu-cloud-builder label exists for future opt-in pinning of jobs that should land here specifically. Disk is tighter than the WSL2 box — sanitizer-tests.yml's ≥30 GB preflight will fail-fast if a sanitizer dispatch lands on this runner; that is intentional and the dispatch will retry on yuzu-wsl2-linux.",
-      "installed": "2026-05-04"
+      "name": "yuzu-bigtam-linux-0",
+      "host": "Big Tam (Threadripper 9970X, native Ubuntu 26.04)",
+      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam-linux"],
+      "role": "Linux CI pool (shared label yuzu-bigtam-linux) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
+      "installed": "2026-06-19"
+    },
+    {
+      "name": "yuzu-bigtam-linux-1",
+      "host": "Big Tam (Threadripper 9970X, native Ubuntu 26.04)",
+      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam-linux"],
+      "role": "Linux CI pool (shared label yuzu-bigtam-linux) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
+      "installed": "2026-06-19"
+    },
+    {
+      "name": "yuzu-bigtam-linux-2",
+      "host": "Big Tam (Threadripper 9970X, native Ubuntu 26.04)",
+      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam-linux"],
+      "role": "Linux CI pool (shared label yuzu-bigtam-linux) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
+      "installed": "2026-06-19"
+    },
+    {
+      "name": "yuzu-bigtam-linux-3",
+      "host": "Big Tam (Threadripper 9970X, native Ubuntu 26.04)",
+      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam-linux"],
+      "role": "Linux CI pool (shared label yuzu-bigtam-linux) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
+      "installed": "2026-06-19"
     }
   ]
 }


### PR DESCRIPTION
## Summary

The `runner-inventory-sentinel` cron evaluates **main** and has been opening `runner-inventory-drift` issues every ~30 min. main's inventory is stale on two counts:

- **MISSING:** still lists `scw-eager-lumiere` — that Scaleway runner is deregistered (absent from GitHub's `/actions/runners`).
- **UNKNOWN ×4:** omits the four live Big Tam Linux runners `yuzu-bigtam-linux-0..3` (`strict_unknown_runners: true`).

This brings `.github/runner-inventory.json` in line with GitHub's actual runner list, so the sentinel greens on the next tick.

## What changed

`.github/runner-inventory.json` only:
- Removed `scw-eager-lumiere` (deregistered).
- Added `yuzu-bigtam-linux-0..3` (label `yuzu-bigtam-linux`), matching the registered names exactly.

After this, declared == live: `yuzu-wsl2-linux`, `yuzu-local-windows`, `yuzu-bigtam-linux-0..3`.

## Why a direct-to-main hotfix

PR #1586 added the Big Tam pool on **dev** as `yuzu-bigtam-*` (label `yuzu-bigtam`), but the runners are registered as `yuzu-bigtam-linux-*`, and that work hasn't promoted to main. Since the cron reads main, the drift won't clear until corrected inventory is on main. A companion PR corrects the names on **dev** so the branches agree on the next promotion.

## Validation

- `runner-inventory.json` parses; declared names == GitHub `/actions/runners` (verified).
- No workflow references the removed `scw-eager-lumiere` or its `yuzu-cloud-builder` label in `runs-on`/gating (grep clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
