### PR TITLE
ci(runners): correct Big Tam runner names/labels to match registration

### DIFF
--- a/.github/runner-inventory.json
+++ b/.github/runner-inventory.json
@@ -17,31 +17,31 @@
       "installed": "2026-04-14"
     },
     {
-      "name": "yuzu-bigtam-0",
-      "host": "BigTam (Threadripper 9970X, native Ubuntu 26.04)",
-      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam"],
-      "role": "Linux CI pool (shared label yuzu-bigtam) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
+      "name": "yuzu-bigtam-linux-0",
+      "host": "Big Tam (Threadripper 9970X, native Ubuntu 26.04)",
+      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam-linux"],
+      "role": "Linux CI pool (shared label yuzu-bigtam-linux) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
       "installed": "2026-06-19"
     },
     {
-      "name": "yuzu-bigtam-1",
-      "host": "BigTam (Threadripper 9970X, native Ubuntu 26.04)",
-      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam"],
-      "role": "Linux CI pool (shared label yuzu-bigtam) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
+      "name": "yuzu-bigtam-linux-1",
+      "host": "Big Tam (Threadripper 9970X, native Ubuntu 26.04)",
+      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam-linux"],
+      "role": "Linux CI pool (shared label yuzu-bigtam-linux) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
       "installed": "2026-06-19"
     },
     {
-      "name": "yuzu-bigtam-2",
-      "host": "BigTam (Threadripper 9970X, native Ubuntu 26.04)",
-      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam"],
-      "role": "Linux CI pool (shared label yuzu-bigtam) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
+      "name": "yuzu-bigtam-linux-2",
+      "host": "Big Tam (Threadripper 9970X, native Ubuntu 26.04)",
+      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam-linux"],
+      "role": "Linux CI pool (shared label yuzu-bigtam-linux) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
       "installed": "2026-06-19"
     },
     {
-      "name": "yuzu-bigtam-3",
-      "host": "BigTam (Threadripper 9970X, native Ubuntu 26.04)",
-      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam"],
-      "role": "Linux CI pool (shared label yuzu-bigtam) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
+      "name": "yuzu-bigtam-linux-3",
+      "host": "Big Tam (Threadripper 9970X, native Ubuntu 26.04)",
+      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam-linux"],
+      "role": "Linux CI pool (shared label yuzu-bigtam-linux) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
       "installed": "2026-06-19"
     }
   ]


### PR DESCRIPTION
## Summary

PR #1586 declared the Big Tam Linux pool as `yuzu-bigtam-0..3` (label `yuzu-bigtam`), but the runners are actually registered with GitHub as `yuzu-bigtam-linux-0..3` (label `yuzu-bigtam-linux`), following the `yuzu-<box>-<os>-N` convention. The mismatch trips the sentinel both ways — `MISSING` for the expected `yuzu-bigtam-*` and `UNKNOWN` for the live `yuzu-bigtam-linux-*` (`strict_unknown_runners: true`).

This renames the four entries to match the live registration.

## What changed

`.github/runner-inventory.json` only — the four Big Tam entries:
- `name`: `yuzu-bigtam-N` → `yuzu-bigtam-linux-N`
- label: `yuzu-bigtam` → `yuzu-bigtam-linux`
- `host` text tidy: `BigTam` → `Big Tam`

## Relationship to the main hotfix (#1587)

The sentinel cron evaluates **main**, so #1587 corrects `main` directly to stop the every-30-min drift issues now. This PR fixes the same names on **dev** (the source of truth) so the two branches agree — after both land, `dev` and `main` have **identical** `runner-inventory.json`, and the next dev→main promotion is a no-op on this file.

## Validation

- Parses; declared names == GitHub `/actions/runners` (verified).
- Pure rename, 16/16 lines; no `runs-on`/gating references the old `yuzu-bigtam` label (the Linux pool gate keys on the `[self-hosted, Linux, X64]` set, per #1586).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
