### PR TITLE
ci(runners): pool-gate the Windows job + register Wee Tam Windows pool

### DIFF
--- a/.github/runner-inventory.json
+++ b/.github/runner-inventory.json
@@ -43,6 +43,34 @@
       "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam-linux"],
       "role": "Linux CI pool (shared label yuzu-bigtam-linux) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
       "installed": "2026-06-19"
+    },
+    {
+      "name": "yuzu-weetam-windows-0",
+      "host": "Wee Tam (Threadripper 9970X, native Windows 11)",
+      "labels": ["self-hosted", "Windows", "X64", "yuzu-weetam-windows"],
+      "role": "Windows MSVC CI pool (shared label yuzu-weetam-windows) — ci.yml windows matrix (release + debug), codeql Windows leg. Replaces yuzu-local-windows after the Shulgi cutover.",
+      "installed": "2026-06-20"
+    },
+    {
+      "name": "yuzu-weetam-windows-1",
+      "host": "Wee Tam (Threadripper 9970X, native Windows 11)",
+      "labels": ["self-hosted", "Windows", "X64", "yuzu-weetam-windows"],
+      "role": "Windows MSVC CI pool (shared label yuzu-weetam-windows) — ci.yml windows matrix (release + debug), codeql Windows leg. Replaces yuzu-local-windows after the Shulgi cutover.",
+      "installed": "2026-06-20"
+    },
+    {
+      "name": "yuzu-weetam-windows-2",
+      "host": "Wee Tam (Threadripper 9970X, native Windows 11)",
+      "labels": ["self-hosted", "Windows", "X64", "yuzu-weetam-windows"],
+      "role": "Windows MSVC CI pool (shared label yuzu-weetam-windows) — ci.yml windows matrix (release + debug), codeql Windows leg. Replaces yuzu-local-windows after the Shulgi cutover.",
+      "installed": "2026-06-20"
+    },
+    {
+      "name": "yuzu-weetam-windows-3",
+      "host": "Wee Tam (Threadripper 9970X, native Windows 11)",
+      "labels": ["self-hosted", "Windows", "X64", "yuzu-weetam-windows"],
+      "role": "Windows MSVC CI pool (shared label yuzu-weetam-windows) — ci.yml windows matrix (release + debug), codeql Windows leg. Replaces yuzu-local-windows after the Shulgi cutover.",
+      "installed": "2026-06-20"
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,10 @@ jobs:
       # true iff >=1 eligible Linux runner (any yuzu-bigtam-* OR the yuzu-wsl2-linux
       # Shulgi fallback) is online. Replaces the old single-named yuzu_wsl2_linux gate.
       linux_pool_healthy: ${{ steps.health.outputs.linux_pool_healthy }}
+      # Pool gate for the [self-hosted, Windows, X64] job: true iff >=1 eligible
+      # Windows runner (any yuzu-weetam-windows-* OR the yuzu-local-windows Shulgi
+      # fallback) is online. Replaces the old single-named yuzu_local_windows gate.
+      windows_pool_healthy: ${{ steps.health.outputs.windows_pool_healthy }}
       yuzu_wsl2_linux_healthy: ${{ steps.health.outputs.yuzu_wsl2_linux_healthy }}
       yuzu_local_windows_healthy: ${{ steps.health.outputs.yuzu_local_windows_healthy }}
       all_healthy: ${{ steps.health.outputs.all_healthy }}
@@ -391,9 +395,10 @@ jobs:
   windows:
     name: "Windows MSVC ${{ matrix.build_type }}"
     needs: [preflight]
-    # PR-7 of CI overhaul plan: skip if the self-hosted Windows runner
-    # is unhealthy or unknown. Fail-closed `== 'true'`.
-    if: needs.preflight.outputs.yuzu_local_windows_healthy == 'true'
+    # Skip if the self-hosted Windows job pool is unhealthy/empty. Fail-closed
+    # `== 'true'`. Pool-gated (yuzu-weetam-windows-* or the yuzu-local-windows
+    # Shulgi fallback) — mirrors the Linux pool gate.
+    if: needs.preflight.outputs.windows_pool_healthy == 'true'
     # Self-hosted: 32-core / 48 GB host. gRPC alone takes ~90 min on the
     # GitHub-hosted 4-vCPU windows-2022 runners; self-hosted with cl /MP
     # finishes in a fraction of that and avoids the GitHub Actions minute

--- a/scripts/ci/runner-health-check.py
+++ b/scripts/ci/runner-health-check.py
@@ -17,7 +17,9 @@ Two consumers (do not duplicate the logic):
    [self-hosted, Linux, X64] job pool is online (see LINUX_POOL_LABELS). The
    proto-compat + linux jobs gate on the pool rather than a single named runner,
    so any free pool member (yuzu-bigtam-* or the Shulgi fallback) keeps them
-   running, while a wholly-offline pool still skips them fast.
+   running, while a wholly-offline pool still skips them fast. Likewise emits
+   `windows_pool_healthy` for the [self-hosted, Windows, X64] pool — the windows
+   job gates on it (yuzu-weetam-windows-* or the yuzu-local-windows fallback).
 
 The fall-closed contract is intentional: a degraded sentinel must NOT
 silently accept "I don't know" as healthy. Always check `== 'true'`,
@@ -56,12 +58,27 @@ INVENTORY_PATH = ".github/runner-inventory.json"
 # emitted unchanged (the sentinel and any pinned-runner gates rely on them).
 LINUX_POOL_LABELS = frozenset({"self-hosted", "Linux", "X64"})
 
+# The self-hosted Windows job pool — ci.yml's windows job uses
+# runs-on: [self-hosted, Windows, X64]. Same pool-gating treatment as Linux:
+# `windows_pool_healthy=true` iff >=1 eligible runner is online. Includes Shulgi
+# (yuzu-local-windows) as a fallback during the Wee Tam cutover; it drops out of
+# the pool when removed from the inventory, leaving the yuzu-weetam-windows-* runners.
+WINDOWS_POOL_LABELS = frozenset({"self-hosted", "Windows", "X64"})
+
 
 def linux_pool_members(expected: dict[str, Any]) -> list[str]:
     """Declared runners eligible for the [self-hosted, Linux, X64] job pool."""
     return [
         name for name, exp in expected.items()
         if LINUX_POOL_LABELS.issubset(set(exp["labels"]))
+    ]
+
+
+def windows_pool_members(expected: dict[str, Any]) -> list[str]:
+    """Declared runners eligible for the [self-hosted, Windows, X64] job pool."""
+    return [
+        name for name, exp in expected.items()
+        if WINDOWS_POOL_LABELS.issubset(set(exp["labels"]))
     ]
 
 
@@ -179,6 +196,7 @@ def main() -> int:
         for name in expected:
             write_output(f"{slug(name)}_healthy", "true")
         write_output("linux_pool_healthy", "true")
+        write_output("windows_pool_healthy", "true")
         write_output("all_healthy", "true")
         return 0
 
@@ -189,6 +207,7 @@ def main() -> int:
             for name in expected:
                 write_output(f"{slug(name)}_healthy", "false")
             write_output("linux_pool_healthy", "false")
+            write_output("windows_pool_healthy", "false")
             write_output("all_healthy", "false")
             return 0
         return 1
@@ -253,6 +272,9 @@ def main() -> int:
         pool = linux_pool_members(expected)
         pool_ok = any(healthy_map.get(n, False) for n in pool)
         write_output("linux_pool_healthy", "true" if pool_ok else "false")
+        win_pool = windows_pool_members(expected)
+        win_ok = any(healthy_map.get(n, False) for n in win_pool)
+        write_output("windows_pool_healthy", "true" if win_ok else "false")
         write_output("all_healthy", "true" if all_healthy else "false")
         if drift:
             print("=== HEALTH ISSUES (preflight mode — non-fatal) ===")


### PR DESCRIPTION
## Summary

Mirror of #1586 for Windows. Registers the 4 **Wee Tam** Windows runners (`yuzu-weetam-windows-0..3`) and moves the ci.yml windows job from the single-named `yuzu_local_windows_healthy` gate to **pool gating** on `windows_pool_healthy` (`[self-hosted, Windows, X64]`).

## ⚠️ Merge-coordination (fail-closed infra)

`runner-inventory-sentinel` compares GitHub's `/actions/runners` to `runner-inventory.json` every ~30 min (`strict_unknown_runners: true`). **Merge this in lockstep with registering the 4 runners on Wee Tam** — not before. Merged first → `MISSING yuzu-weetam-windows-N`; registered first → `UNKNOWN`. Don't start the runners from here — that's the manual cutover on the box.

## Changes

- **`scripts/ci/runner-health-check.py`**: `WINDOWS_POOL_LABELS` + `windows_pool_members()`; emit `windows_pool_healthy` in all three preflight paths (fork-PR, PAT-fail, normal). Per-runner `<slug>_healthy` outputs + the sentinel drift path unchanged.
- **`.github/workflows/ci.yml`**: add `windows_pool_healthy` to preflight outputs; the windows job gates on it instead of `yuzu_local_windows_healthy`. `runs-on` unchanged.
- **`.github/runner-inventory.json`**: add `yuzu-weetam-windows-0..3` (labels `self-hosted,Windows,X64,yuzu-weetam-windows`; host Wee Tam).

Shulgi's `yuzu-local-windows` stays in the pool as a fallback during cutover and drops out automatically when later removed from the inventory (a one-line follow-up). Persistent runners for now; ephemeral migration tracked in #1595.

## Validation

- `runner-inventory.json` parses; windows pool members = `[yuzu-local-windows, yuzu-weetam-windows-0..3]`, linux pool unchanged.
- `runner-health-check.py` compiles; preflight emits `windows_pool_healthy` (verified via the fork-PR path).
- ci.yml valid YAML; codeql.yml has no health-gated Windows leg (so no flip needed there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
