### PR TITLE
ci(runners): add Wee Tam Windows pool to main inventory (cutover)

### DIFF
--- a/.github/runner-inventory.json
+++ b/.github/runner-inventory.json
@@ -43,6 +43,34 @@
       "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam-linux"],
       "role": "Linux CI pool (shared label yuzu-bigtam-linux) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
       "installed": "2026-06-19"
+    },
+    {
+      "name": "yuzu-weetam-windows-0",
+      "host": "Wee Tam (Threadripper 9970X, native Windows 11)",
+      "labels": ["self-hosted", "Windows", "X64", "yuzu-weetam-windows"],
+      "role": "Windows MSVC CI pool (shared label yuzu-weetam-windows) — ci.yml windows matrix (release + debug), codeql Windows leg. Replaces yuzu-local-windows after the Shulgi cutover.",
+      "installed": "2026-06-20"
+    },
+    {
+      "name": "yuzu-weetam-windows-1",
+      "host": "Wee Tam (Threadripper 9970X, native Windows 11)",
+      "labels": ["self-hosted", "Windows", "X64", "yuzu-weetam-windows"],
+      "role": "Windows MSVC CI pool (shared label yuzu-weetam-windows) — ci.yml windows matrix (release + debug), codeql Windows leg. Replaces yuzu-local-windows after the Shulgi cutover.",
+      "installed": "2026-06-20"
+    },
+    {
+      "name": "yuzu-weetam-windows-2",
+      "host": "Wee Tam (Threadripper 9970X, native Windows 11)",
+      "labels": ["self-hosted", "Windows", "X64", "yuzu-weetam-windows"],
+      "role": "Windows MSVC CI pool (shared label yuzu-weetam-windows) — ci.yml windows matrix (release + debug), codeql Windows leg. Replaces yuzu-local-windows after the Shulgi cutover.",
+      "installed": "2026-06-20"
+    },
+    {
+      "name": "yuzu-weetam-windows-3",
+      "host": "Wee Tam (Threadripper 9970X, native Windows 11)",
+      "labels": ["self-hosted", "Windows", "X64", "yuzu-weetam-windows"],
+      "role": "Windows MSVC CI pool (shared label yuzu-weetam-windows) — ci.yml windows matrix (release + debug), codeql Windows leg. Replaces yuzu-local-windows after the Shulgi cutover.",
+      "installed": "2026-06-20"
     }
   ]
 }


### PR DESCRIPTION
## Summary

The 4 Wee Tam Windows runners `yuzu-weetam-windows-0..3` are **registered and online** (each CCD-pinned). The `runner-inventory-sentinel` cron evaluates `main`, so main's `runner-inventory.json` must list them or it flags `UNKNOWN` drift within ~30 min.

## What changed

`.github/runner-inventory.json` only — adds `yuzu-weetam-windows-0..3` (labels `self-hosted,Windows,X64,yuzu-weetam-windows`). After this, declared == live: `wsl2-linux, local-windows, bigtam-linux-0..3, weetam-windows-0..3` (verified).

## Relationship to #1596

Mirrors #1587 for Big Tam. The full change — `windows_pool_healthy` pool-gating + the ci.yml Windows gate flip — lands on **dev** via **#1596**. This inventory-only hotfix keeps **main**'s cron green during the cutover; after both land, dev and main inventory are identical.

Inventory-only and in `ci.yml`'s `paths-ignore`, so it triggers no build matrix. Merge alongside #1596 to complete the cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
