### PR TITLE
ci(windows): cap Build -j to the runner's pinned CCD width

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -578,7 +578,12 @@ jobs:
             ${{ matrix.build_type == 'release' && '-Db_lto=true' || '' }}
 
       - name: Build
-        run: meson compile -C build-windows-${{ matrix.build_type }}
+        # -j is capped to the runner's pinned CCD width via $YUZU_BUILD_JOBS,
+        # exported only by the Wee Tam pin-wrapper (Shulgi is unpinned and omits
+        # it, keeping ninja's default). Without the cap, ninja sizes -j from the
+        # 64-CPU system count and oversubscribes the 16-thread CCD, thrashing the
+        # very L3 the pinning exists to keep hot.
+        run: meson compile -C build-windows-${{ matrix.build_type }} ${YUZU_BUILD_JOBS:+-j $YUZU_BUILD_JOBS}
 
       # Link-provenance assertion (#1331 review HIGH-2): on Windows libpq is
       # DELIBERATELY dynamic (triplet static override = grpc stack only; the


### PR DESCRIPTION
## Summary

Caps the Windows **Build** step's `-j` to the runner's pinned CCD width.

## Why

The Wee Tam Windows runners are each hard-pinned to one CCD (16 threads). But ninja sizes `-j` from the **64-CPU system count** — it ignores the process affinity mask (confirmed: `nproc` isn't installed, and `NUMBER_OF_PROCESSORS` + .NET `ProcessorCount` both report 64 regardless of affinity). So it launches ~66 compilers onto 16 threads, thrashing the single 32 MB L3 the pinning exists to keep hot. A cold-cache release build on Wee Tam ran **98 min** and hit the 120-min job timeout at `[625/626]` — the build itself is clean (zero compile errors), it just couldn't finish in time.

## Change

The Windows Build step now runs:
```
meson compile -C build-windows-${{ matrix.build_type }} ${YUZU_BUILD_JOBS:+-j $YUZU_BUILD_JOBS}
```
The Wee Tam pin-wrapper exports `YUZU_BUILD_JOBS=16` (the CCD thread count). **Opt-in**: `yuzu-local-windows` (Shulgi, unpinned) doesn't set it → bash `${VAR:+...}` expands to nothing → ninja's default, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
