### PR TITLE
ci(windows): codify the Windows toolchain + de-hardcode the gateway build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,7 +478,7 @@ jobs:
           # a specific error rather than producing weird build failures.
           for tool in meson ninja cl ccache cmake python; do
             if ! command -v "$tool" >/dev/null 2>&1; then
-              echo "::error::$tool not on PATH on yuzu-local-windows runner"
+              echo "::error::$tool not on PATH on the self-hosted Windows runner"
               exit 1
             fi
           done
@@ -493,6 +493,20 @@ jobs:
           # cannot inject a malicious wheel (Gate 7 re-review LOW).
           python -c "import yaml" >/dev/null 2>&1 || \
             python -m pip install --user --require-hashes -r requirements-ci.txt
+
+      - name: Assert toolchain manifest (self-hosted, optional)
+        shell: pwsh
+        run: |
+          # Manifest-based self-test for boxes provisioned via
+          # deploy/windows/Provision-Windows-Runner.ps1. SKIPS (does not fail) on
+          # runners that predate the manifest — the PATH check above still covers
+          # them. Catches path/version/env drift the bare PATH check misses.
+          $m = 'C:\actions-runner\toolchain-manifest.json'
+          if (Test-Path $m) {
+            ./deploy/windows/Assert-Toolchain.ps1 -ManifestPath $m
+          } else {
+            Write-Host 'no toolchain-manifest.json on this runner — skipping manifest self-test'
+          }
 
       - name: Assert runner disk (>= 45 GB free)
         run: |
@@ -648,9 +662,38 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
-      - name: ccache stats
+      - name: ccache stats + build observability
         if: always()
-        run: ccache -s
+        run: |
+          # Informational only — never fail the job from here (set +e).
+          set +e
+          ccache -s
+          # Machine-readable parse for a job-summary: cache warmth + effective
+          # parallelism + LTO. Surfaces cold/fragmented caches and -j
+          # oversubscription automatically, instead of only by hand (P3).
+          s="$(ccache --print-stats 2>/dev/null)"
+          get(){ printf '%s\n' "$s" | awk -F'\t' -v k="$1" '$1==k{v=$2} END{print v+0}'; }
+          hits=$(( $(get direct_cache_hit) + $(get preprocessed_cache_hit) ))
+          miss=$(get cache_miss)
+          total=$(( hits + miss ))
+          rate="n/a"; [ "$total" -gt 0 ] && rate=$(( 100 * hits / total ))
+          {
+            echo "### Windows ${{ matrix.build_type }} — cache & parallelism"
+            echo ""
+            echo "| metric | value |"
+            echo "|---|---|"
+            echo "| ccache hit rate | ${rate}% (${hits}/${total}) |"
+            echo "| ccache misses | ${miss} |"
+            echo "| effective -j | ${YUZU_BUILD_JOBS:-ninja default} |"
+            echo "| LTO | ${{ matrix.build_type == 'release' && 'yes (link-time, ccache cannot accelerate)' || 'no' }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          # Cold-cache alarm: a near-zero hit rate over a meaningful sample on a
+          # self-hosted runner means the shared caches aren't warming (the
+          # fragmentation signal we previously only caught manually).
+          if [ "$total" -gt 100 ] && [ "$rate" != "n/a" ] && [ "$rate" -lt 40 ]; then
+            echo "::warning::ccache hit rate ${rate}% over ${total} compiles is low on a self-hosted runner — caches may be cold/fragmented (see deploy/windows/README.md: shared RUNNER_TOOL_CACHE)"
+          fi
+          exit 0
 
   # ── macOS (Apple Clang) ────────────────────────────────────────────────
   macos:

--- a/.github/workflows/vcpkg-baseline-update.yml
+++ b/.github/workflows/vcpkg-baseline-update.yml
@@ -87,6 +87,7 @@ jobs:
             deploy/docker/Dockerfile.ci-linux
             deploy/docker/Dockerfile.runner-linux
             deploy/docker/Dockerfile.ci
+            deploy/windows/Provision-Windows-Runner.ps1
           )
           # sed -i works because SHAs are globally unique 40-char strings.
           sed -i "s/${old}/${new}/g" "${files[@]}"
@@ -127,6 +128,7 @@ jobs:
             - `deploy/docker/Dockerfile.ci-linux` `VCPKG_COMMIT` ARG
             - `deploy/docker/Dockerfile.runner-linux` `VCPKG_COMMIT` ARG
             - `deploy/docker/Dockerfile.ci` `VCPKG_COMMIT` ENV
+            - `deploy/windows/Provision-Windows-Runner.ps1` `$VcpkgBaseline` param
 
             CI will re-resolve every vcpkg port against the new baseline. If
             any downstream port now fails to build, **revert this PR** and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,8 @@ Use `scripts/setup.sh` (auto-picks the dir) or pass `-C build-<os>` to `meson co
 
 `docs/windows-build.md` is the source of truth — MSYS2 bash sequence, the `setup_msvc_env.sh` + `scripts/ensure-erlang.sh` activation pair, full path inventory, and the two hard rules: **never use `vcvars64.bat`** (extension exit-1 corrupts wrappers) and **never Clang from `C:\Program Files\LLVM\bin`** (must be cl.exe/MSVC). `cross-platform` and `build-ci` agents load this on any Windows-touching change.
 
+**Provisioning a native Windows CI runner** is codified in `deploy/windows/` (the analog of `deploy/docker/Dockerfile.ci-linux`): a versioned provisioning spec, a `toolchain-manifest.json`, a runner self-test, and the CCD-pin wrapper. The gateway build resolves its toolchain from `YUZU_ESCRIPT`/`YUZU_REBAR3` (no hardcoded host paths — `scripts/build_gateway.py`), and the 4 CCD-pinned runners share one vcpkg binary cache via `RUNNER_TOOL_CACHE`. See `deploy/windows/README.md`.
+
 ### Cross-compilation
 ```bash
 ./scripts/setup.sh --cross-file meson/cross/aarch64-linux-gnu.ini

--- a/deploy/docker/Dockerfile.runner-linux
+++ b/deploy/docker/Dockerfile.runner-linux
@@ -20,7 +20,7 @@ FROM ghcr.io/actions/actions-runner:latest@sha256:08c30b0a7105f64bddfc485d2487a2
 
 USER root
 
-ARG MESON_VERSION=1.9.2
+ARG MESON_VERSION=1.11.1
 ARG VCPKG_COMMIT=4b77da7fed37817f124936239197833469f1b9a8
 
 # ── Build tools (mirrors Dockerfile.ci-linux) ─────────────────────────

--- a/deploy/windows/Assert-Toolchain.ps1
+++ b/deploy/windows/Assert-Toolchain.ps1
@@ -1,0 +1,71 @@
+<#
+  Assert-Toolchain.ps1 — runner self-test. Verifies that the toolchain manifest
+  emitted by Provision-Windows-Runner.ps1 still holds: every required tool is
+  present at its recorded path and every contract env var is set.
+
+  Run it (a) at the end of provisioning, and (b) as a registration / preflight
+  gate, so a mis-provisioned box fails in SECONDS rather than 90 minutes into a
+  build. This is the catch for the cutover faults (toolchain off PATH, MSYS2
+  /usr/bin missing, gateway escript/rebar3 unresolved).
+
+  Exit 0 = healthy; exit 1 = at least one required tool/env missing.
+#>
+[CmdletBinding()]
+param(
+  [string]$ManifestPath = 'C:\actions-runner\toolchain-manifest.json'
+)
+$ErrorActionPreference = 'Stop'
+
+if(-not (Test-Path $ManifestPath)){
+  Write-Host "FAIL: no manifest at $ManifestPath — run Provision-Windows-Runner.ps1 first." -ForegroundColor Red
+  exit 1
+}
+$m = Get-Content $ManifestPath -Raw | ConvertFrom-Json
+$fail = 0
+
+Write-Host "Toolchain manifest: $ManifestPath" -ForegroundColor Cyan
+Write-Host ("  host=$($m.host)  generated=$($m.generated)")
+
+Write-Host "`n-- tools --"
+foreach($t in $m.tools){
+  $ok = $t.path -and (Test-Path -LiteralPath $t.path)
+  $req = if($t.required){ 'required' } else { 'optional' }
+  if($ok){
+    Write-Host ("  [OK]   {0,-11} {1}  ({2})" -f $t.name, $t.path, ($t.version ?? '?')) -ForegroundColor Green
+  } elseif($t.required){
+    Write-Host ("  [MISS] {0,-11} {1}" -f $t.name, ($t.path ?? '<unset>')) -ForegroundColor Red
+    $fail++
+  } else {
+    Write-Host ("  [warn] {0,-11} {1} (optional)" -f $t.name, ($t.path ?? '<unset>')) -ForegroundColor Yellow
+  }
+}
+
+# Contract env vars must be visible to a freshly-launched process. Check the live
+# machine registry (what Start-PinnedRunner.ps1 refreshes into the runner).
+Write-Host "`n-- env (machine) --"
+foreach($k in $m.env.PSObject.Properties.Name){
+  $live = [Environment]::GetEnvironmentVariable($k,'Machine')
+  if($live){
+    Write-Host ("  [OK]   {0,-22} {1}" -f $k, $live) -ForegroundColor Green
+  } else {
+    Write-Host ("  [MISS] {0,-22} (expected {1})" -f $k, $m.env.$k) -ForegroundColor Red
+    $fail++
+  }
+}
+
+# MSYS2 coreutils must be reachable the way the CI bash scripts use them
+# (full path); this is the `head: command not found` regression guard.
+$bash = ($m.tools | Where-Object name -eq 'msys2_bash').path
+if($bash -and (Test-Path $bash)){
+  $head = & $bash --noprofile --norc -c 'command -v head' 2>$null
+  if($head){ Write-Host "`n  [OK]   msys2 bash resolves coreutils (head=$head)" -ForegroundColor Green }
+  else     { Write-Host "`n  [MISS] msys2 bash cannot resolve 'head'" -ForegroundColor Red; $fail++ }
+}
+
+if($fail -eq 0){
+  Write-Host "`nPASS: toolchain healthy." -ForegroundColor Green
+  exit 0
+} else {
+  Write-Host "`nFAIL: $fail required item(s) missing — fix before registering this runner." -ForegroundColor Red
+  exit 1
+}

--- a/deploy/windows/Provision-Windows-Runner.ps1
+++ b/deploy/windows/Provision-Windows-Runner.ps1
@@ -1,0 +1,239 @@
+#Requires -RunAsAdministrator
+<#
+  Provision-Windows-Runner.ps1 — versioned, idempotent spec for a Yuzu native
+  Windows CI build host. This is the Windows analog of
+  deploy/docker/Dockerfile.ci-linux: the single source of truth for what a
+  Windows runner's toolchain must contain. Run it on a fresh box (or re-run to
+  reconcile) and you get a runner that matches every other Windows runner —
+  no per-host archaeology.
+
+  RUN IN AN ELEVATED PowerShell 7 (pwsh) SESSION over RDP / console. winget's
+  source catalog does not work over headless SSH, so this is hand-run, not
+  agent-run.
+
+  What it does:
+    - installs the pinned toolchain (Python+Meson+Ninja, Git, CMake, ccache,
+      MSYS2, Erlang/OTP + rebar3, VS 2022 Build Tools C++ workload,
+      PostgreSQL, vcpkg @ pinned baseline);
+    - sets machine env + PATH, INCLUDING the de-Shulgi-ified gateway contract
+      (YUZU_ESCRIPT / YUZU_REBAR3 — scripts/build_gateway.py reads these instead
+      of assuming a C:\Erlang junction + Chocolatey path) and the shared CI
+      cache location (RUNNER_TOOL_CACHE -> one machine-level dir so the 4
+      CCD-pinned runners share ONE vcpkg binary cache instead of fragmenting it
+      4x; mirrors CCACHE_DIR);
+    - emits a machine-readable toolchain manifest that
+      deploy/windows/Assert-Toolchain.ps1 (the runner self-test) verifies at
+      registration, so a mis-provisioned box fails in seconds, not 90 min into
+      a build.
+
+  After this, register the runners + the CCD-pin wrapper — see
+  deploy/windows/README.md and deploy/windows/Start-PinnedRunner.ps1.
+#>
+[CmdletBinding()]
+param(
+  # --- pinned toolchain versions (the "spec"); bump deliberately ---
+  [string]$PythonVersion   = '3.14.6',
+  [string]$MesonVersion    = '1.11.1',   # CLAUDE.md build minimum
+  [string]$ErlangVersion   = '28.4.2',
+  [string]$Rebar3Version   = '3.24.0',
+  [string]$PostgresVersion = '18.4',
+  [string]$VcpkgBaseline   = '4b77da7fed37817f124936239197833469f1b9a8',  # == vcpkg.json builtin-baseline
+
+  # --- machine layout (conventions; keep in sync with Start-PinnedRunner.ps1) ---
+  [string]$CacheRoot       = 'D:\ci',     # ccache + shared tool_cache live here (fast data drive)
+  [string]$Rebar3Dir       = 'C:\tools\rebar3',
+  [string]$VcpkgRoot       = 'C:\vcpkg',
+  [string]$Msys2Root       = 'C:\msys64',
+  [int]   $PostgresPort    = 5433,
+  [string]$ManifestPath    = 'C:\actions-runner\toolchain-manifest.json'
+)
+$ErrorActionPreference = 'Continue'
+$ProgressPreference    = 'SilentlyContinue'
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+New-Item -ItemType Directory -Force 'C:\ProvisionLogs' | Out-Null
+Start-Transcript -Path "C:\ProvisionLogs\provision-$(Get-Date -Format yyyyMMdd-HHmmss).log" | Out-Null
+
+function Step([string]$name,[scriptblock]$body){
+  Write-Host "`n===== $name =====" -ForegroundColor Cyan
+  try   { & $body; Write-Host "[OK]  $name" -ForegroundColor Green }
+  catch { Write-Host "[FAIL] $name :: $($_.Exception.Message)" -ForegroundColor Red }
+}
+function WG([string]$id,[string]$ver='',[string]$override='',[string]$scope='machine'){
+  $a=@('install','--id',$id,'-e','--source','winget','--accept-source-agreements','--accept-package-agreements','--disable-interactivity')
+  if($ver)     { $a+=@('--version',$ver) }
+  if($scope)   { $a+=@('--scope',$scope) }
+  if($override){ $a+=@('--override',$override) }
+  Write-Host ("winget " + ($a -join ' '))
+  winget @a
+}
+function Add-MachinePath([string]$dir){
+  if(-not (Test-Path $dir)){ return }
+  $p=[Environment]::GetEnvironmentVariable('Path','Machine')
+  if($p -notmatch [regex]::Escape($dir)){
+    [Environment]::SetEnvironmentVariable('Path', ($p.TrimEnd(';')+';'+$dir), 'Machine')
+    Write-Host "PATH (machine) += $dir"
+  }
+}
+function Set-MachineEnv([string]$k,[string]$v){ [Environment]::SetEnvironmentVariable($k,$v,'Machine'); Write-Host "$k = $v" }
+function Find-RealEscript {
+  # The real erts escript.exe (NOT the top-level launcher stub — see
+  # scripts/build_gateway.py for why). Search common OTP install roots.
+  $roots = @('C:\Erlang') + (Get-ChildItem 'C:\Program Files' -Directory -EA SilentlyContinue |
+            Where-Object { $_.Name -like 'Erlang*' -or $_.Name -like 'erl*' } | ForEach-Object FullName)
+  foreach($r in $roots){
+    $e = Get-ChildItem $r -Filter escript.exe -Recurse -EA SilentlyContinue |
+         Where-Object { $_.DirectoryName -match 'erts-' } | Select-Object -First 1
+    if($e){ return $e.FullName }
+  }
+  return $null
+}
+
+Step 'winget sanity' { "winget " + (winget --version) }
+
+Step 'Python + Meson + Ninja + PyYAML' {
+  # PyYAML is a HARD configure-time dep (embed_content.py); install it apt-style.
+  if(-not (Get-Command python -EA SilentlyContinue)){ WG -id 'Python.Python.3.14' -ver $PythonVersion }
+  $py = (Get-Command python -EA SilentlyContinue).Source
+  if($py){
+    & $py -m pip install --upgrade pip | Out-Null
+    & $py -m pip install "meson==$MesonVersion" ninja pyyaml | Out-Null
+  } else { throw 'python not found after install' }
+}
+
+Step 'Git + CMake' {
+  if(-not (Get-Command git   -EA SilentlyContinue)){ WG -id 'Git.Git' }
+  if(-not (Get-Command cmake -EA SilentlyContinue)){ WG -id 'Kitware.CMake' }
+}
+
+Step 'ccache' {
+  if(Get-Command ccache -EA SilentlyContinue){ 'already on PATH' } else { WG -id 'ccache.ccache' }
+}
+
+Step "MSYS2 (CI shell = $Msys2Root\usr\bin\bash.exe)" {
+  if(-not (Test-Path "$Msys2Root\usr\bin\bash.exe")){ WG -id 'MSYS2.MSYS2' }
+  if(Test-Path "$Msys2Root\usr\bin\bash.exe"){ 'bash present' } else { throw "MSYS2 not at $Msys2Root" }
+}
+
+Step "Erlang/OTP $ErlangVersion" {
+  $erl = Get-ChildItem 'C:\Program Files\Erlang*','C:\Program Files\erl*' -Filter erl.exe -Recurse -EA SilentlyContinue | Select-Object -First 1
+  if(-not $erl){ WG -id 'Erlang.ErlangOTP' -ver $ErlangVersion
+                 $erl = Get-ChildItem 'C:\Program Files\Erlang*','C:\Program Files\erl*' -Filter erl.exe -Recurse -EA SilentlyContinue | Select-Object -First 1 }
+  if($erl){ Add-MachinePath $erl.DirectoryName; "erl: $($erl.FullName)" } else { throw 'erl.exe not found after install' }
+}
+
+Step "rebar3 $Rebar3Version (de-Shulgi-ified: env vars, NOT a C:\Erlang junction)" {
+  New-Item -ItemType Directory -Force $Rebar3Dir | Out-Null
+  if(-not (Test-Path "$Rebar3Dir\rebar3")){
+    Invoke-WebRequest -UseBasicParsing "https://github.com/erlang/rebar3/releases/download/$Rebar3Version/rebar3" -OutFile "$Rebar3Dir\rebar3"
+  }
+  Set-Content "$Rebar3Dir\rebar3.cmd" '@escript "%~dp0rebar3" %*' -Encoding Ascii
+  Add-MachinePath $Rebar3Dir
+  # scripts/build_gateway.py resolves the gateway toolchain from these env vars
+  # (YUZU_ESCRIPT / YUZU_REBAR3), so we no longer replicate Shulgi's C:\Erlang
+  # junction or the Chocolatey rebar3 path. THIS is the de-hardcoding fix (B1).
+  $escript = Find-RealEscript
+  if(-not $escript){ throw 'real erts escript.exe not found' }
+  Set-MachineEnv 'YUZU_ESCRIPT' $escript
+  Set-MachineEnv 'YUZU_REBAR3'  "$Rebar3Dir\rebar3"
+  "escript: $escript ; rebar3: $Rebar3Dir\rebar3"
+}
+
+Step 'VS 2022 Build Tools (C++ workload)' {
+  $vsw="${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+  $have = (Test-Path $vsw) -and (& $vsw -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath)
+  if($have){ "already: $have" }
+  else { WG -id 'Microsoft.VisualStudio.2022.BuildTools' -scope '' `
+            -override '--quiet --wait --norestart --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended' }
+}
+
+Step "PostgreSQL $PostgresVersion (service :$PostgresPort, role yuzu, db yuzu_test)" {
+  $major = $PostgresVersion.Split('.')[0]
+  $pgbin = "C:\Program Files\PostgreSQL\$major\bin"
+  if(-not (Test-Path "$pgbin\psql.exe")){
+    WG -id "PostgreSQL.PostgreSQL.$major" -ver $PostgresVersion -scope '' `
+       -override "--mode unattended --unattendedmodeui none --superpassword postgres --servicename postgresql-x64-$major-yuzu-ci --serverport $PostgresPort"
+  }
+  if(-not (Test-Path "$pgbin\psql.exe")){ throw "psql not found at $pgbin" }
+  $svc = "postgresql-x64-$major-yuzu-ci"
+  $deadline=(Get-Date).AddSeconds(90)
+  while(((Get-Service $svc -EA SilentlyContinue).Status -ne 'Running') -and ((Get-Date) -lt $deadline)){ Start-Sleep 2 }
+  $env:PGPASSWORD='postgres'
+  $psql="$pgbin\psql.exe"; $H=@('-U','postgres','-h','127.0.0.1','-p',"$PostgresPort")
+  if((& $psql @H -tAc 'SELECT 1 FROM pg_roles WHERE rolname=''yuzu''') -ne '1'){
+    & $psql @H -c 'CREATE ROLE yuzu LOGIN SUPERUSER PASSWORD ''yuzu'''
+  }
+  if((& $psql @H -tAc 'SELECT 1 FROM pg_database WHERE datname=''yuzu_test''') -ne '1'){
+    & $psql @H -c 'CREATE DATABASE yuzu_test OWNER yuzu'
+  }
+  Remove-Item Env:\PGPASSWORD
+  "PG $PostgresVersion on :$PostgresPort, role yuzu, db yuzu_test ready"
+}
+
+Step "vcpkg @ pinned baseline $($VcpkgBaseline.Substring(0,7))" {
+  $git=(Get-Command git -EA SilentlyContinue).Source
+  if(-not (Test-Path "$VcpkgRoot\.git")){ & $git clone https://github.com/microsoft/vcpkg $VcpkgRoot }
+  & $git -C $VcpkgRoot fetch --depth 1 origin $VcpkgBaseline
+  & $git -C $VcpkgRoot checkout $VcpkgBaseline
+  if(-not (Test-Path "$VcpkgRoot\vcpkg.exe")){ & "$VcpkgRoot\bootstrap-vcpkg.bat" -disableMetrics }
+  "vcpkg bootstrapped at $VcpkgRoot"
+}
+
+Step 'machine env vars + PATH' {
+  Set-MachineEnv 'VCPKG_ROOT'             $VcpkgRoot
+  Set-MachineEnv 'CCACHE_DIR'             "$CacheRoot\ccache"
+  Set-MachineEnv 'CCACHE_MAXSIZE'         '30G'
+  Set-MachineEnv 'CCACHE_COMPRESS'        'true'
+  Set-MachineEnv 'CCACHE_COMPRESSLEVEL'   '1'
+  Set-MachineEnv 'YUZU_TEST_POSTGRES_DSN' "postgresql://yuzu:yuzu@127.0.0.1:$PostgresPort/yuzu_test"
+  # Shared CI tool cache (P0): one machine-level dir so the 4 CCD-pinned runners
+  # share ONE vcpkg binary cache instead of 4 per-runner copies. Each runner's
+  # .env also pins RUNNER_TOOL_CACHE to this (see deploy/windows/README.md);
+  # this machine env is the default for anything that reads it directly.
+  New-Item -ItemType Directory -Force "$CacheRoot\ccache","$CacheRoot\tool_cache" | Out-Null
+  Set-MachineEnv 'RUNNER_TOOL_CACHE'      "$CacheRoot\tool_cache"
+  Add-MachinePath $VcpkgRoot
+  # NOTE: deliberately NOT adding $Msys2Root\usr\bin to the machine PATH (it would
+  # shadow Windows find/sort/etc.); Start-PinnedRunner.ps1 prepends it only inside
+  # the runner's process env, and CI invokes bash by full path.
+}
+
+Step "emit toolchain manifest -> $ManifestPath" {
+  function Ver([scriptblock]$b){ try { (& $b 2>&1 | Select-Object -First 1) -replace '\s+$','' } catch { $null } }
+  $vsw="${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+  $msvc = if(Test-Path $vsw){ (& $vsw -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath | Select-Object -First 1) } else { $null }
+  $major = $PostgresVersion.Split('.')[0]
+  $tools = @(
+    @{ name='python';     path=(Get-Command python -EA SilentlyContinue).Source; version=(Ver { python --version }); required=$true }
+    @{ name='meson';      path=(Get-Command meson  -EA SilentlyContinue).Source; version=(Ver { meson --version });  required=$true }
+    @{ name='ninja';      path=(Get-Command ninja  -EA SilentlyContinue).Source; version=(Ver { ninja --version });  required=$true }
+    @{ name='cmake';      path=(Get-Command cmake  -EA SilentlyContinue).Source; version=(Ver { cmake --version });  required=$true }
+    @{ name='git';        path=(Get-Command git    -EA SilentlyContinue).Source; version=(Ver { git --version });    required=$true }
+    @{ name='ccache';     path=(Get-Command ccache -EA SilentlyContinue).Source; version=(Ver { ccache --version }); required=$true }
+    @{ name='escript';    path=[Environment]::GetEnvironmentVariable('YUZU_ESCRIPT','Machine'); version=(Ver { erl -version }); required=$true }
+    @{ name='rebar3';     path=[Environment]::GetEnvironmentVariable('YUZU_REBAR3','Machine');  version=$Rebar3Version; required=$true }
+    @{ name='msvc';       path=$msvc; version=$null; required=$true }
+    @{ name='msys2_bash'; path="$Msys2Root\usr\bin\bash.exe"; version=(Ver { & "$Msys2Root\usr\bin\bash.exe" --version }); required=$true }
+    @{ name='vcpkg';      path="$VcpkgRoot\vcpkg.exe"; version=(Ver { & "$VcpkgRoot\vcpkg.exe" version }); required=$true }
+    @{ name='postgres';   path="C:\Program Files\PostgreSQL\$major\bin\psql.exe"; version=$PostgresVersion; required=$true }
+  )
+  $manifest = [ordered]@{
+    generated = (Get-Date).ToUniversalTime().ToString('o')
+    host      = $env:COMPUTERNAME
+    pins      = [ordered]@{ python=$PythonVersion; meson=$MesonVersion; erlang=$ErlangVersion; rebar3=$Rebar3Version; postgres=$PostgresVersion; vcpkg_baseline=$VcpkgBaseline }
+    env       = [ordered]@{
+      VCPKG_ROOT=$VcpkgRoot; CCACHE_DIR="$CacheRoot\ccache"; RUNNER_TOOL_CACHE="$CacheRoot\tool_cache"
+      YUZU_ESCRIPT=[Environment]::GetEnvironmentVariable('YUZU_ESCRIPT','Machine')
+      YUZU_REBAR3=[Environment]::GetEnvironmentVariable('YUZU_REBAR3','Machine')
+      YUZU_TEST_POSTGRES_DSN="postgresql://yuzu:yuzu@127.0.0.1:$PostgresPort/yuzu_test"
+    }
+    tools     = $tools
+  }
+  New-Item -ItemType Directory -Force (Split-Path $ManifestPath) | Out-Null
+  $manifest | ConvertTo-Json -Depth 6 | Set-Content -Path $ManifestPath -Encoding UTF8
+  "wrote $ManifestPath ($($tools.Count) tools)"
+}
+
+Stop-Transcript | Out-Null
+Write-Host "`nDone. Transcript in C:\ProvisionLogs\. Open a NEW shell so machine PATH/env take effect." -ForegroundColor Yellow
+Write-Host "Verify: pwsh -File deploy\windows\Assert-Toolchain.ps1 -ManifestPath $ManifestPath" -ForegroundColor Yellow
+Write-Host "Next: register the 4 CCD-pinned runners — see deploy\windows\README.md + Start-PinnedRunner.ps1." -ForegroundColor Yellow

--- a/deploy/windows/README.md
+++ b/deploy/windows/README.md
@@ -1,0 +1,89 @@
+# Windows CI runner — provisioning spec
+
+This directory is the **versioned source of truth for a native Windows CI build
+host**, the Windows analog of `deploy/docker/Dockerfile.ci-linux`. Linux runners
+get their toolchain from a Dockerfile; Windows needs native MSVC (no practical
+container), so the equivalent is a declarative, idempotent PowerShell spec plus a
+machine-readable manifest a self-test verifies.
+
+The goal: a new Windows runner is reproducible from this directory, not a
+multi-hour archaeology dig, and no script hardcodes one host's layout.
+
+| File | Role |
+|---|---|
+| `Provision-Windows-Runner.ps1` | Installs the pinned toolchain, sets machine env (incl. the gateway + shared-cache contracts), emits `toolchain-manifest.json`. |
+| `Assert-Toolchain.ps1` | Runner self-test: verifies the manifest (every required tool present, every contract env set). Run at provision time **and** as a registration/preflight gate. |
+| `Start-PinnedRunner.ps1` | Supervises one runner, hard-pinned to one Threadripper CCD (L3 domain); shares the vcpkg binary cache via `RUNNER_TOOL_CACHE`. |
+
+## Standing up a new box
+
+1. **Provision** (elevated pwsh 7, over RDP/console — winget's source catalog
+   doesn't work headless):
+   ```powershell
+   pwsh -File deploy\windows\Provision-Windows-Runner.ps1
+   ```
+   Re-runnable; pins live in the `param()` block (bump deliberately). Open a new
+   shell afterwards so machine PATH/env take effect.
+
+2. **Self-test** (must pass before registering):
+   ```powershell
+   pwsh -File deploy\windows\Assert-Toolchain.ps1
+   ```
+
+3. **Register the runners.** One runner per CCD. Configure each with its own root
+   and a work dir on the fast data drive, labelled into the Windows pool
+   (`.github/runner-inventory.json` declares the expected set):
+   ```powershell
+   # repeat for r0..r3 with a fresh --token each (gh api ... /registration-token)
+   C:\actions-runner\r0\config.cmd --unattended --replace `
+     --url https://github.com/Tr3kkR/Yuzu `
+     --name yuzu-weetam-windows-0 `
+     --labels self-hosted,Windows,X64,yuzu-weetam-windows `
+     --work D:\ci\work-0 --token <TOKEN>
+   ```
+
+4. **Pin + supervise.** Run each runner under a **boot-triggered scheduled task**
+   (NOT `svc.cmd install` — the service control manager starts it with full
+   affinity, breaking the CCD pin), invoking the wrapper:
+   ```
+   pwsh.exe -NoProfile -File C:\actions-runner\Start-PinnedRunner.ps1 -Index 0
+   ```
+   Boot trigger ⇒ the runners auto-rejoin after a reboot / physical move.
+
+## Contracts (why the env vars exist)
+
+- **Gateway build (de-Shulgi-ified).** `scripts/build_gateway.py` resolves the
+  Erlang toolchain from `YUZU_ESCRIPT` / `YUZU_REBAR3` (set by provisioning),
+  then PATH/glob — it no longer assumes Shulgi's `C:\Erlang` junction or the
+  Chocolatey rebar3 path. A box that sets those env vars builds the gateway with
+  no filesystem fakery.
+- **Shared vcpkg binary cache.** `RUNNER_TOOL_CACHE=D:\ci\tool_cache` points
+  `${{ runner.tool_cache }}` (hence `VCPKG_DEFAULT_BINARY_CACHE` in `ci.yml`) at
+  **one** machine-level dir, so the 4 CCD-pinned runners share one warm vcpkg
+  binary cache instead of fragmenting it 4× (~1.9 GB each). Mirrors
+  `CCACHE_DIR=D:\ci\ccache`. Set in each runner's `.env` (durable) and exported
+  by the wrapper. The vcpkg binary cache is content-addressed → concurrent writes
+  across runners are safe.
+
+## `toolchain-manifest.json`
+
+Emitted by provisioning (default `C:\actions-runner\toolchain-manifest.json`),
+verified by `Assert-Toolchain.ps1`:
+
+```json
+{
+  "generated": "2026-06-20T13:00:00Z",
+  "host": "WEETAM",
+  "pins":  { "python": "3.14.6", "meson": "1.11.1", "erlang": "28.4.2",
+             "rebar3": "3.24.0", "postgres": "18.4", "vcpkg_baseline": "4b77da7..." },
+  "env":   { "VCPKG_ROOT": "C:\\vcpkg", "CCACHE_DIR": "D:\\ci\\ccache",
+             "RUNNER_TOOL_CACHE": "D:\\ci\\tool_cache",
+             "YUZU_ESCRIPT": "...erts-*\\bin\\escript.exe",
+             "YUZU_REBAR3": "C:\\tools\\rebar3\\rebar3",
+             "YUZU_TEST_POSTGRES_DSN": "postgresql://yuzu:yuzu@127.0.0.1:5433/yuzu_test" },
+  "tools": [ { "name": "vcpkg", "path": "C:\\vcpkg\\vcpkg.exe", "version": "...", "required": true }, ... ]
+}
+```
+
+The manifest is host-generated (like a lockfile) and not committed; this README
+documents its shape so the self-test and any tooling agree on the contract.

--- a/deploy/windows/Start-PinnedRunner.ps1
+++ b/deploy/windows/Start-PinnedRunner.ps1
@@ -74,6 +74,21 @@ Write-Host "[r$Index] RUNNER_TOOL_CACHE = $ToolCache (shared)"
 # affinity mask). ci.yml's Windows Build step honors -j $YUZU_BUILD_JOBS when set.
 [Environment]::SetEnvironmentVariable('YUZU_BUILD_JOBS', "$BuildJobs", 'Process')
 
+# Registration-time self-test: assert the toolchain manifest (if present) before
+# taking jobs, so a mis-provisioned box is flagged loudly at startup instead of
+# 90 min into a build. WARN, don't block — the in-job "Assert toolchain
+# available" step hard-fails a genuinely broken build, and we'd rather a
+# slightly-stale manifest not strand a runner offline. (Assert-Toolchain.ps1
+# deploys alongside this wrapper — see deploy/windows/README.md.)
+$selftest = Join-Path $PSScriptRoot 'Assert-Toolchain.ps1'
+$manifest = 'C:\actions-runner\toolchain-manifest.json'
+if((Test-Path $selftest) -and (Test-Path $manifest)){
+  & $selftest -ManifestPath $manifest
+  if($LASTEXITCODE -ne 0){ Write-Warning "[r$Index] toolchain self-test FAILED — starting anyway; fix provisioning (see deploy/windows/README.md)." }
+} else {
+  Write-Host "[r$Index] toolchain self-test skipped (manifest/selftest not present)"
+}
+
 $run = Join-Path $RunnerRoot 'run.cmd'
 while ($true) {
   if (-not (Test-Path (Join-Path $RunnerRoot '.runner'))) {

--- a/deploy/windows/Start-PinnedRunner.ps1
+++ b/deploy/windows/Start-PinnedRunner.ps1
@@ -1,0 +1,88 @@
+<#
+  Start-PinnedRunner.ps1 — supervise ONE GitHub Actions runner, hard-pinned to a
+  single Threadripper 9970X CCD (a 32 MB L3 domain) so a build (ninja/cl.exe)
+  never migrates across an L3 boundary.
+
+  Canonical, version-controlled copy. The provisioning spec is
+  deploy/windows/Provision-Windows-Runner.ps1; registration is in
+  deploy/windows/README.md.
+
+  CCD map (9970X = 4 CCDs x 8C/16T, 32 MB L3 each):
+     Index  CCD  logical CPUs   affinity mask
+       0     0    0-15          0x000000000000FFFF
+       1     1    16-31         0x00000000FFFF0000
+       2     2    32-47         0x0000FFFF00000000
+       3     3    48-63         0xFFFF000000000000
+     mask = 0xFFFF << (16 * Index)
+
+  Affinity is set on THIS process; run.cmd and every descendant
+  (Runner.Listener -> Runner.Worker -> cmd/pwsh -> ninja -> cl.exe) inherit it.
+  Launch via a scheduled task / console, NOT `svc.cmd install` — the service
+  control manager starts the runner with full affinity, breaking the pin.
+
+  Persistent model: run.cmd runs continuously (job after job). This wrapper just
+  restarts it if it ever exits (crash, runner auto-update, manual stop).
+  Ephemeral/JIT re-arm is deferred — tracked in issue #1595.
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)][ValidateRange(0,3)][int]$Index,
+  [string]$RunnerRoot = "C:\actions-runner\r$Index",
+  # Shared CI tool cache (P0): all runners point RUNNER_TOOL_CACHE at ONE
+  # machine-level dir so ${{ runner.tool_cache }} (hence VCPKG_DEFAULT_BINARY_CACHE
+  # in ci.yml) is shared, not fragmented per-runner. Mirrors CCACHE_DIR=D:\ci\ccache.
+  [string]$ToolCache  = 'D:\ci\tool_cache',
+  [int]   $BuildJobs  = 16          # threads per CCD; caps ninja -j (see below)
+)
+$ErrorActionPreference = 'Continue'
+
+# --- pin: 16-thread mask for CCD #Index; children inherit at creation ---
+[int64]$mask = [int64]0xFFFF -shl (16 * $Index)
+$first = 16 * $Index
+[System.Diagnostics.Process]::GetCurrentProcess().ProcessorAffinity = [IntPtr]$mask
+Write-Host ("[r{0}] pinned to CCD{0}  cpus {1}-{2}  mask=0x{3:X16}" -f $Index,$first,($first+15),$mask)
+
+# Refresh the process environment from the live machine registry. The Task
+# Scheduler service hands tasks a CACHED env block, so a runner launched this
+# way misses PATH/vars added after the service last refreshed (Python, Meson,
+# ninja, cmake, ccache, VCPKG_ROOT, YUZU_ESCRIPT/YUZU_REBAR3, the Postgres DSN).
+# Without this the CI "Assert toolchain available" step fails. run.cmd -> jobs
+# inherit this env.
+foreach($e in [Environment]::GetEnvironmentVariables('Machine').GetEnumerator()){
+  if($e.Key -ieq 'Path'){ continue }
+  [Environment]::SetEnvironmentVariable($e.Key, $e.Value, 'Process')
+}
+$userPath = [Environment]::GetEnvironmentVariable('Path','User')
+# Prepend MSYS2 /usr/bin: the Windows CI jobs use `bash --noprofile`, whose
+# scripts call coreutils (head/grep/sed/find/sort). MSYS2 tools take precedence
+# in the bash context; MSVC (prepended by msvc-dev-cmd at job time) still wins
+# for cl/link. Without this, "Assert toolchain available" dies on `head`.
+$env:Path = 'C:\msys64\usr\bin;' + [Environment]::GetEnvironmentVariable('Path','Machine') + $(if($userPath){ ";$userPath" } else { '' })
+Write-Host "[r$Index] env refreshed (MSYS2 /usr/bin + machine registry)"
+
+# Shared vcpkg binary cache (P0). The runner reads RUNNER_TOOL_CACHE at Listener
+# startup; this is belt-and-suspenders alongside the runner's .env. Pointing all
+# four runners here means ONE warm vcpkg binary cache, not four per-runner copies
+# (~1.9 GB each). ccache already shares via CCACHE_DIR. (The vcpkg binary cache is
+# content-addressed, so concurrent writes across the 4 runners are safe.)
+[Environment]::SetEnvironmentVariable('RUNNER_TOOL_CACHE', $ToolCache, 'Process')
+New-Item -ItemType Directory -Force $ToolCache | Out-Null
+Write-Host "[r$Index] RUNNER_TOOL_CACHE = $ToolCache (shared)"
+
+# Cap build parallelism to this CCD's thread count so ninja doesn't oversubscribe
+# the pinned threads (ninja sizes -j from the 64-CPU system count, ignoring the
+# affinity mask). ci.yml's Windows Build step honors -j $YUZU_BUILD_JOBS when set.
+[Environment]::SetEnvironmentVariable('YUZU_BUILD_JOBS', "$BuildJobs", 'Process')
+
+$run = Join-Path $RunnerRoot 'run.cmd'
+while ($true) {
+  if (-not (Test-Path (Join-Path $RunnerRoot '.runner'))) {
+    Write-Warning "[r$Index] $RunnerRoot not configured yet (no .runner) — waiting 30s"
+    Start-Sleep -Seconds 30
+    continue
+  }
+  Write-Host "[r$Index] starting persistent run.cmd ..."
+  & $run
+  Write-Host "[r$Index] run.cmd exited ($LASTEXITCODE) — restarting in 5s"
+  Start-Sleep -Seconds 5
+}

--- a/docs/ci-architecture.md
+++ b/docs/ci-architecture.md
@@ -50,8 +50,15 @@ dormant until merged.
 | Runner | Host | Jobs |
 |---|---|---|
 | `yuzu-wsl2-linux` | Shulgi 5950X WSL2 Ubuntu 24.04 | proto-compat, linux matrix, nightly (asan/tsan/coverage), cache-prune-linux |
-| `yuzu-local-windows` | Shulgi native Windows 11 | windows matrix, cache-prune-windows |
+| `yuzu-weetam-windows-{0..3}` | Wee Tam 9970X native Windows 11 — 4 CCD-pinned runners, shared label `yuzu-weetam-windows` | windows matrix (successor to Shulgi for Windows); provisioned from [`deploy/windows/`](../deploy/windows/README.md) |
+| `yuzu-local-windows` | Shulgi native Windows 11 | windows matrix, cache-prune-windows (legacy — retire once Wee Tam is proven) |
 | `macos-15` | GitHub-hosted | macos matrix |
+
+The Windows toolchain is codified in [`deploy/windows/`](../deploy/windows/README.md)
+(the native-Windows analog of `deploy/docker/Dockerfile.ci-linux`): a versioned
+provisioning spec, a manifest, and a runner self-test. All four runners share one
+vcpkg binary cache via `RUNNER_TOOL_CACHE=D:\ci\tool_cache` (mirroring
+`CCACHE_DIR`), so the CCD split doesn't fragment the cache 4×.
 
 Inventory declared in `.github/runner-inventory.json`. The sentinel at
 `runner-inventory-sentinel.yml` (every 30 min) compares actual to expected

--- a/scripts/build_gateway.py
+++ b/scripts/build_gateway.py
@@ -23,32 +23,78 @@ if sys.platform == "win32":
     env["TEMP"] = real_temp
     env["TMP"] = real_temp
 
-    # Bypass the Chocolatey shim for rebar3 — it can lose env vars.
-    # Use escript.exe directly via the C:\Erlang junction (space-free path).
+    # Resolve the Erlang toolchain WITHOUT hardcoding one host's layout. The
+    # proven-good invocation is `<real escript.exe> <rebar3 escript file>
+    # compile`: it bypasses the Chocolatey shim (which can lose env vars) and
+    # the OTP 28 top-level launcher stub at <root>\bin\escript.exe (no useful
+    # output non-interactively; can segfault with access violation 0xC0000005
+    # under the choco path). The real escript.exe lives at
+    # <root>\erts-*\bin\escript.exe across modern (Erlang OTP\) and legacy
+    # (erl-<ver>\) layouts. We just resolve the PATHS portably instead of
+    # assuming Shulgi's C:\Erlang junction + Chocolatey path.
     #
-    # Modern OTP 28 installers ship a launcher stub at <root>\bin\escript.exe
-    # that produces no useful output when invoked non-interactively and can
-    # segfault with Windows access violation 0xC0000005 under the choco
-    # install path. The real escript.exe lives at <root>\erts-*\bin\escript.exe
-    # across both modern (Erlang OTP\) and legacy (erl-<ver>\) layouts;
-    # prefer that. Fallback to the top-level launcher for older OTP installs
-    # where no erts-* subdir exists, then to PATH-resolved rebar3 if the
-    # junction doesn't exist at all.
-    erlang_junction = r"C:\Erlang"
-    erts_escripts = sorted(
-        glob.glob(os.path.join(erlang_junction, "erts-*", "bin", "escript.exe")),
-        reverse=True,
-    )
-    escript = (
-        erts_escripts[0]
-        if erts_escripts
-        else os.path.join(erlang_junction, "bin", "escript.exe")
-    )
-    rebar3_escript = r"C:\ProgramData\chocolatey\lib\rebar3\tools\rebar3"
-    if os.path.isfile(escript) and os.path.isfile(rebar3_escript):
+    # Resolution precedence (per the runner provisioning contract — see
+    # deploy/windows/Provision-Windows-Runner.ps1 + toolchain-manifest.json):
+    #   1. explicit env vars (YUZU_ESCRIPT / ESCRIPT, YUZU_REBAR3 / REBAR3)
+    #   2. the real erts escript globbed across common OTP install roots
+    #   3. PATH (shutil.which)
+    def _env_file(*names):
+        for n in names:
+            v = os.environ.get(n)
+            if v and os.path.isfile(v):
+                return v
+        return None
+
+    escript = _env_file("YUZU_ESCRIPT", "ESCRIPT")
+    if not escript:
+        roots = [r"C:\Erlang"]
+        roots += glob.glob(r"C:\Program Files\Erlang*")
+        roots += glob.glob(r"C:\Program Files\erl*")
+        candidates = []
+        for root in roots:
+            candidates += sorted(
+                glob.glob(os.path.join(root, "erts-*", "bin", "escript.exe")),
+                reverse=True,
+            )
+            candidates.append(os.path.join(root, "bin", "escript.exe"))
+        escript = next((c for c in candidates if os.path.isfile(c)), None)
+    if not escript:
+        escript = shutil.which("escript")
+
+    rebar3_escript = _env_file("YUZU_REBAR3", "REBAR3")
+    if not rebar3_escript:
+        rebar3_escript = next(
+            (
+                c
+                for c in (
+                    r"C:\tools\rebar3\rebar3",
+                    r"C:\ProgramData\chocolatey\lib\rebar3\tools\rebar3",
+                )
+                if os.path.isfile(c)
+            ),
+            None,
+        )
+
+    if escript and rebar3_escript:
         cmd = [escript, rebar3_escript, "compile"]
     else:
-        cmd = ["rebar3", "compile"]
+        # Last resort: a PATH-resolved rebar3 launcher. shutil.which returns the
+        # full path incl. extension (.cmd/.bat), which subprocess CAN exec — a
+        # bare "rebar3" cannot be exec'd on Windows (no PATHEXT resolution), the
+        # old FileNotFoundError trap.
+        rebar3_launcher = shutil.which("rebar3")
+        if rebar3_launcher:
+            cmd = [rebar3_launcher, "compile"]
+        else:
+            sys.stderr.write(
+                "build_gateway: could not locate the Erlang toolchain on Windows.\n"
+                "  Set YUZU_ESCRIPT and YUZU_REBAR3 (see "
+                "deploy/windows/toolchain-manifest.json), or put escript.exe and\n"
+                "  rebar3 on PATH.\n"
+                f"  escript={escript!r} rebar3={rebar3_escript!r} "
+                f"which(rebar3)={shutil.which('rebar3')!r}\n"
+            )
+            sys.exit(1)
 else:
     cmd = ["rebar3", "compile"]
 


### PR DESCRIPTION
## Why

Standing up Wee Tam (a 2nd native-Windows runner box) surfaced that Yuzu's Windows build was implicitly coupled to **one host's hand-provisioning** — `scripts/build_gateway.py` hardcoded Shulgi's `C:\Erlang` junction + Chocolatey rebar3 path, the toolchain lived only in an untracked PowerShell script, and the 4 CCD-pinned runners each kept a **separate** vcpkg binary cache. Linux already codifies its toolchain (`deploy/docker/Dockerfile.ci-linux`); this brings Windows up to the same bar.

Thesis (from the epistemically-graded, doc-grilled plan): **codify the Windows toolchain to match Linux** rather than bolt on pipeline stages.

## What's in this PR

**De-hardcode the gateway build**
- `scripts/build_gateway.py` resolves escript/rebar3 from `YUZU_ESCRIPT`/`YUZU_REBAR3` → glob common OTP roots → PATH, with a clear actionable error instead of a bare `FileNotFoundError`. Backward-compatible with the existing live runners (still resolves via `C:\Erlang` / choco fallbacks).

**Codify the toolchain (`deploy/windows/`, the Windows analog of `Dockerfile.ci-linux`)**
- `Provision-Windows-Runner.ps1` — versioned, idempotent provisioning spec; sets the gateway env contract + shared `RUNNER_TOOL_CACHE`; emits `toolchain-manifest.json`.
- `Start-PinnedRunner.ps1` — in-repo CCD-pin wrapper; shares the vcpkg binary cache via `RUNNER_TOOL_CACHE`; runs the self-test at startup.
- `Assert-Toolchain.ps1` — runner self-test asserting the manifest (fails in seconds at registration, not 90 min into a build).
- `README.md` — standup runbook + manifest contract.
- `vcpkg-baseline-update.yml` tracks the provisioning script's pinned baseline.

**Observability + doc-drift**
- `ci.yml` Windows job: optional manifest self-test step (skips on un-reprovisioned runners) + a cache/parallelism **job-summary** (ccache hit rate, effective `-j`, LTO) with a cold-cache `::warning::` — the fragmentation/oversubscription signal we previously caught only by hand.
- `docs/ci-architecture.md` topology table now lists the `yuzu-weetam-windows` pool; `Dockerfile.runner-linux` Meson `1.9.2`→`1.11.1`; CLAUDE.md pointer.

## Shared vcpkg binary cache (P0)

`${{ runner.tool_cache }}` was per-runner (`D:\ci\work-N\_tool`), so the 4 runners fragmented the vcpkg binary cache 4× (~1.9 GB each). Setting `RUNNER_TOOL_CACHE=D:\ci\tool_cache` shares one warm cache (mirrors `CCACHE_DIR`). The **live** apply (seed + `.env` + restart) is an ops change applied to the runners directly, not in this PR; this PR codifies it for any future/reprovisioned box.

> Note: the earlier 2h Windows timeouts were one-time **cold warmup** (now past — warm fast-path builds are ~4 min). The slow **release** leg is MSVC **LTO** (`-Db_lto`), which is largely inherent (ccache can't accelerate link-time codegen) — surfaced, not "fixed", here.

## Not in this PR (tracked follow-ups)
- CodeQL weekly → **nightly** (`nightly.yml`); CI flaky retry/quarantine on `test-runs.db`; `RUNNER_INVENTORY_TOKEN`/`SCORECARD_READ_TOKEN` PATs → GitHub App.

Draft until the live P0 validates a warm shared-cache build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)