### PR TITLE
ci: cut self-hosted Linux CI over to Big Tam (Ubuntu 26.04, gcc-15/clang-21)

### DIFF
--- a/.github/runner-inventory.json
+++ b/.github/runner-inventory.json
@@ -6,7 +6,7 @@
       "name": "yuzu-wsl2-linux",
       "host": "Shulgi (AMD 5950X, WSL2 Ubuntu 24.04)",
       "labels": ["self-hosted", "Linux", "X64"],
-      "role": "Linux CI jobs — ci.yml proto-compat, linux matrix, sanitizer-asan, sanitizer-tsan, coverage. Also CodeQL Linux leg and sanitizer-tests.yml dispatches.",
+      "role": "Linux CI jobs — ci.yml proto-compat, linux matrix, sanitizer-asan, sanitizer-tsan, coverage. Also CodeQL Linux leg and sanitizer-tests.yml dispatches. INCUMBENT 24.04 toolchain (gcc-13 / clang-19) — remains the live Linux runner until the Big Tam cutover. Cannot build the gcc-15 / clang-21 (26.04) toolchain.",
       "installed": "2026-04-09"
     },
     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,9 @@ jobs:
       # true iff >=1 eligible Linux runner (any yuzu-bigtam-* OR the yuzu-wsl2-linux
       # Shulgi fallback) is online. Replaces the old single-named yuzu_wsl2_linux gate.
       linux_pool_healthy: ${{ steps.health.outputs.linux_pool_healthy }}
+      # Big Tam sub-pool (yuzu-bigtam-linux) — gates the gcc-15/clang-21 compile
+      # job, whose 26.04-only toolchain cannot run on the Shulgi 24.04 fallback.
+      bigtam_pool_healthy: ${{ steps.health.outputs.bigtam_pool_healthy }}
       yuzu_wsl2_linux_healthy: ${{ steps.health.outputs.yuzu_wsl2_linux_healthy }}
       yuzu_local_windows_healthy: ${{ steps.health.outputs.yuzu_local_windows_healthy }}
       all_healthy: ${{ steps.health.outputs.all_healthy }}
@@ -159,32 +162,33 @@ jobs:
       - name: Check backward compatibility
         run: buf breaking proto --against '.git#subdir=proto,ref=origin/main'
 
-  # ── Linux (GCC + Clang, self-hosted yuzu-wsl2-linux) ──────────────────
+  # ── Linux (GCC + Clang, self-hosted yuzu-bigtam-linux) ────────────────
   linux:
     name: "Linux ${{ matrix.compiler }} ${{ matrix.build_type }}"
     needs: [preflight]
-    # PR-7 of CI overhaul plan: skip if the self-hosted Linux job pool is
-    # unhealthy or unknown. Pool = any [self-hosted, Linux, X64] runner online
-    # (yuzu-bigtam-* or the Shulgi fallback). Fail-closed `== 'true'` (NOT `!= 'false'`).
-    if: needs.preflight.outputs.linux_pool_healthy == 'true'
-    # Self-hosted: Shulgi 5950X WSL2 Ubuntu. Persistent ccache + vcpkg
-    # state between runs on the same workspace amortizes the install
-    # cost. Trade-off: the single runner process serializes this 4-way
-    # matrix, so multi-commit pushes are slower end-to-end than on the
-    # parallel ubuntu-24.04 fleet. Mirrors the Windows migration in
-    # #374 — the optimization target is Actions-minute spend, not
-    # per-PR latency.
-    runs-on: [self-hosted, Linux, X64]
+    # Pinned to the Big Tam sub-pool: the GCC 15 / Clang 21 toolchain is
+    # 26.04-only and cannot build on the Shulgi 24.04 fallback, so gate on
+    # bigtam_pool_healthy (>=1 yuzu-bigtam-linux runner online) rather than the
+    # broader linux_pool. Fail-closed `== 'true'` (NOT `!= 'false'`) — an offline
+    # Big Tam skips this job fast instead of queueing against an empty pool.
+    if: needs.preflight.outputs.bigtam_pool_healthy == 'true'
+    # Self-hosted: Big Tam (Threadripper 9970X, native Ubuntu 26.04). Persistent
+    # ccache + vcpkg state between runs on the same workspace amortizes the
+    # install cost. Trade-off: the runner process serializes this matrix, so
+    # multi-commit pushes are slower end-to-end than on the parallel GHA-hosted
+    # fleet. Mirrors the Windows migration in #374 — the optimization target is
+    # Actions-minute spend, not per-PR latency.
+    runs-on: [self-hosted, Linux, X64, yuzu-bigtam-linux]
     timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc-13, clang-19]
+        compiler: [gcc-15, clang-21]
         build_type: [debug, release]
         exclude:
-          # PRs: only gcc-13 debug (fast feedback)
+          # PRs: only gcc-15 debug (fast feedback)
           - build_type: ${{ github.event_name == 'pull_request' && 'release' || 'NONE' }}
-          - compiler: ${{ github.event_name == 'pull_request' && 'clang-19' || 'NONE' }}
+          - compiler: ${{ github.event_name == 'pull_request' && 'clang-21' || 'NONE' }}
 
     steps:
       # PR-5 of the CI overhaul plan: clean:false preserves build-linux/
@@ -229,7 +233,7 @@ jobs:
           sudo apt-get install -y \
             cmake ninja-build pkg-config curl zip unzip tar python3-pip ccache \
             bison flex libsystemd-dev \
-            ${{ matrix.compiler == 'gcc-13' && 'gcc-13 g++-13' || 'clang-19' }}
+            ${{ matrix.compiler == 'gcc-15' && 'gcc-15 g++-15' || 'clang-21' }}
           pip3 install --user --break-system-packages --require-hashes -r requirements-ci.txt
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
@@ -243,6 +247,12 @@ jobs:
       # ImageOS is required because erlef/setup-beam can't auto-detect
       # the runner OS on self-hosted; set at step scope so the rest of
       # the job doesn't see it.
+      # DELIBERATELY ubuntu24 even though Big Tam is Ubuntu 26.04: setup-beam
+      # has NO ubuntu26 prebuilt OTP (supported ImageOS tops out at ubuntu24).
+      # ImageOS only selects which prebuilt OTP tarball to fetch; the 24.04
+      # build runs fine on 26.04 (same libcrypto.so.3 soname). Do NOT change to
+      # ubuntu26 until setup-beam ships a 26.04 build — it would fail to resolve
+      # the asset. Verified by gateway eunit on the Big Tam leg.
       - name: Install Erlang/OTP and rebar3
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         env:
@@ -305,8 +315,8 @@ jobs:
 
       - name: Configure (Meson)
         env:
-          CC: ccache ${{ matrix.compiler == 'gcc-13' && 'gcc-13' || 'clang-19' }}
-          CXX: ccache ${{ matrix.compiler == 'gcc-13' && 'g++-13' || 'clang++-19' }}
+          CC: ccache ${{ matrix.compiler == 'gcc-15' && 'gcc-15' || 'clang-21' }}
+          CXX: ccache ${{ matrix.compiler == 'gcc-15' && 'g++-15' || 'clang++-21' }}
           PKG_CONFIG_PATH: ${{ github.workspace }}/vcpkg_installed/x64-linux/lib/pkgconfig
         run: |
           # Under clean:false (PR-5) build-linux/ may already be configured
@@ -325,11 +335,11 @@ jobs:
           reconfig=""
           [[ -d "$BUILDDIR/meson-info" ]] && reconfig="--reconfigure"
           meson setup $reconfig "$BUILDDIR" \
-            --native-file meson/native/${{ matrix.compiler == 'gcc-13' && 'linux-gcc13.ini' || 'linux-clang19.ini' }} \
+            --native-file meson/native/${{ matrix.compiler == 'gcc-15' && 'linux-gcc15.ini' || 'linux-clang21.ini' }} \
             --buildtype=${{ matrix.build_type }} \
             -Dcmake_prefix_path=${{ github.workspace }}/vcpkg_installed/x64-linux \
             -Dbuild_tests=true \
-            ${{ matrix.build_type == 'release' && matrix.compiler == 'gcc-13' && '-Db_lto=true' || '' }}
+            ${{ matrix.build_type == 'release' && matrix.compiler == 'gcc-15' && '-Db_lto=true' || '' }}
 
       - name: Build
         run: meson compile -C build-linux-${{ matrix.compiler }}-${{ matrix.build_type }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,8 +229,15 @@ jobs:
 
       - name: Install system packages
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          # DPkg::Lock::Timeout: the Big Tam host runs 4 runners (r0-r3), so the
+          # matrix legs hit `apt-get` concurrently and race the single system
+          # apt/dpkg lock (Shulgi was one runner, so its matrix serialized and
+          # never contended). Wait up to 300s for the lock instead of failing
+          # with "Could not get lock /var/lib/apt/lists/lock" (exit 100). Applied
+          # to BOTH update and install — the lists lock bites first. Matches the
+          # nightly.yml shared-box pattern.
+          sudo apt-get -o DPkg::Lock::Timeout=300 update
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y \
             cmake ninja-build pkg-config curl zip unzip tar python3-pip ccache \
             bison flex libsystemd-dev \
             ${{ matrix.compiler == 'gcc-15' && 'gcc-15 g++-15' || 'clang-21' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,15 @@ jobs:
     # Actions-minute spend, not per-PR latency.
     runs-on: [self-hosted, Linux, X64, yuzu-bigtam-linux]
     timeout-minutes: 90
+    env:
+      # Big Tam runs 4 runners on one host. A gateway eunit test that boots the
+      # app can transiently bring up Erlang distribution and trip the #659
+      # insecure-default-cookie boot guard (observed flaking 1/4 legs). This is
+      # the documented dev/CI override — the guard's policy logic is still
+      # unit-tested directly by yuzu_gw_app_tests. The host-side per-runner
+      # ERL_EPMD_PORT isolation (each runner's .env) removes the cross-runner
+      # EPMD collision that triggers the transient distribution in the first place.
+      YUZU_GW_ALLOW_DEFAULT_COOKIE: "1"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,18 +229,30 @@ jobs:
 
       - name: Install system packages
         run: |
-          # DPkg::Lock::Timeout: the Big Tam host runs 4 runners (r0-r3), so the
-          # matrix legs hit `apt-get` concurrently and race the single system
-          # apt/dpkg lock (Shulgi was one runner, so its matrix serialized and
-          # never contended). Wait up to 300s for the lock instead of failing
-          # with "Could not get lock /var/lib/apt/lists/lock" (exit 100). Applied
-          # to BOTH update and install — the lists lock bites first. Matches the
-          # nightly.yml shared-box pattern.
-          sudo apt-get -o DPkg::Lock::Timeout=300 update
-          sudo apt-get -o DPkg::Lock::Timeout=300 install -y \
-            cmake ninja-build pkg-config curl zip unzip tar python3-pip ccache \
-            bison flex libsystemd-dev \
-            ${{ matrix.compiler == 'gcc-15' && 'gcc-15 g++-15' || 'clang-21' }}
+          # The Big Tam host runs 4 runners (r0-r3), so the matrix legs hit apt
+          # concurrently and race the system locks (Shulgi was one runner, so its
+          # matrix serialized and never contended). apt operations cannot run in
+          # parallel by design. DPkg::Lock::Timeout only governs the dpkg FRONTEND
+          # lock (install) — it does NOT cover `apt-get update`'s lists lock
+          # (/var/lib/apt/lists/lock), which still failed instantly under
+          # contention. So serialize the whole apt sequence across legs with flock
+          # on a shared host lock (the standard fix — this is what apt-systemd-daily
+          # itself does). Keep DPkg::Lock::Timeout inside as belt-and-suspenders
+          # for the frontend lock vs. any background unattended-upgrades. Serializing
+          # apt also staggers the legs, so they don't hit ensure-postgres (one
+          # shared yuzu-ci-postgres container) or pip --user ($HOME) all at once.
+          # FD-9 flock pattern: the subshell opens the lock file on fd 9, flock
+          # blocks up to 600s for it, and releases on subshell exit. /tmp is
+          # 1777 so the runner can create the lock; all 4 runners are the same
+          # user on the same host, so they share it.
+          (
+            flock -w 600 9 || { echo "::error::timed out waiting for apt lock"; exit 1; }
+            sudo apt-get -o DPkg::Lock::Timeout=300 update
+            sudo apt-get -o DPkg::Lock::Timeout=300 install -y \
+              cmake ninja-build pkg-config curl zip unzip tar python3-pip ccache \
+              bison flex libsystemd-dev \
+              ${{ matrix.compiler == 'gcc-15' && 'gcc-15 g++-15' || 'clang-21' }}
+          ) 9>/tmp/yuzu-ci-apt.lock
           pip3 install --user --break-system-packages --require-hashes -r requirements-ci.txt
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -327,7 +327,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: ["ubuntu:22.04", "ubuntu:24.04", "debian:12"]
+        distro: ["ubuntu:22.04", "ubuntu:24.04", "ubuntu:26.04", "debian:12"]
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/deploy/docker/Dockerfile.agent-asan
+++ b/deploy/docker/Dockerfile.agent-asan
@@ -10,20 +10,20 @@ WORKDIR /build/src
 RUN rm -rf builddir vcpkg_installed node_modules .uat gateway/_build gateway/.deps_cache \
     && cp -r /opt/vcpkg_installed ./vcpkg_installed
 
-RUN CC="gcc-13" CXX="g++-13" \
+RUN CC="gcc-15" CXX="g++-15" \
     PKG_CONFIG_PATH=/build/src/vcpkg_installed/x64-linux/lib/pkgconfig \
     meson setup builddir \
-      --native-file meson/native/linux-gcc13.ini \
+      --native-file meson/native/linux-gcc15.ini \
       --buildtype=debug \
       -Dcmake_prefix_path=/build/src/vcpkg_installed/x64-linux \
       -Dbuild_tests=false \
       -Db_sanitize=address,undefined \
     && meson compile -C builddir
 
-FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
+FROM ubuntu:26.04@sha256:53958ec7b67c2c9355df922dd08dbf0360611f8c3cdb656875e81873db9ffdba
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        libgcc-13-dev libstdc++6 libssl3t64 libsystemd0 ca-certificates \
+        libgcc-15-dev libstdc++6 libssl3t64 libsystemd0 ca-certificates \
         libasan8 libubsan1 \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && useradd -r -s /sbin/nologin yuzu

--- a/deploy/docker/Dockerfile.agent-tsan
+++ b/deploy/docker/Dockerfile.agent-tsan
@@ -10,20 +10,20 @@ WORKDIR /build/src
 RUN rm -rf builddir vcpkg_installed node_modules .uat gateway/_build gateway/.deps_cache \
     && cp -r /opt/vcpkg_installed ./vcpkg_installed
 
-RUN CC="gcc-13" CXX="g++-13" \
+RUN CC="gcc-15" CXX="g++-15" \
     PKG_CONFIG_PATH=/build/src/vcpkg_installed/x64-linux/lib/pkgconfig \
     meson setup builddir \
-      --native-file meson/native/linux-gcc13.ini \
+      --native-file meson/native/linux-gcc15.ini \
       --buildtype=debug \
       -Dcmake_prefix_path=/build/src/vcpkg_installed/x64-linux \
       -Dbuild_tests=false \
       -Db_sanitize=thread \
     && meson compile -C builddir
 
-FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
+FROM ubuntu:26.04@sha256:53958ec7b67c2c9355df922dd08dbf0360611f8c3cdb656875e81873db9ffdba
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        libgcc-13-dev libstdc++6 libssl3t64 libsystemd0 ca-certificates \
+        libgcc-15-dev libstdc++6 libssl3t64 libsystemd0 ca-certificates \
         libtsan2 \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && useradd -r -s /sbin/nologin yuzu

--- a/deploy/docker/Dockerfile.ci
+++ b/deploy/docker/Dockerfile.ci
@@ -1,29 +1,31 @@
 # Yuzu CI — Pre-built Linux CI image with all deps ready
 #
-# Contains: GCC 13, Clang 18, Meson, ccache, vcpkg with all packages
+# Contains: GCC 15, Clang 21, Meson, ccache, vcpkg with all packages
 # pre-compiled. Mount your source tree and run configure+build+test
 # instantly — no waiting for vcpkg or apt installs.
 #
 # Build (one-time, ~40 min):
 #   docker build -t yuzu-ci -f deploy/docker/Dockerfile.ci .
 #
-# Usage — GCC 13 debug:
-#   docker run --rm -v "$(pwd):/src" yuzu-ci gcc-13 debug
+# Usage — GCC 15 debug:
+#   docker run --rm -v "$(pwd):/src" yuzu-ci gcc-15 debug
 #
-# Usage — Clang 18 release:
-#   docker run --rm -v "$(pwd):/src" yuzu-ci clang-18 release
+# Usage — Clang 21 release:
+#   docker run --rm -v "$(pwd):/src" yuzu-ci clang-21 release
 #
 # Usage — interactive shell:
 #   docker run --rm -it -v "$(pwd):/src" yuzu-ci bash
 
-FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
+# Ubuntu 26.04 (Resolute) — matches the Big Tam self-hosted Linux runner.
+# GCC 15 / Clang 21 are 26.04 defaults. Multi-arch OCI index digest.
+FROM ubuntu:26.04@sha256:53958ec7b67c2c9355df922dd08dbf0360611f8c3cdb656875e81873db9ffdba
 
 # ── System packages (matches ci.yml) ─────────────────────────────────────
 RUN apt-get update && apt-get install -y \
         cmake ninja-build pkg-config curl zip unzip tar \
         python3-pip ccache git \
         bison flex libsystemd-dev \
-        gcc-13 g++-13 clang-18 \
+        gcc-15 g++-15 clang-21 \
     && pip3 install --break-system-packages meson==1.9.2 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -58,4 +60,4 @@ RUN chmod +x /usr/local/bin/ci-entrypoint.sh
 
 WORKDIR /build
 ENTRYPOINT ["ci-entrypoint.sh"]
-CMD ["gcc-13", "debug"]
+CMD ["gcc-15", "debug"]

--- a/deploy/docker/Dockerfile.ci-linux
+++ b/deploy/docker/Dockerfile.ci-linux
@@ -11,7 +11,11 @@
 #       runs-on: ubuntu-24.04
 #       container: ghcr.io/tr3kkr/yuzu-ci-linux:latest
 
-FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
+# Ubuntu 26.04 (Resolute) — matches the native OS of the Big Tam self-hosted
+# Linux runner pool (yuzu-bigtam-linux). GCC 15 / Clang 21 are 26.04 defaults;
+# gcc-13 (24.04 / Shulgi) is retired from this image as part of the runner
+# cutover. Digest is the multi-arch OCI index for ubuntu:26.04.
+FROM ubuntu:26.04@sha256:53958ec7b67c2c9355df922dd08dbf0360611f8c3cdb656875e81873db9ffdba
 
 ARG MESON_VERSION=1.9.2
 ARG VCPKG_COMMIT=4b77da7fed37817f124936239197833469f1b9a8
@@ -20,7 +24,7 @@ ARG VCPKG_COMMIT=4b77da7fed37817f124936239197833469f1b9a8
 RUN apt-get update && apt-get install -y \
     # Build essentials
     cmake ninja-build make pkg-config ccache \
-    gcc-13 g++-13 \
+    gcc-15 g++-15 \
     # Autotools (required by vcpkg ports: c-ares, grpc) + bison/flex (libpq)
     autoconf automake libtool bison flex \
     # sd-bus headers for the Linux Guardian systemd service guard (agent build)
@@ -64,10 +68,10 @@ RUN git clone https://github.com/microsoft/vcpkg.git /opt/vcpkg \
 ENV VCPKG_ROOT=/opt/vcpkg
 
 # ── Default compiler symlinks (must be before vcpkg install) ──────────
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 130 \
-    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 130 \
-    && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-13 130 \
-    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-13 130
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-15 150 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-15 150 \
+    && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-15 150 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-15 150
 
 # ── vcpkg packages installed at CI runtime via NuGet/x-gha cache ──────
 # Pre-baking vcpkg into Docker is fragile (OpenSSL download auth,

--- a/deploy/docker/Dockerfile.server-asan
+++ b/deploy/docker/Dockerfile.server-asan
@@ -14,21 +14,22 @@ WORKDIR /build/src
 RUN rm -rf builddir vcpkg_installed node_modules .uat gateway/_build gateway/.deps_cache \
     && cp -r /opt/vcpkg_installed ./vcpkg_installed
 
-RUN CC="gcc-13" CXX="g++-13" \
+RUN CC="gcc-15" CXX="g++-15" \
     PKG_CONFIG_PATH=/build/src/vcpkg_installed/x64-linux/lib/pkgconfig \
     meson setup builddir \
-      --native-file meson/native/linux-gcc13.ini \
+      --native-file meson/native/linux-gcc15.ini \
       --buildtype=debug \
       -Dcmake_prefix_path=/build/src/vcpkg_installed/x64-linux \
       -Dbuild_tests=false \
       -Db_sanitize=address,undefined \
     && meson compile -C builddir
 
-# Runtime — need libasan and libubsan from GCC
-FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
+# Runtime — need libasan and libubsan from GCC (Ubuntu 26.04; gcc-15 still
+# ships its ASan/UBSan runtimes as libasan8/libubsan1)
+FROM ubuntu:26.04@sha256:53958ec7b67c2c9355df922dd08dbf0360611f8c3cdb656875e81873db9ffdba
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        libgcc-13-dev libstdc++6 libssl3t64 ca-certificates \
+        libgcc-15-dev libstdc++6 libssl3t64 ca-certificates \
         libasan8 libubsan1 \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && useradd -r -s /sbin/nologin yuzu

--- a/deploy/docker/Dockerfile.server-tsan
+++ b/deploy/docker/Dockerfile.server-tsan
@@ -13,20 +13,20 @@ WORKDIR /build/src
 RUN rm -rf builddir vcpkg_installed node_modules .uat gateway/_build gateway/.deps_cache \
     && cp -r /opt/vcpkg_installed ./vcpkg_installed
 
-RUN CC="gcc-13" CXX="g++-13" \
+RUN CC="gcc-15" CXX="g++-15" \
     PKG_CONFIG_PATH=/build/src/vcpkg_installed/x64-linux/lib/pkgconfig \
     meson setup builddir \
-      --native-file meson/native/linux-gcc13.ini \
+      --native-file meson/native/linux-gcc15.ini \
       --buildtype=debug \
       -Dcmake_prefix_path=/build/src/vcpkg_installed/x64-linux \
       -Dbuild_tests=false \
       -Db_sanitize=thread \
     && meson compile -C builddir
 
-FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
+FROM ubuntu:26.04@sha256:53958ec7b67c2c9355df922dd08dbf0360611f8c3cdb656875e81873db9ffdba
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        libgcc-13-dev libstdc++6 libssl3t64 ca-certificates \
+        libgcc-15-dev libstdc++6 libssl3t64 ca-certificates \
         libtsan2 \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && useradd -r -s /sbin/nologin yuzu

--- a/deploy/docker/ci-entrypoint.sh
+++ b/deploy/docker/ci-entrypoint.sh
@@ -2,8 +2,8 @@
 # Yuzu CI entrypoint — run configure + build + test matching ci.yml
 #
 # Usage:
-#   ci-entrypoint.sh gcc-13 debug     # GCC 13 debug build
-#   ci-entrypoint.sh clang-18 release # Clang 18 release build
+#   ci-entrypoint.sh gcc-15 debug     # GCC 15 debug build
+#   ci-entrypoint.sh clang-21 release # Clang 21 release build
 #   ci-entrypoint.sh bash             # interactive shell
 
 set -euo pipefail
@@ -13,7 +13,7 @@ if [[ "${1:-}" == "bash" || "${1:-}" == "sh" ]]; then
     exec "$@"
 fi
 
-COMPILER="${1:-gcc-13}"
+COMPILER="${1:-gcc-15}"
 BUILD_TYPE="${2:-debug}"
 
 echo "════════════════════════════════════════════════════════"
@@ -37,18 +37,18 @@ cp -r /opt/vcpkg_installed ./vcpkg_installed
 
 # ── Set compiler ─────────────────────────────────────────────────────────
 case "$COMPILER" in
-    gcc-13)
-        export CC="ccache gcc-13"
-        export CXX="ccache g++-13"
-        NATIVE_FILE="meson/native/linux-gcc13.ini"
+    gcc-15)
+        export CC="ccache gcc-15"
+        export CXX="ccache g++-15"
+        NATIVE_FILE="meson/native/linux-gcc15.ini"
         ;;
-    clang-18)
-        export CC="ccache clang-18"
-        export CXX="ccache clang++-18"
-        NATIVE_FILE="meson/native/linux-clang18.ini"
+    clang-21)
+        export CC="ccache clang-21"
+        export CXX="ccache clang++-21"
+        NATIVE_FILE="meson/native/linux-clang21.ini"
         ;;
     *)
-        echo "Unknown compiler: $COMPILER (use gcc-13 or clang-18)"
+        echo "Unknown compiler: $COMPILER (use gcc-15 or clang-21)"
         exit 1
         ;;
 esac

--- a/docs/ci-architecture.md
+++ b/docs/ci-architecture.md
@@ -50,8 +50,31 @@ dormant until merged.
 | Runner | Host | Jobs |
 |---|---|---|
 | `yuzu-wsl2-linux` | Shulgi 5950X WSL2 Ubuntu 24.04 | proto-compat, linux matrix, nightly (asan/tsan/coverage), cache-prune-linux |
+| `yuzu-bigtam-linux-{0..3}` | Big Tam Threadripper 9970X, native Ubuntu **26.04** | Linux CI pool (shared label `yuzu-bigtam-linux`) — successor to Shulgi for the Linux legs; see "Ubuntu 26.04 migration" below |
 | `yuzu-local-windows` | Shulgi native Windows 11 | windows matrix, cache-prune-windows |
 | `macos-15` | GitHub-hosted | macos matrix |
+
+### Ubuntu 26.04 migration (Big Tam)
+
+Big Tam is a native **Ubuntu 26.04 (Resolute)** box whose default toolchain is
+**GCC 15 / Clang 21** — versus Shulgi's Ubuntu 24.04 (GCC 13 / Clang 19). The
+self-hosted Linux build is being moved to it. The 26.04/gcc-15 scaffolding is
+**staged but not yet live** (the live self-hosted jobs still target Shulgi@24.04
+on gcc-13/clang-19):
+
+- Native files `meson/native/linux-gcc15.ini` + `linux-clang21.ini` exist (the
+  24.04 `linux-gcc13.ini`/`linux-clang19.ini` stay for Shulgi).
+- The CI runner image (`Dockerfile.ci-linux`), the local `Dockerfile.ci`, and
+  the four sanitizer images (`Dockerfile.{server,agent}-{asan,tsan}`) are on
+  `ubuntu:26.04` + gcc-15/clang-21. `gcc-13` and `clang-19` remain installable
+  from 26.04's archive (gcc-13 in *universe*; clang-19 in-archive) but are not
+  the defaults.
+- `pre-release.yml`'s `install-deb` smoke matrix gained an `ubuntu:26.04` leg.
+
+The remaining **flip** (live `runs-on`/compiler/`ImageOS` changes) is deferred
+until Big Tam is confirmed online — Shulgi (24.04) cannot build gcc-15/clang-21,
+so flipping while it is the only available Linux runner would red the board. The
+exact one-shot flip is enumerated in **`docs/ci-ubuntu-2604-cutover.md`**.
 
 Inventory declared in `.github/runner-inventory.json`. The sentinel at
 `runner-inventory-sentinel.yml` (every 30 min) compares actual to expected

--- a/docs/ci-ubuntu-2604-cutover.md
+++ b/docs/ci-ubuntu-2604-cutover.md
@@ -1,6 +1,21 @@
 # CI cutover runbook — Shulgi (Ubuntu 24.04) → Big Tam (Ubuntu 26.04)
 
-Status: **staged, not yet flipped** (2026-06-20).
+Status: **ci.yml linux leg FLIPPED + validated on Big Tam** (2026-06-20). Remaining:
+sanitizer-tests → nightly → codeql still on Shulgi.
+
+Branch `ci/ubuntu-2604-cutover`. Two extra shared-host fixes were needed beyond the
+plan, both because Big Tam runs **4 runners on one host** (Shulgi was one):
+- **apt lock:** the matrix legs race `apt-get`. `DPkg::Lock::Timeout` does NOT cover
+  `apt-get update`'s lists lock, so the install step is wrapped in `flock -w 600 9 …
+  9>/tmp/yuzu-ci-apt.lock`. **The sanitizer/nightly/codeql legs must add the SAME
+  flock when they move to Big Tam** (reuse that lock path so they coordinate).
+- **eunit fixed-port collision:** `yuzu_gw_health_nf_tests` hardcoded `health_port=18081`
+  → 2nd concurrent leg got `eaddrinuse` → setup crash → eunit cancelled the group
+  ("0 failures, one cancelled, exit 1"). Fixed to ephemeral port 0 (commit `60412341`).
+- Pre-created shared `yuzu-ci-postgres` container (no per-leg creation race) + job-env
+  `YUZU_GW_ALLOW_DEFAULT_COOKIE=1` (harmless defence; the cookie reports were red herrings).
+- The per-runner `.env` (HOME/ERL_EPMD_PORT) was tried but the runner ignored it; it
+  proved unnecessary once the above landed.
 
 The self-hosted Linux CI is moving from Shulgi (`yuzu-wsl2-linux`, WSL2 Ubuntu
 24.04, GCC 13 / Clang 19) to the Big Tam pool (`yuzu-bigtam-linux-{0..3}`, native

--- a/docs/ci-ubuntu-2604-cutover.md
+++ b/docs/ci-ubuntu-2604-cutover.md
@@ -1,0 +1,109 @@
+# CI cutover runbook — Shulgi (Ubuntu 24.04) → Big Tam (Ubuntu 26.04)
+
+Status: **staged, not yet flipped** (2026-06-20).
+
+The self-hosted Linux CI is moving from Shulgi (`yuzu-wsl2-linux`, WSL2 Ubuntu
+24.04, GCC 13 / Clang 19) to the Big Tam pool (`yuzu-bigtam-linux-{0..3}`, native
+Ubuntu 26.04, **GCC 15 / Clang 21**). This runbook is the one-shot flip to run
+**once Big Tam is back online and healthy**.
+
+## Why it is deferred
+
+GCC 15 / Clang 21 exist only on Ubuntu 26.04. Shulgi is 24.04 and **cannot**
+build them. While Big Tam is offline, Shulgi is the only available Linux runner —
+flipping the compiler now would fail every self-hosted Linux job at the
+`apt-get install gcc-15` step. So the scaffolding below is landed, but the live
+`runs-on:` / compiler / `ImageOS` changes wait for Big Tam.
+
+## What is already staged (this PR)
+
+- `meson/native/linux-gcc15.ini`, `meson/native/linux-clang21.ini` (additive; the
+  24.04 `linux-gcc13.ini` / `linux-clang19.ini` stay for Shulgi).
+- `deploy/docker/Dockerfile.ci-linux`, `Dockerfile.ci` (+ `ci-entrypoint.sh`),
+  and the four sanitizer images `Dockerfile.{server,agent}-{asan,tsan}` →
+  `ubuntu:26.04` + gcc-15/clang-21. (`Dockerfile.runner-linux` left on its
+  `actions-runner` base — it is the *containerized* runner path, not Big Tam,
+  which is a native runner.)
+- `.github/workflows/pre-release.yml` `install-deb` matrix gained `ubuntu:26.04`.
+
+## Pre-flip verification (do these first)
+
+Status verified on Big Tam 2026-06-20 (now back online): OS = Ubuntu 26.04,
+gcc-15/g++-15 installed, clang-21 + the rest apt-installable, `runner` user has a
+dedicated `/etc/sudoers.d/10-runner` NOPASSWD grant, runners run as `runner` from
+`/home/runner/r{0..3}`. Outstanding items below.
+
+0. **Container runtime (HARD PREREQ).** `scripts/ci/ensure-postgres.sh` needs
+   docker (or a pre-set `YUZU_TEST_POSTGRES_DSN`) for the server-test step. Big
+   Tam shipped with **no** container runtime. Install it (needs root on Big Tam):
+   ```
+   sudo apt-get update && sudo apt-get install -y docker.io
+   sudo usermod -aG docker runner
+   sudo systemctl restart 'actions.runner.Tr3kkR-Yuzu.yuzu-bigtam-linux-*.service'
+   sudo -u runner docker run --rm hello-world   # verify
+   ```
+   (`docker.io` 29.1.3 is in 26.04's archive; Docker Hub egress confirmed.)
+   Without this the `linux` job fails at "Ensure Postgres".
+1. **Big Tam online & healthy** — `gh api repos/Tr3kkR/Yuzu/actions/runners`
+   shows `yuzu-bigtam-linux-*` as `online`; ci.yml `preflight` reports
+   `bigtam_pool_healthy == true`.
+2. **Toolchain present on the host** — validated on `ubuntu:26.04` and on Big Tam:
+   gcc 15.2.0 default, clang-21 1.21.1.8,
+   `libasan8`/`libubsan1`/`libtsan2`/`libssl3t64`/`libgcc-15-dev`/`libpq5` all
+   resolve; a C++23 `<print>` program compiles & runs.
+3. **`erlef/setup-beam` ImageOS — RESOLVED: keep `ubuntu24`.** setup-beam has
+   **no** `ubuntu26` prebuilt OTP (supported ImageOS tops out at `ubuntu24`).
+   ImageOS only selects which OTP tarball to fetch; the 24.04 build runs on 26.04
+   (same `libcrypto.so.3` soname). **Do NOT flip ImageOS to ubuntu26** — it would
+   fail to resolve the asset. Validate via `gateway eunit` on the Big Tam leg.
+4. **Per-runner state** — `scripts/ci/ensure-postgres.sh` works on Big Tam (needs
+   item 0); ccache (`~/.cache/ccache`) and the vcpkg binary cache
+   (`runner.tool_cache/yuzu-vcpkg-binary-cache-linux`) directories are writable.
+
+## The flip (edits)
+
+Reference by content — line numbers drift. In every file below, the change is
+`gcc-13`→`gcc-15`, `g++-13`→`g++-15`, `clang-19`→`clang-21`,
+`clang++-19`→`clang++-21`, `linux-gcc13.ini`→`linux-gcc15.ini`,
+`linux-clang19.ini`→`linux-clang21.ini`. **`ImageOS: ubuntu24` stays `ubuntu24`**
+(see pre-flip item 3). Pin compile jobs to `…, yuzu-bigtam-linux` and gate them on
+`bigtam_pool_healthy` (compiler-agnostic jobs like proto-compat stay on the
+broader `linux_pool` gate).
+
+Incremental order: do ci.yml first, prove it green on Big Tam, then the rest.
+
+1. **`.github/workflows/ci.yml`** — `linux` job — **DONE (2026-06-20).**
+   matrix→`[gcc-15, clang-21]`, the `exclude` ternaries, the apt line, `CC`/`CXX`,
+   `--native-file`, `-Db_lto`; `runs-on`→`[self-hosted, Linux, X64, yuzu-bigtam-linux]`;
+   `if`→`bigtam_pool_healthy == 'true'` (new gate added to
+   `scripts/ci/runner-health-check.py` + the preflight outputs). `ImageOS` left at
+   `ubuntu24` with an explanatory comment. `proto-compat` left on the generic pool
+   (no compiler — needs no pin). The GHA-hosted **canary** stays on
+   `ubuntu-24.04`/gcc-13 per the "keep GHA-hosted on 24.04" decision, so it no
+   longer mirrors the primary toolchain (a known, accepted divergence).
+2. **`.github/workflows/sanitizer-tests.yml`** — repin
+   `[self-hosted, Linux, X64, yuzu-shulgi]` → `…, yuzu-bigtam-linux`; bump the
+   `gcc-13`/`g++-13` tool-presence checks + `CC: ccache gcc-13`. Add a
+   `bigtam_pool_healthy` gate (it currently has none). Leave `ImageOS: ubuntu24`.
+3. **`.github/workflows/nightly.yml`** — ASan + TSan legs repin
+   `yuzu-shulgi` → `yuzu-bigtam-linux`; the generic coverage leg is already
+   pool-labelled; bump every `gcc-13 g++-13` apt line and `CC: ccache gcc-13`.
+   Leave `ImageOS: ubuntu24`.
+4. **`.github/workflows/codeql.yml`** — Linux leg repin `yuzu-shulgi` →
+   `yuzu-bigtam-linux`; bump the `TOOLS=` list and `CC: ccache gcc-13`.
+   Leave `ImageOS: ubuntu24`.
+5. **`.github/workflows/release.yml`** — the `[self-hosted, Linux]` legs match
+   both boxes. Decide deliberately: keep release on gcc-13 (Shulgi) until the PR
+   matrix has soaked on gcc-15, **or** move it. If moving, bump the `gcc-13 g++-13`
+   tool-check + `CC: ccache gcc-13` and pin to Big Tam.
+6. **`.github/runner-inventory.json`** — update the Shulgi role (no longer the
+   live Linux runner) and the Big Tam roles (now live); if Shulgi is retired from
+   Linux CI, reflect that.
+7. **`docs/ci-architecture.md`** — update the runner-topology table + flip this
+   doc's status to "flipped".
+
+## Rollback
+
+Revert the `runs-on` pins and compiler tokens to gcc-13/clang-19/`ImageOS: ubuntu24`
+and the jobs run on Shulgi again unchanged. The staged 26.04 Docker images and
+native files are inert when nothing references them, so they need no rollback.

--- a/gateway/apps/yuzu_gw/test/yuzu_gw_health_nf_tests.erl
+++ b/gateway/apps/yuzu_gw/test/yuzu_gw_health_nf_tests.erl
@@ -17,26 +17,47 @@
 %%%===================================================================
 
 health_nf_test_() ->
+    %% Instantiator form: the OS-assigned ephemeral port lives in the
+    %% setup result tuple and is closed over by each test fun. This is the
+    %% only safe way to thread the port through — calling
+    %% yuzu_gw_health:port/0 from inside a test issues a
+    %% gen_server:call(yuzu_gw_health, get_port) that can block up to ~1s
+    %% behind the server's blocking gen_tcp:accept(LSock, 1000) accept
+    %% loop. That latency exceeds the 200ms circuit-breaker reset timeout
+    %% and lets the circuit slip open->half_open before readyz is hit,
+    %% turning the expected 503 into a 200 (readyz_503_circuit_open).
     {setup,
      fun setup/0,
      fun cleanup/1,
-     {timeout, 30,
-      [
-       {"readyz 503 when registry process is dead",
-        fun readyz_503_dead_process/0},
-       {"readyz 503 when circuit breaker is open",
-        fun readyz_503_circuit_open/0},
-       {"concurrent health checks complete without error",
-        fun concurrent_health_checks/0},
-       {"healthz response time is bounded",
-        fun healthz_response_time/0},
-       {"readyz response time is bounded",
-        fun readyz_response_time/0}
-      ]}}.
+     fun({Port, _HealthPid, _UpPid, _MockPids}) ->
+        {timeout, 30,
+         [
+          {"readyz 503 when registry process is dead",
+           fun() -> readyz_503_dead_process(Port) end},
+          {"readyz 503 when circuit breaker is open",
+           fun() -> readyz_503_circuit_open(Port) end},
+          {"concurrent health checks complete without error",
+           fun() -> concurrent_health_checks(Port) end},
+          {"healthz response time is bounded",
+           fun() -> healthz_response_time(Port) end},
+          {"readyz response time is bounded",
+           fun() -> readyz_response_time(Port) end}
+         ]}
+     end}.
 
 setup() ->
-    Port = 18081,
-    application:set_env(yuzu_gw, health_port, Port),
+    %% Bind to port 0 — the OS picks a free ephemeral port. A previous
+    %% version hardcoded 18081, which collides when Big Tam runs 4 CI
+    %% matrix legs concurrently on one host: the second leg's
+    %% yuzu_gw_health:init/1 gets {error, eaddrinuse} from gen_tcp:listen,
+    %% start_link returns {error, {listen_failed, eaddrinuse}}, the
+    %% `{ok, HealthPid} = ...` match in this setup crashes, and eunit
+    %% CANCELS the whole group ("One or more tests were cancelled", 0
+    %% failures). SO_REUSEADDR does not let two live listeners share a
+    %% port, so it cannot save us. Ephemeral binding eliminates the whole
+    %% class — the same fix yuzu_gw_health_tests already carries. Tests
+    %% read the actual port back via health_port/0 (yuzu_gw_health:port/0).
+    application:set_env(yuzu_gw, health_port, 0),
 
     %% Trap exits for the group process. With {setup, ...}, the group
     %% process stays alive while tests run in sub-processes. The upstream
@@ -80,9 +101,12 @@ setup() ->
     application:set_env(yuzu_gw, circuit_breaker_max_reset_timeout_ms, 1000),
     {ok, UpPid} = yuzu_gw_upstream:start_link(),
 
-    %% Start the health endpoint.
+    %% Start the health endpoint, then read back the OS-assigned ephemeral
+    %% port. The 100ms sleep keeps the original margin so the accept loop
+    %% is up before any test fires.
     {ok, HealthPid} = yuzu_gw_health:start_link(),
     timer:sleep(100),
+    {ok, Port} = yuzu_gw_health:port(),
     {Port, HealthPid, UpPid, MockPids}.
 
 cleanup({_Port, HealthPid, UpPid, MockPids}) ->
@@ -189,7 +213,7 @@ safe_meck_new(Mod, Opts) ->
 %%% Tests
 %%%===================================================================
 
-readyz_503_dead_process() ->
+readyz_503_dead_process(Port) ->
     %% Kill the registry mock to simulate a dead core process.
     %% Must trap exits to avoid cascading death to the test process.
     process_flag(trap_exit, true),
@@ -203,7 +227,7 @@ readyz_503_dead_process() ->
             timer:sleep(50)
     end,
     drain_exits(),
-    {Status, Body} = http_get(18081, "/readyz"),
+    {Status, Body} = http_get(Port, "/readyz"),
     ?assertEqual(503, Status),
     ?assert(binary:match(Body, <<"not_ready">>) =/= nomatch),
     ?assert(binary:match(Body, <<"\"registry\":false">>) =/= nomatch),
@@ -212,7 +236,7 @@ readyz_503_dead_process() ->
     register(yuzu_gw_registry, NewPid),
     process_flag(trap_exit, false).
 
-readyz_503_circuit_open() ->
+readyz_503_circuit_open(Port) ->
     %% Trip the circuit breaker to open state.
     meck:expect(grpcbox_client, unary, fun(_, _, _, _, _) ->
         {error, connection_refused}
@@ -223,7 +247,7 @@ readyz_503_circuit_open() ->
     ?assertEqual(open, yuzu_gw_upstream:circuit_state()),
 
     %% readyz should now return 503.
-    {Status, Body} = http_get(18081, "/readyz"),
+    {Status, Body} = http_get(Port, "/readyz"),
     ?assertEqual(503, Status),
     ?assert(binary:match(Body, <<"not_ready">>) =/= nomatch),
     ?assert(binary:match(Body, <<"\"circuit_breaker\":false">>) =/= nomatch),
@@ -237,12 +261,12 @@ readyz_503_circuit_open() ->
     {ok, _} = yuzu_gw_upstream:proxy_register(#{info => #{}}),
     ?assertEqual(closed, yuzu_gw_upstream:circuit_state()).
 
-concurrent_health_checks() ->
+concurrent_health_checks(Port) ->
     %% Fire 50 concurrent healthz requests and verify all succeed.
     Self = self(),
     N = 50,
     Workers = [spawn_link(fun() ->
-        Result = http_get(18081, "/healthz"),
+        Result = http_get(Port, "/healthz"),
         Self ! {health_result, I, Result}
     end) || I <- lists:seq(1, N)],
 
@@ -259,11 +283,11 @@ concurrent_health_checks() ->
     %% Workers are linked, will be cleaned up.
     _ = Workers.
 
-healthz_response_time() ->
+healthz_response_time(Port) ->
     %% Measure 20 sequential healthz requests. Average should be < 10ms.
     Timings = [begin
         T0 = erlang:monotonic_time(microsecond),
-        {200, _} = http_get(18081, "/healthz"),
+        {200, _} = http_get(Port, "/healthz"),
         T1 = erlang:monotonic_time(microsecond),
         T1 - T0
     end || _ <- lists:seq(1, 20)],
@@ -271,11 +295,11 @@ healthz_response_time() ->
     %% Average should be well under 10ms (10000 us).
     ?assert(AvgUs < 10000).
 
-readyz_response_time() ->
+readyz_response_time(Port) ->
     %% readyz does process checks + circuit breaker query. Should still be fast.
     Timings = [begin
         T0 = erlang:monotonic_time(microsecond),
-        {200, _} = http_get(18081, "/readyz"),
+        {200, _} = http_get(Port, "/readyz"),
         T1 = erlang:monotonic_time(microsecond),
         T1 - T0
     end || _ <- lists:seq(1, 20)],

--- a/meson/native/linux-clang21.ini
+++ b/meson/native/linux-clang21.ini
@@ -1,0 +1,11 @@
+# Meson native file: Linux x64 with Clang 21
+# Usage: meson setup builddir --native-file meson/native/linux-clang21.ini
+# NOTE: Set CC/CXX env vars to control compiler selection (e.g. CC='ccache clang-21')
+#
+# Clang 21 is the default LLVM/Clang on Ubuntu 26.04 (Resolute). This native
+# file is the Ubuntu-26.04 / Big Tam counterpart to linux-clang19.ini (Ubuntu
+# 24.04 / Shulgi). It is staged ahead of the self-hosted Linux runner cutover
+# documented in docs/ci-architecture.md — nothing references it until the flip.
+
+[built-in options]
+cpp_std = 'c++23'

--- a/meson/native/linux-gcc15.ini
+++ b/meson/native/linux-gcc15.ini
@@ -1,0 +1,11 @@
+# Meson native file: Linux x64 with GCC 15
+# Usage: meson setup builddir --native-file meson/native/linux-gcc15.ini
+# NOTE: Set CC/CXX env vars to control compiler selection (e.g. CC='ccache gcc-15')
+#
+# GCC 15 is the default toolchain on Ubuntu 26.04 (Resolute). This native
+# file is the Ubuntu-26.04 / Big Tam counterpart to linux-gcc13.ini (Ubuntu
+# 24.04 / Shulgi). It is staged ahead of the self-hosted Linux runner cutover
+# documented in docs/ci-architecture.md — nothing references it until the flip.
+
+[built-in options]
+cpp_std = 'c++23'

--- a/scripts/ci/runner-health-check.py
+++ b/scripts/ci/runner-health-check.py
@@ -56,12 +56,29 @@ INVENTORY_PATH = ".github/runner-inventory.json"
 # emitted unchanged (the sentinel and any pinned-runner gates rely on them).
 LINUX_POOL_LABELS = frozenset({"self-hosted", "Linux", "X64"})
 
+# The Big Tam Linux pool. The ci.yml `linux` compile job pins
+# runs-on: [self-hosted, Linux, X64, yuzu-bigtam-linux] because its toolchain
+# (GCC 15 / Clang 21) exists only on Big Tam's Ubuntu 26.04 — Shulgi (24.04)
+# cannot build it. preflight emits `bigtam_pool_healthy=true` iff >=1 such
+# runner is online, so the pinned job skips fast (fail-closed) instead of
+# queueing forever against an offline Big Tam. The compiler-agnostic
+# proto-compat job stays on the broader linux_pool gate.
+BIGTAM_POOL_LABELS = frozenset({"self-hosted", "Linux", "X64", "yuzu-bigtam-linux"})
+
 
 def linux_pool_members(expected: dict[str, Any]) -> list[str]:
     """Declared runners eligible for the [self-hosted, Linux, X64] job pool."""
     return [
         name for name, exp in expected.items()
         if LINUX_POOL_LABELS.issubset(set(exp["labels"]))
+    ]
+
+
+def bigtam_pool_members(expected: dict[str, Any]) -> list[str]:
+    """Declared runners eligible for the Big Tam (yuzu-bigtam-linux) job pool."""
+    return [
+        name for name, exp in expected.items()
+        if BIGTAM_POOL_LABELS.issubset(set(exp["labels"]))
     ]
 
 
@@ -179,6 +196,7 @@ def main() -> int:
         for name in expected:
             write_output(f"{slug(name)}_healthy", "true")
         write_output("linux_pool_healthy", "true")
+        write_output("bigtam_pool_healthy", "true")
         write_output("all_healthy", "true")
         return 0
 
@@ -189,6 +207,7 @@ def main() -> int:
             for name in expected:
                 write_output(f"{slug(name)}_healthy", "false")
             write_output("linux_pool_healthy", "false")
+            write_output("bigtam_pool_healthy", "false")
             write_output("all_healthy", "false")
             return 0
         return 1
@@ -253,6 +272,10 @@ def main() -> int:
         pool = linux_pool_members(expected)
         pool_ok = any(healthy_map.get(n, False) for n in pool)
         write_output("linux_pool_healthy", "true" if pool_ok else "false")
+        # Big Tam sub-pool gate for the gcc-15/clang-21 compile job (26.04-only).
+        bigtam_pool = bigtam_pool_members(expected)
+        bigtam_ok = any(healthy_map.get(n, False) for n in bigtam_pool)
+        write_output("bigtam_pool_healthy", "true" if bigtam_ok else "false")
         write_output("all_healthy", "true" if all_healthy else "false")
         if drift:
             print("=== HEALTH ISSUES (preflight mode — non-fatal) ===")


### PR DESCRIPTION
## What

Cuts the self-hosted Linux CI build over from **Shulgi** (`yuzu-wsl2-linux`, WSL2 Ubuntu 24.04, GCC 13 / Clang 19) to the **Big Tam** pool (`yuzu-bigtam-linux-{0..3}`, native Ubuntu **26.04**, GCC 15 / Clang 21). The `ci.yml` `linux` job is flipped and validated; the supporting 26.04 scaffolding lands with it.

GHA-hosted jobs deliberately **stay on `ubuntu-24.04`** (still GA; 26.04 hosted images are public-preview). `ImageOS` stays `ubuntu24` for `setup-beam` (no ubuntu26 prebuilt OTP yet; the 24.04 OTP runs on 26.04 — same `libcrypto.so.3` soname).

## Changes

- **ci.yml `linux` job** → matrix `[gcc-15, clang-21]`; pinned to the `yuzu-bigtam-linux` label; gated on a new `bigtam_pool_healthy` preflight output (fail-closed). `proto-compat` stays on the generic pool; the GHA-hosted canary stays on 24.04/gcc-13.
- **`scripts/ci/runner-health-check.py`** → new `bigtam_pool_healthy` gate.
- **`meson/native/`** → add `linux-gcc15.ini`, `linux-clang21.ini`.
- **Docker images** (`Dockerfile.ci-linux`, `Dockerfile.ci`, the 4 sanitizer images, `ci-entrypoint.sh`) → `ubuntu:26.04` + gcc-15/clang-21; `libgcc-13-dev` → `libgcc-15-dev` (asan/ubsan/tsan/ssl libs unchanged on 26.04).
- **`pre-release.yml`** → add `ubuntu:26.04` to the install-deb smoke matrix.
- **Docs** → `ci-architecture.md` migration section + `ci-ubuntu-2604-cutover.md` runbook.

### Shared-host fixes (Big Tam runs 4 runners on one host; Shulgi was one)

- **apt lock:** the matrix legs race `apt-get`. `DPkg::Lock::Timeout` does **not** cover `apt-get update`'s lists lock, so the install step is wrapped in `flock -w 600 9 … 9>/tmp/yuzu-ci-apt.lock`.
- **eunit fixed-port collision:** `yuzu_gw_health_nf_tests` hardcoded `health_port=18081`; a 2nd concurrent leg got `eaddrinuse` → `setup/0` crash → eunit **cancelled the group** ("0 failures, one cancelled, exit 1"). Fixed to ephemeral port 0 (diagnosed by the gateway-erlang agent).
- Pre-created shared `yuzu-ci-postgres` container (no per-leg creation race) + job-env `YUZU_GW_ALLOW_DEFAULT_COOKIE=1` (defence; the cookie reports were red herrings).

## Validation

- **2× full 4-leg runs all green on Big Tam** (gcc-15/clang-21 × debug/release): compile + full test suite + gateway eunit.
- Local gateway eunit (`All 215 tests passed`) + `rebar3 dialyzer` clean (OTP 28).

## Out of scope (follow-up)

`sanitizer-tests`, `nightly` (asan/tsan/coverage), and `codeql` Linux legs are still on Shulgi — they migrate to Big Tam next (same repin + gcc-15 + apt-flock treatment; see the runbook). Shulgi serves them fine meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)