### PR TITLE
ci: Phase-2 quick wins — CodeQL daily, Linux/macOS observability, proto-compat fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
       # Pool gate for the [self-hosted, Linux, X64] jobs (proto-compat, linux):
       # true iff >=1 eligible Linux runner (any yuzu-bigtam-* OR the yuzu-wsl2-linux
       # Shulgi fallback) is online. Replaces the old single-named yuzu_wsl2_linux gate.
+      linux_pool_healthy: ${{ steps.health.outputs.linux_pool_healthy }}
       # Big Tam sub-pool (yuzu-bigtam-linux) — gates the gcc-15/clang-21 compile
       # job, whose 26.04-only toolchain cannot run on the Shulgi 24.04 fallback.
       bigtam_pool_healthy: ${{ steps.health.outputs.bigtam_pool_healthy }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
       # runner.tool_cache binary caches — those have their own
       # sentinel, see scripts/ci/vcpkg-triplet-sentinel.sh).
       - name: Wipe build-linux*/ on branch switch (pre-checkout)
-        # Per-variant dirs (build-linux-gcc-13-debug, ...) — wipe all of
+        # Per-variant dirs (build-linux-gcc-15-debug, ...) — wipe all of
         # them on branch switch, not just the matrix-specific one, so
         # any stale variant-dir from a different branch is also cleared.
         run: |
@@ -332,7 +332,7 @@ jobs:
         env:
           # Single shared cache across all matrix variants. The x64-linux
           # triplet produces bit-identical package zips regardless of the
-          # consuming compiler (gcc-13 vs clang-19) or buildtype (vcpkg
+          # consuming compiler (gcc-15 vs clang-21) or buildtype (vcpkg
           # builds with its own toolchain, not the consumer's). Sharing
           # one cache means the first matrix variant pays the from-source
           # cost (~25 min) and the other three restore in seconds, vs.
@@ -353,12 +353,13 @@ jobs:
           # Under clean:false (PR-5) build-linux/ may already be configured
           # from a previous matrix variant or push. meson setup errors on
           # Per-variant build dir under PR-5 clean:false. Sharing one
-          # build-linux/ across all 4 matrix legs (gcc-13/clang-19 ×
+          # build-linux/ across all 4 matrix legs (gcc-15/clang-21 ×
           # debug/release) trips a meson --reconfigure edge case where
           # the linker driver from a previous variant leaks into the
-          # current one — observed in run #25070779695 where Linux
-          # gcc-13 release ended up linking yuzu-agent with `clang++-19
-          # -flto` instead of `g++-13 -flto`, producing CLI11 undefined
+          # current one — observed historically in run #25070779695 (on
+          # the then-current gcc-13/clang-19 matrix) where Linux gcc-13
+          # release ended up linking yuzu-agent with `clang++-19 -flto`
+          # instead of `g++-13 -flto`, producing CLI11 undefined
           # references. Per-variant dirs eliminate the reconfigure
           # entirely; ccache absorbs the per-TU work across matrix runs
           # so the disk cost is the only added cost (~1-2 GB × 4).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,9 +425,39 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
-      - name: ccache stats
+      - name: ccache stats + build observability
         if: always()
-        run: ccache -s
+        run: |
+          # Informational only — never fail the job from here (set +e).
+          set +e
+          ccache -s
+          # Machine-readable parse for a job-summary: cache warmth + effective
+          # parallelism + LTO. Mirrors the Windows leg (P3 observability) so
+          # every self-hosted leg surfaces cold/fragmented caches and -j
+          # behaviour automatically, instead of only by hand.
+          s="$(ccache --print-stats 2>/dev/null)"
+          get(){ printf '%s\n' "$s" | awk -F'\t' -v k="$1" '$1==k{v=$2} END{print v+0}'; }
+          hits=$(( $(get direct_cache_hit) + $(get preprocessed_cache_hit) ))
+          miss=$(get cache_miss)
+          total=$(( hits + miss ))
+          rate="n/a"; [ "$total" -gt 0 ] && rate=$(( 100 * hits / total ))
+          {
+            echo "### Linux ${{ matrix.compiler }} ${{ matrix.build_type }} — cache & parallelism"
+            echo ""
+            echo "| metric | value |"
+            echo "|---|---|"
+            echo "| ccache hit rate | ${rate}% (${hits}/${total}) |"
+            echo "| ccache misses | ${miss} |"
+            echo "| effective -j | ${YUZU_BUILD_JOBS:-ninja default} |"
+            echo "| LTO | ${{ matrix.build_type == 'release' && matrix.compiler == 'gcc-15' && 'yes (link-time, ccache cannot accelerate)' || 'no' }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          # Cold-cache alarm: a near-zero hit rate over a meaningful sample on a
+          # self-hosted runner means the shared caches aren't warming (the
+          # fragmentation signal we previously only caught manually).
+          if [ "$total" -gt 100 ] && [ "$rate" != "n/a" ] && [ "$rate" -lt 40 ]; then
+            echo "::warning::ccache hit rate ${rate}% over ${total} compiles is low on the Big Tam self-hosted pool — caches may be cold/fragmented (see docs/ci-architecture.md)"
+          fi
+          exit 0
 
   # ── Windows (MSVC, self-hosted yuzu-local-windows) ─────────────────────
   windows:
@@ -876,9 +906,33 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
-      - name: ccache stats
+      - name: ccache stats + build observability
         if: always()
-        run: ccache -s
+        run: |
+          # Informational only — never fail the job from here (set +e).
+          set +e
+          ccache -s
+          # Mirror the Linux/Windows job-summary (P3 observability). macOS is a
+          # GHA-hosted ephemeral runner with an actions/cache-backed ccache, so
+          # a cold restore is expected on a cache-key miss — no cold-cache
+          # ::warning:: here (that signal is self-hosted-only).
+          s="$(ccache --print-stats 2>/dev/null)"
+          get(){ printf '%s\n' "$s" | awk -F'\t' -v k="$1" '$1==k{v=$2} END{print v+0}'; }
+          hits=$(( $(get direct_cache_hit) + $(get preprocessed_cache_hit) ))
+          miss=$(get cache_miss)
+          total=$(( hits + miss ))
+          rate="n/a"; [ "$total" -gt 0 ] && rate=$(( 100 * hits / total ))
+          {
+            echo "### macOS ${{ matrix.build_type }} — cache & parallelism"
+            echo ""
+            echo "| metric | value |"
+            echo "|---|---|"
+            echo "| ccache hit rate | ${rate}% (${hits}/${total}) |"
+            echo "| ccache misses | ${miss} |"
+            echo "| effective -j | ${YUZU_BUILD_JOBS:-ninja default} |"
+            echo "| LTO | ${{ matrix.build_type == 'release' && 'yes (link-time, ccache cannot accelerate)' || 'no' }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0
 
       # Paired saves for the two restore-only steps above. `if: always()`
       # is the documented replacement for `save-always: true` and lets

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ name: "CodeQL"
 #     build-{linux,windows}-{asan,tsan,coverage}/
 #   - Pre-build runner disk-free assertion (≥40 GB Linux, ≥45 GB Windows;
 #     MSVC debug builds are chunkier)
-#   - Weekly scheduled run (Sunday 04:00 UTC, low-activity window)
+#   - Daily scheduled run (04:00 UTC, low-activity window)
 #   - Manual workflow_dispatch
 #
 # Known remaining coverage gaps:
@@ -62,11 +62,13 @@ name: "CodeQL"
 on:
   workflow_dispatch:
   schedule:
-    # Weekly Sunday 04:00 UTC — off-hours, both runners available.
-    # Both Linux and Windows runs start simultaneously on their
-    # respective runners (no queue contention between them; they're
-    # different physical hosts on the same desktop).
-    - cron: "0 4 * * 0"
+    # Daily 04:00 UTC — off-hours, both runners available. Tightens C++
+    # vuln detection from <=7 days to <=24h (folds CodeQL into the Tier-3
+    # nightly cadence; it stays a ~20-25 min trace, NOT the PR fast-path).
+    # 04:00 is 2h ahead of nightly.yml's 06:00 cron so the two self-hosted
+    # Linux workloads don't contend for the Big Tam pool. Both Linux and
+    # Windows legs start simultaneously on their respective runners.
+    - cron: "0 4 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,7 +3,7 @@ name: "CodeQL"
 # CodeQL C++ + GitHub Actions static analysis across BOTH self-hosted
 # runners, running in parallel:
 #   - yuzu-wsl2-linux (labels: self-hosted/Linux/X64/yuzu-shulgi) — gcc-13 build
-#   - yuzu-local-windows (labels: self-hosted/Windows/X64) — MSVC build
+#   - yuzu-weetam-windows (labels: self-hosted/Windows/X64/yuzu-weetam-windows) — MSVC build
 #
 # The Linux leg pins `yuzu-shulgi` explicitly rather than matching the
 # bare `[self-hosted, Linux, X64]` label set. Today Shulgi is the only
@@ -117,7 +117,16 @@ jobs:
             disk_min_gb: 40
             shell: bash
           - os: windows
-            runner: [self-hosted, Windows, X64]
+            # yuzu-weetam-windows pin — successor to the retiring Shulgi
+            # yuzu-local-windows box (see deploy/windows/README.md). The bare
+            # [self-hosted, Windows, X64] set matches BOTH pools; pinning routes
+            # the daily trace to the proven Wee Tam fleet (shared vcpkg binary
+            # cache, meets the 45 GB disk floor). Wee Tam runners are CCD-pinned
+            # to 16 threads, so the Build step passes -j $YUZU_BUILD_JOBS (set by
+            # the pin wrapper) — without it ninja sizes -j from the 64-CPU host
+            # and thrashes the 32 MB L3 (the 98-min-timeout failure mode), which
+            # CCACHE_RECACHE's forced full recompile makes acute.
+            runner: [self-hosted, Windows, X64, yuzu-weetam-windows]
             triplet: x64-windows
             vcpkg_bin: vcpkg.exe
             build_dir: build-windows-codeql
@@ -383,7 +392,11 @@ jobs:
         # the cache update and degrade subsequent CI builds.
         env:
           CCACHE_RECACHE: "true"
-        run: meson compile -C ${{ matrix.build_dir }}
+        # -j is capped to the runner's pinned CCD width via $YUZU_BUILD_JOBS on
+        # Wee Tam (unset elsewhere → ninja default, so the Linux leg is
+        # unaffected). Essential here because CCACHE_RECACHE forces every TU to
+        # actually compile, so an uncapped ninja oversubscribes the pinned CCD.
+        run: meson compile -C ${{ matrix.build_dir }} ${YUZU_BUILD_JOBS:+-j $YUZU_BUILD_JOBS}
 
       - name: ccache stats
         if: always()


### PR DESCRIPTION
Phase-2 CI gap-closing on the already-mature pipeline. Five commits, two workflows, no change to build/test logic.

## Changes

**CodeQL → daily** — flips the schedule from weekly (Sun 04:00 UTC) to daily (04:00 UTC), tightening C++ vuln detection from ≤7 days to ≤24h. Recent runs finish in ~20-25 min, so a daily trace is cheap and stays off the PR fast-path. 04:00 sits 2h ahead of `nightly.yml`'s 06:00 cron so the two self-hosted Linux workloads don't contend for the Big Tam pool.

**CodeQL Windows leg → Wee Tam pool + `-j` cap** — pins the Windows leg to `yuzu-weetam-windows` instead of the bare `[self-hosted, Windows, X64]` set (which also matches the retiring Shulgi `yuzu-local-windows`), routing the now-daily trace to the proven Wee Tam fleet (shared vcpkg binary cache, meets the 45 GB disk floor). Adds `-j $YUZU_BUILD_JOBS` to the Build step (exported by the Wee Tam pin wrapper; unset elsewhere → Linux leg unaffected) — without it ninja sizes `-j` from the 64-CPU host and thrashes the CCD-pinned runner's L3, and `CCACHE_RECACHE` forces a full recompile every run so an uncapped build would reliably hit the timeout.
> ⚠️ **Overlap:** touches codeql.yml's top header line, which the in-flight `ci/bigtam-followup-self-hosted-legs` branch also rewrites. Expect a trivial rebase if that lands first. This commit is self-contained and can be dropped if you'd rather keep CodeQL on Shulgi until the retirement is executed.

**Build observability → Linux + macOS** — the Windows leg already emits a per-job "cache & parallelism" summary (ccache hit rate, misses, effective -j, LTO) + a cold-cache `::warning::`. Replicated on the Linux and macOS legs so every build surfaces cache warmth and `-j` behaviour automatically. Linux: LTO cell reflects the gcc-15-release-only LTO; cold-cache warning points at the Big Tam pool. macOS: no cold-cache warning (GHA-hosted ephemeral runner legitimately misses on a key change).

**Stale-comment cleanup** — three comments in ci.yml's linux job still named `gcc-13`/`clang-19`; the matrix flipped to gcc-15/clang-21 in #1609 (still 4 legs: gcc-15/clang-21 × debug/release). The run-#25070779695 reconfigure anecdote keeps its real names but is marked historical. The GHA-hosted ubuntu-24.04 canary's gcc-13 is correct and untouched.

**Bonus fix — proto-compat was silently skipping** — found via actionlint: `proto-compat` gates on `needs.preflight.outputs.linux_pool_healthy`, but preflight never re-exported that output, so the expression resolved to `''` and the job skipped on every run — the buf backward-compat check has not been running. `scripts/ci/runner-health-check.py` already emits the value; this wires it through (the orphaned comment above `bigtam_pool_healthy` was already describing this exact output — the declaration line had been dropped).

## Validation
- **actionlint** (Docker `rhysd/actionlint`, incl. bundled shellcheck on the embedded run-block bash): clean on every changed line. The remaining `yuzu-bigtam-linux` "unknown label" note is cosmetic/pre-existing — self-hosted custom labels need an `actionlint.yaml` config; it affects every self-hosted pin.
- pre-commit hooks (yaml / whitespace / merge-conflict): pass.

## Notes
- Cron + schedule changes only take effect once on the default branch (`main`).
- The observability parse block is now duplicated across three legs; intentional for now — if a 4th consumer appears it should move to a composite action under `.github/actions/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)