### PR TITLE
ci: retire Shulgi & yuzu-local-windows — all self-hosted jobs to Big Tam / Wee Tam + build speed

### DIFF
--- a/.github/workflows/cache-prune.yml
+++ b/.github/workflows/cache-prune.yml
@@ -57,11 +57,11 @@ jobs:
         run: |
           set -eu
           # docker-publish-chisel writes a type=local,mode=max buildx cache per
-          # image under /mnt/d/docker-buildcache/<image>-chisel — several GB per
-          # arch with no built-in eviction. buildx rewrites the dir each run, so
-          # an untouched *-chisel dir is genuinely stale. Linux-only (the chisel
-          # C++ builds run on the self-hosted Linux runner).
-          bc="/mnt/d/docker-buildcache"
+          # image under $RUNNER_TOOL_CACHE/yuzu-docker-buildcache/<image>-chisel —
+          # several GB per arch with no built-in eviction. buildx rewrites the dir
+          # each run, so an untouched *-chisel dir is genuinely stale. Linux-only
+          # (the chisel C++ builds run on the self-hosted Big Tam Linux runner).
+          bc="${RUNNER_TOOL_CACHE:-/opt/actions-runner/_work/_tool}/yuzu-docker-buildcache"
           if [[ ! -d "$bc" ]]; then
             echo "::notice::buildx cache dir $bc not present — skipping"
             exit 0
@@ -73,7 +73,7 @@ jobs:
 
   prune-windows:
     name: "Prune Windows runner cache"
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, yuzu-weetam-windows]
     timeout-minutes: 10
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,7 +473,7 @@ jobs:
     # finishes in a fraction of that and avoids the GitHub Actions minute
     # drain. Per-PR turnaround on the dependabot rollout is the
     # optimization target. See issue #374 for the full migration rationale.
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, yuzu-weetam-windows]
     timeout-minutes: 120
     defaults:
       run:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,18 +2,28 @@ name: "CodeQL"
 
 # CodeQL C++ + GitHub Actions static analysis across BOTH self-hosted
 # runners, running in parallel:
-#   - yuzu-wsl2-linux (labels: self-hosted/Linux/X64/yuzu-shulgi) — gcc-13 build
+#   - yuzu-bigtam-linux (labels: self-hosted/Linux/X64/yuzu-bigtam-linux,
+#     native Ubuntu 26.04) — gcc-15 build
 #   - yuzu-weetam-windows (labels: self-hosted/Windows/X64/yuzu-weetam-windows) — MSVC build
 #
-# The Linux leg pins `yuzu-shulgi` explicitly rather than matching the
-# bare `[self-hosted, Linux, X64]` label set. Today Shulgi is the only
-# Linux runner, but the pin is deliberate: any future overflow runner
-# sharing the bare label set must NOT receive this workload unless it
-# meets the 40 GB disk threshold CodeQL needs. (A retired Scaleway cloud
-# builder sized for nightly Coverage routinely sat below it — run
-# 25986790721 died at the disk check at 23 GB free before any CodeQL
-# work — which is why the pin exists.) Same selector pattern nightly.yml
-# uses for the equivalent meson workload.
+# The Linux leg pins `yuzu-bigtam-linux` explicitly rather than matching
+# the bare `[self-hosted, Linux, X64]` label set. The pin is deliberate on
+# two counts: (1) the gcc-15 toolchain is 26.04-only — the Shulgi 24.04
+# fallback can't build it; (2) any future overflow runner sharing the bare
+# label set must NOT receive this workload unless it meets the 40 GB disk
+# threshold CodeQL needs. (A retired Scaleway cloud builder sized for
+# nightly Coverage routinely sat below it — run 25986790721 died at the
+# disk check at 23 GB free before any CodeQL work — which is why the pin
+# exists.) Same selector pattern ci.yml + nightly.yml use for the
+# equivalent meson workload.
+#
+# NOTE: the Linux leg is NOT gated on a preflight bigtam_pool_healthy
+# output (unlike ci.yml/sanitizer-tests/nightly). This is a single matrix
+# job spanning Linux + Windows; a job-level `if` cannot reference the
+# `matrix` context, so a fail-closed per-leg gate would require splitting
+# the job — out of scope for the cutover. If Big Tam is offline at the
+# weekly run, the Linux leg queues until its 90-min timeout (same as the
+# pre-cutover Shulgi-offline behaviour); CodeQL is not a required check.
 #
 # The two runs are separate matrix legs with `fail-fast: false`, so a
 # quirk on one platform doesn't kill the other. Each leg uploads SARIF
@@ -104,9 +114,9 @@ jobs:
       matrix:
         include:
           - os: linux
-            # yuzu-shulgi pin — see header comment (guards the 40 GB disk
-            # threshold against any future overflow Linux runner).
-            runner: [self-hosted, Linux, X64, yuzu-shulgi]
+            # yuzu-bigtam-linux pin — see header comment (gcc-15 is 26.04-only
+            # + guards the 40 GB disk threshold against any overflow runner).
+            runner: [self-hosted, Linux, X64, yuzu-bigtam-linux]
             triplet: x64-linux
             vcpkg_bin: vcpkg
             build_dir: build-linux-codeql
@@ -171,11 +181,32 @@ jobs:
         if: matrix.os == 'windows'
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
+      # Big Tam (the Linux leg's runner) does not carry meson on the default
+      # PATH: ci.yml pip-installs it under ~/.local/bin and adds that to PATH
+      # per-job, which does not persist to this workflow. So install the
+      # toolchain here (mirrors ci.yml's linux leg) before the verify below.
+      # flock serializes apt across the 4 runners sharing the Big Tam host —
+      # DPkg::Lock::Timeout does NOT cover apt-get update's lists lock —
+      # reusing ci.yml's lock path so all Big Tam jobs coordinate. Windows
+      # has its toolchain pre-baked on the runner (no apt), so Linux-only.
+      - name: Install system packages (linux)
+        if: matrix.os == 'linux'
+        run: |
+          (
+            flock -w 600 9 || { echo "::error::timed out waiting for apt lock"; exit 1; }
+            sudo apt-get -o DPkg::Lock::Timeout=300 update
+            sudo apt-get -o DPkg::Lock::Timeout=300 install -y \
+              cmake ninja-build pkg-config curl zip unzip tar python3-pip ccache \
+              bison flex libsystemd-dev gcc-15 g++-15
+          ) 9>/tmp/yuzu-ci-apt.lock
+          pip3 install --user --break-system-packages --require-hashes -r requirements-ci.txt
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Assert toolchain available
         run: |
           set -e
           if [[ "${{ matrix.os }}" == "linux" ]]; then
-            TOOLS="meson ninja gcc-13 g++-13 ccache python3 cmake pkg-config"
+            TOOLS="meson ninja gcc-15 g++-15 ccache python3 cmake pkg-config"
           else
             # MSVC cl is on PATH after ilammy/msvc-dev-cmd. Self-hosted
             # runner must have meson/ninja/ccache/cmake/python pre-baked.
@@ -280,8 +311,9 @@ jobs:
       # custom_target must succeed or `meson compile` fails the whole
       # job. Mirror ci.yml's "Install Erlang/OTP and rebar3" step
       # verbatim — same pinned SHA, same OTP version, same ImageOS
-      # override. Runs reliably on the same yuzu-wsl2-linux runner on
-      # every Tier-2 PR build. Replaces the prior `scripts/ensure-erlang.sh`
+      # override (DELIBERATELY ubuntu24 even on Big Tam's 26.04 — setup-beam
+      # has no ubuntu26 OTP; the 24.04 build runs fine on 26.04). Replaces
+      # the prior `scripts/ensure-erlang.sh`
       # +`$GITHUB_PATH` plumbing (PR #923) which could not find Erlang
       # at all when the runner lacked a kerl/asdf/brew install — the
       # 2026-05-10 and 2026-05-17 scheduled runs both failed on this
@@ -321,8 +353,8 @@ jobs:
       - name: Configure (Meson debug) — linux
         if: matrix.os == 'linux'
         env:
-          CC: ccache gcc-13
-          CXX: ccache g++-13
+          CC: ccache gcc-15
+          CXX: ccache g++-15
           # ${{ github.workspace }} is inlined directly in step env (NOT
           # via matrix include values) because matrix include values do
           # not expand workflow context expressions. The previous
@@ -342,7 +374,7 @@ jobs:
           # 2026-04-13 baseline run scanned only 231/364 files because
           # tests was skipped).
           meson setup ${{ matrix.build_dir }} \
-            --native-file meson/native/linux-gcc13.ini \
+            --native-file meson/native/linux-gcc15.ini \
             --buildtype=debug \
             -Dcmake_prefix_path="$GITHUB_WORKSPACE/vcpkg_installed/x64-linux" \
             -Dbuild_tests=true

--- a/.github/workflows/instructions-windows-validate.yml
+++ b/.github/workflows/instructions-windows-validate.yml
@@ -2,8 +2,8 @@ name: Instructions gate (Windows validate)
 
 # One-shot workflow_dispatch to validate the instructions runner + plugin
 # fixes (PR `feat/viz-engine` bucket A/B/D/E/F/C work) on a real Windows
-# host without needing inbound SSH. Runs on `yuzu-local-windows`
-# self-hosted runner (Shulgi), which polls GitHub over outbound HTTPS so
+# host without needing inbound SSH. Runs on the `yuzu-weetam-windows`
+# self-hosted pool (Wee Tam), which polls GitHub over outbound HTTPS so
 # corporate / guest WiFi that blocks Tailscale doesn't matter.
 #
 # Builds debug, stands up server + agent on non-default ports (host has
@@ -19,7 +19,7 @@ permissions:
 jobs:
   windows-instructions:
     name: Windows MSVC — Instructions gate
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, yuzu-weetam-windows]
     timeout-minutes: 60
     defaults:
       run:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,20 +33,47 @@ env:
   CCACHE_COMPRESSLEVEL: "1"
 
 jobs:
+  # ── Preflight: Big Tam runner-health gate ─────────────────────────────
+  # Mirrors ci.yml's preflight. All three build jobs pin the Big Tam pool
+  # (gcc-15/26.04 toolchain) and gate on bigtam_pool_healthy with explicit
+  # `== 'true'` (fail-closed: an offline Big Tam skips them in <30s rather
+  # than queueing 60 min into a stalled runner). Secrets are available on
+  # schedule + workflow_dispatch, so the PAT resolves.
+  #
+  # Skip semantics: if Big Tam is wholly offline, all three skip; `alert`
+  # (if: failure()) does NOT fire on a skip and `close-on-green`
+  # (if: success()) does — i.e. nightly does not block on an offline pool.
+  # That edge is covered by runner-inventory-sentinel.yml, which opens an
+  # issue on an OFFLINE/MISSING runner independently.
+  preflight:
+    name: "Preflight (runner health)"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      bigtam_pool_healthy: ${{ steps.health.outputs.bigtam_pool_healthy }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Probe runner health
+        id: health
+        env:
+          GH_TOKEN: ${{ secrets.RUNNER_INVENTORY_TOKEN || secrets.GITHUB_TOKEN }}
+        run: python3 scripts/ci/runner-health-check.py --mode preflight
+
   # ── Sanitizers (ASan + UBSan) ──────────────────────────────────────────
   sanitize-asan:
     name: "Sanitizers (ASan+UBSan)"
-    # Pinned to Shulgi (yuzu-wsl2-linux). The ASan triplet (x64-linux-asan)
-    # is a forced cold-cache rebuild every run because per-instrumentation
-    # vcpkg packages can't be safely shared with the standard triplet — so
-    # the ASan job rebuilds the full dep tree from source on every nightly.
-    # On a small cloud runner that step alone runs 60+ minutes and
-    # routinely blows the 60-min job timeout; this is why the Linux legs
-    # pin Shulgi (16-core 5950X), which clears the same workload in
-    # ~15 min. TSan and
-    # Coverage share the warm x64-linux triplet cache so they don't need
-    # pinning and keep the runner pool flexible.
-    runs-on: [self-hosted, Linux, X64, yuzu-shulgi]
+    needs: [preflight]
+    if: needs.preflight.outputs.bigtam_pool_healthy == 'true'
+    # Pinned to the Big Tam pool (native Ubuntu 26.04, GCC 15). The ASan
+    # triplet (x64-linux-asan) is a forced cold-cache rebuild every run
+    # because per-instrumentation vcpkg packages can't be safely shared
+    # with the standard triplet, so the ASan job rebuilds the full dep tree
+    # from source on every nightly. The Threadripper Big Tam host clears it
+    # fast; the bigtam-linux label guarantees the gcc-15 toolchain (Shulgi
+    # 24.04 can't build it).
+    runs-on: [self-hosted, Linux, X64, yuzu-bigtam-linux]
     timeout-minutes: 60
     env:
       # detect_odr_violation=0 mirrors ci.yml's matrix linux: gRPC's
@@ -55,6 +82,9 @@ jobs:
       # vcpkg port stops vendoring abseil.
       ASAN_OPTIONS: "detect_leaks=1:halt_on_error=1:detect_odr_violation=0"
       UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1"
+      # Shared 4-runner Big Tam host: harmless gateway-eunit default-cookie
+      # defence (matches ci.yml's linux leg).
+      YUZU_GW_ALLOW_DEFAULT_COOKIE: "1"
 
     steps:
       - name: Wipe build-linux-asan/ on branch switch (pre-checkout)
@@ -76,13 +106,17 @@ jobs:
 
       - name: Install system packages
         run: |
-          sudo apt-get update
-          # DPkg lock timeout: all nightly jobs share one self-hosted box and one
-          # cron fire time, so concurrent installs race the dpkg lock (gov #1331 UP-9).
-          sudo apt-get -o DPkg::Lock::Timeout=300 install -y \
-            cmake ninja-build gcc-13 g++-13 \
-            pkg-config curl zip unzip tar python3-pip ccache \
-            bison flex libsystemd-dev
+          # flock serializes apt across the 4 runners sharing the Big Tam
+          # host — DPkg::Lock::Timeout does NOT cover apt-get update's lists
+          # lock — reusing ci.yml's lock path so all Big Tam jobs coordinate.
+          (
+            flock -w 600 9 || { echo "::error::timed out waiting for apt lock"; exit 1; }
+            sudo apt-get -o DPkg::Lock::Timeout=300 update
+            sudo apt-get -o DPkg::Lock::Timeout=300 install -y \
+              cmake ninja-build gcc-15 g++-15 \
+              pkg-config curl zip unzip tar python3-pip ccache \
+              bison flex libsystemd-dev
+          ) 9>/tmp/yuzu-ci-apt.lock
           pip3 install --user --break-system-packages --require-hashes -r requirements-ci.txt
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
@@ -125,14 +159,14 @@ jobs:
 
       - name: Configure (Meson + ASan/UBSan)
         env:
-          CC: ccache gcc-13
-          CXX: ccache g++-13
+          CC: ccache gcc-15
+          CXX: ccache g++-15
           PKG_CONFIG_PATH: ${{ github.workspace }}/vcpkg_installed/x64-linux-asan/lib/pkgconfig
         run: |
           reconfig=""
           [[ -d build-linux-asan/meson-info ]] && reconfig="--reconfigure"
           meson setup $reconfig build-linux-asan \
-            --native-file meson/native/linux-gcc13.ini \
+            --native-file meson/native/linux-gcc15.ini \
             --buildtype=debug \
             -Dcmake_prefix_path=${{ github.workspace }}/vcpkg_installed/x64-linux-asan \
             -Dbuild_tests=true \
@@ -170,17 +204,20 @@ jobs:
   # ── Sanitizers (TSan) ──────────────────────────────────────────────────
   sanitize-tsan:
     name: "Sanitizers (TSan)"
-    # Pinned to Shulgi (yuzu-wsl2-linux). Same compute argument as the
-    # ASan job: the TSan triplet (x64-linux-tsan, issue #917) is a forced
-    # cold-cache rebuild every run because per-instrumentation vcpkg
-    # packages can't be safely shared with the standard or ASan triplets.
-    # On a small cloud VM the from-source dep-tree rebuild blows the
-    # 60-min job timeout; Shulgi (16-core 5950X) clears the same workload
-    # in ~15 min, which is why this leg pins yuzu-shulgi.
-    runs-on: [self-hosted, Linux, X64, yuzu-shulgi]
+    needs: [preflight]
+    if: needs.preflight.outputs.bigtam_pool_healthy == 'true'
+    # Pinned to the Big Tam pool. Same compute argument as the ASan job:
+    # the TSan triplet (x64-linux-tsan, issue #917) is a forced cold-cache
+    # rebuild every run because per-instrumentation vcpkg packages can't be
+    # safely shared with the standard or ASan triplets. The bigtam-linux
+    # label guarantees the gcc-15 toolchain (Shulgi 24.04 can't build it).
+    runs-on: [self-hosted, Linux, X64, yuzu-bigtam-linux]
     timeout-minutes: 60
     env:
       TSAN_OPTIONS: "halt_on_error=1:second_deadlock_stack=1"
+      # Shared 4-runner Big Tam host: harmless gateway-eunit default-cookie
+      # defence (matches ci.yml's linux leg).
+      YUZU_GW_ALLOW_DEFAULT_COOKIE: "1"
 
     steps:
       - name: Wipe build-linux-tsan/ on branch switch (pre-checkout)
@@ -202,13 +239,17 @@ jobs:
 
       - name: Install system packages
         run: |
-          sudo apt-get update
-          # DPkg lock timeout: all nightly jobs share one self-hosted box and one
-          # cron fire time, so concurrent installs race the dpkg lock (gov #1331 UP-9).
-          sudo apt-get -o DPkg::Lock::Timeout=300 install -y \
-            cmake ninja-build gcc-13 g++-13 \
-            pkg-config curl zip unzip tar python3-pip ccache \
-            bison flex libsystemd-dev
+          # flock serializes apt across the 4 runners sharing the Big Tam
+          # host — DPkg::Lock::Timeout does NOT cover apt-get update's lists
+          # lock — reusing ci.yml's lock path so all Big Tam jobs coordinate.
+          (
+            flock -w 600 9 || { echo "::error::timed out waiting for apt lock"; exit 1; }
+            sudo apt-get -o DPkg::Lock::Timeout=300 update
+            sudo apt-get -o DPkg::Lock::Timeout=300 install -y \
+              cmake ninja-build gcc-15 g++-15 \
+              pkg-config curl zip unzip tar python3-pip ccache \
+              bison flex libsystemd-dev
+          ) 9>/tmp/yuzu-ci-apt.lock
           pip3 install --user --break-system-packages --require-hashes -r requirements-ci.txt
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
@@ -255,14 +296,14 @@ jobs:
 
       - name: Configure (Meson + TSan)
         env:
-          CC: ccache gcc-13
-          CXX: ccache g++-13
+          CC: ccache gcc-15
+          CXX: ccache g++-15
           PKG_CONFIG_PATH: ${{ github.workspace }}/vcpkg_installed/x64-linux-tsan/lib/pkgconfig
         run: |
           reconfig=""
           [[ -d build-linux-tsan/meson-info ]] && reconfig="--reconfigure"
           meson setup $reconfig build-linux-tsan \
-            --native-file meson/native/linux-gcc13.ini \
+            --native-file meson/native/linux-gcc15.ini \
             --buildtype=debug \
             -Dcmake_prefix_path=${{ github.workspace }}/vcpkg_installed/x64-linux-tsan \
             -Dbuild_tests=true \
@@ -356,7 +397,11 @@ jobs:
         env:
           LD_PRELOAD: /tmp/libgai_sync_shim.so
         run: |
-          sudo apt-get install -y gdb >/dev/null 2>&1 || true
+          # flock-wrapped (shared Big Tam host); best-effort, so a lock
+          # timeout must not fail this diagnostic step.
+          ( flock -w 120 9 || true
+            sudo apt-get -o DPkg::Lock::Timeout=120 install -y gdb >/dev/null 2>&1 || true
+          ) 9>/tmp/yuzu-ci-apt.lock
           if ! command -v gdb >/dev/null; then
             echo "gdb unavailable on this runner — skipping stack capture"
             exit 0
@@ -411,9 +456,19 @@ jobs:
 
   # ── Coverage (gcov + gcovr) ────────────────────────────────────────────
   coverage:
-    name: "Coverage (GCC 13)"
-    runs-on: [self-hosted, Linux, X64]
+    name: "Coverage (GCC 15)"
+    needs: [preflight]
+    if: needs.preflight.outputs.bigtam_pool_healthy == 'true'
+    # Pinned to the Big Tam pool. Was the generic [self-hosted, Linux, X64]
+    # pool, but that spans both Shulgi (24.04/gcc-13) and Big Tam
+    # (26.04/gcc-15); a gcc-15 coverage build can only run on Big Tam, so
+    # pin it there rather than risk landing on a gcc-13 host.
+    runs-on: [self-hosted, Linux, X64, yuzu-bigtam-linux]
     timeout-minutes: 60
+    env:
+      # Shared 4-runner Big Tam host: harmless gateway-eunit default-cookie
+      # defence (matches ci.yml's linux leg).
+      YUZU_GW_ALLOW_DEFAULT_COOKIE: "1"
 
     steps:
       - name: Wipe build-linux-coverage/ on branch switch (pre-checkout)
@@ -435,13 +490,17 @@ jobs:
 
       - name: Install system packages
         run: |
-          sudo apt-get update
-          # DPkg lock timeout: all nightly jobs share one self-hosted box and one
-          # cron fire time, so concurrent installs race the dpkg lock (gov #1331 UP-9).
-          sudo apt-get -o DPkg::Lock::Timeout=300 install -y \
-            cmake ninja-build gcc-13 g++-13 \
-            pkg-config curl zip unzip tar python3-pip ccache \
-            bison flex libsystemd-dev
+          # flock serializes apt across the 4 runners sharing the Big Tam
+          # host — DPkg::Lock::Timeout does NOT cover apt-get update's lists
+          # lock — reusing ci.yml's lock path so all Big Tam jobs coordinate.
+          (
+            flock -w 600 9 || { echo "::error::timed out waiting for apt lock"; exit 1; }
+            sudo apt-get -o DPkg::Lock::Timeout=300 update
+            sudo apt-get -o DPkg::Lock::Timeout=300 install -y \
+              cmake ninja-build gcc-15 g++-15 \
+              pkg-config curl zip unzip tar python3-pip ccache \
+              bison flex libsystemd-dev
+          ) 9>/tmp/yuzu-ci-apt.lock
           # requirements-ci.txt is hash-pinned (includes gcovr for the
           # coverage report).
           pip3 install --user --break-system-packages --require-hashes -r requirements-ci.txt
@@ -492,14 +551,14 @@ jobs:
         # runner. Distinct from PR-1's per-OS naming because coverage
         # is a sanitizer-class job, not a tier-2 matrix variant.
         env:
-          CC: ccache gcc-13
-          CXX: ccache g++-13
+          CC: ccache gcc-15
+          CXX: ccache g++-15
           PKG_CONFIG_PATH: ${{ github.workspace }}/vcpkg_installed/x64-linux/lib/pkgconfig
         run: |
           reconfig=""
           [[ -d build-linux-coverage/meson-info ]] && reconfig="--reconfigure"
           meson setup $reconfig build-linux-coverage \
-            --native-file meson/native/linux-gcc13.ini \
+            --native-file meson/native/linux-gcc15.ini \
             --buildtype=debug \
             -Dcmake_prefix_path=${{ github.workspace }}/vcpkg_installed/x64-linux \
             -Dbuild_tests=true \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,20 @@ env:
   # .github/workflows/vcpkg-baseline-update.yml workflow.
   VCPKG_COMMIT: "4b77da7fed37817f124936239197833469f1b9a8"
   VCPKG_BINARY_SOURCES: "default"
+  # ccache sizing — mirror ci.yml. Without this the self-hosted build-linux
+  # leg inherits the host default (5 GiB on Big Tam), far too small for ~700
+  # TUs and a full release+LTO build → cache thrash → slow release. 30G covers
+  # the working set with headroom. (Harmless on the Wee Tam Windows / hosted
+  # macOS build ccaches too.)
+  CCACHE_MAXSIZE: "30G"
+  CCACHE_COMPRESS: "true"
+  CCACHE_COMPRESSLEVEL: "1"
 
 jobs:
   # ── Linux x64 release build ──────────────────────────────────────────
   build-linux:
     name: "Build Linux x64"
-    runs-on: [self-hosted, Linux]
+    runs-on: [self-hosted, Linux, X64, yuzu-bigtam-linux]
     permissions:
       contents: read
       id-token: write       # cosign keyless + actions/attest-build-provenance OIDC
@@ -75,7 +83,7 @@ jobs:
           # bison/flex: vcpkg's libpq port builds postgresql from source and
           # cannot auto-acquire them on Linux (gov #1331 — do not rely on the
           # machine-wide side effect of ci.yml's apt step).
-          for cmd in gcc-13 g++-13 cmake ninja meson ccache pkg-config rpmbuild bison flex; do
+          for cmd in gcc-15 g++-15 cmake ninja meson ccache pkg-config rpmbuild bison flex; do
             command -v "$cmd" >/dev/null 2>&1 || MISSING="$MISSING $cmd"
           done
           if [ -n "$MISSING" ]; then
@@ -126,13 +134,13 @@ jobs:
 
       - name: Configure (Meson release)
         env:
-          CC: ccache gcc-13
-          CXX: ccache g++-13
+          CC: ccache gcc-15
+          CXX: ccache g++-15
           PKG_CONFIG_PATH: ${{ github.workspace }}/vcpkg_installed/x64-linux-static/lib/pkgconfig
           CMAKE_PREFIX_PATH: ${{ github.workspace }}/vcpkg_installed/x64-linux-static
         run: |
           meson setup build-linux \
-            --native-file meson/native/linux-gcc13.ini \
+            --native-file meson/native/linux-gcc15.ini \
             --buildtype=release \
             -Dcmake_prefix_path=${{ github.workspace }}/vcpkg_installed/x64-linux-static \
             -Dbuild_tests=false
@@ -276,7 +284,7 @@ jobs:
   build-gateway:
     name: "Build Gateway (Erlang)"
     needs: [build-linux]
-    runs-on: [self-hosted, Linux]
+    runs-on: [self-hosted, Linux, X64, yuzu-bigtam-linux]
     permissions:
       contents: read
       id-token: write       # cosign keyless + actions/attest-build-provenance OIDC
@@ -441,11 +449,11 @@ jobs:
           retention-days: 3
 
   # ── Windows x64 release build ────────────────────────────────────────
-  # No needs: — runs on a separate self-hosted runner (same physical box,
-  # different OS) so it can build in parallel with build-linux + build-gateway.
+  # No needs: — runs on the Wee Tam Windows pool (a separate host from the Big
+  # Tam Linux build) so it can build in parallel with build-linux + build-gateway.
   build-windows:
     name: "Build Windows x64"
-    runs-on: [self-hosted, Windows]
+    runs-on: [self-hosted, Windows, X64, yuzu-weetam-windows]
     permissions:
       contents: read
       id-token: write       # cosign keyless + actions/attest-build-provenance OIDC
@@ -1081,7 +1089,7 @@ jobs:
   docker-publish:
     name: "Publish ${{ matrix.image }} image"
     needs: [build-linux, build-gateway]
-    runs-on: [self-hosted, Linux]
+    runs-on: [self-hosted, Linux, X64, yuzu-bigtam-linux]
     timeout-minutes: 90
     permissions:
       contents: read
@@ -1167,8 +1175,8 @@ jobs:
             TRIPLET=x64-linux
           # Registry cache lives in GHCR itself under a :buildcache tag.
           # mode=max caches intermediate layers too (best hit rate).
-          cache-from: type=local,src=/mnt/d/docker-buildcache/${{ matrix.image }}
-          cache-to: type=local,dest=/mnt/d/docker-buildcache/${{ matrix.image }},mode=max
+          cache-from: type=local,src=${{ runner.tool_cache }}/yuzu-docker-buildcache/${{ matrix.image }}
+          cache-to: type=local,dest=${{ runner.tool_cache }}/yuzu-docker-buildcache/${{ matrix.image }},mode=max
           # Disable buildx's own provenance/sbom attestation — we emit
           # GitHub-native attestations + cosign signatures below so
           # customers have a single verification path via `gh
@@ -1271,7 +1279,7 @@ jobs:
   #   3. Distinct local buildcache path (postgres suffix).
   docker-publish-postgres:
     name: "Publish postgres image"
-    runs-on: [self-hosted, Linux]
+    runs-on: [self-hosted, Linux, X64, yuzu-bigtam-linux]
     timeout-minutes: 60
     permissions:
       contents: read
@@ -1341,8 +1349,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           # Distinct local buildcache path — never collides with the
           # server/gateway/chisel caches on this runner.
-          cache-from: type=local,src=/mnt/d/docker-buildcache/postgres
-          cache-to: type=local,dest=/mnt/d/docker-buildcache/postgres,mode=max
+          cache-from: type=local,src=${{ runner.tool_cache }}/yuzu-docker-buildcache/postgres
+          cache-to: type=local,dest=${{ runner.tool_cache }}/yuzu-docker-buildcache/postgres,mode=max
           # Disable buildx's own provenance/sbom attestation — we emit
           # GitHub-native attestations + cosign signatures below (single
           # verification path, same as docker-publish).
@@ -1438,7 +1446,7 @@ jobs:
     # Mirror docker-publish's needs (core builds must pass) but stay OUT
     # of the release job's needs: so this never gates the release.
     needs: [build-linux, build-gateway]
-    runs-on: [self-hosted, Linux]
+    runs-on: [self-hosted, Linux, X64, yuzu-bigtam-linux]
     # Job-level concurrency so a re-tagged release (same ref) cancels an
     # in-flight 6 h QEMU build instead of wedging the single self-hosted
     # Linux runner slot behind a stale emulated arm64 compile. The
@@ -1571,8 +1579,8 @@ jobs:
           # the non-chisel docker-publish cache. mode=max caches
           # intermediate layers too (best hit rate) — important given the
           # full vcpkg-from-source compile.
-          cache-from: type=local,src=/mnt/d/docker-buildcache/${{ matrix.image }}-chisel
-          cache-to: type=local,dest=/mnt/d/docker-buildcache/${{ matrix.image }}-chisel,mode=max
+          cache-from: type=local,src=${{ runner.tool_cache }}/yuzu-docker-buildcache/${{ matrix.image }}-chisel
+          cache-to: type=local,dest=${{ runner.tool_cache }}/yuzu-docker-buildcache/${{ matrix.image }}-chisel,mode=max
           # Disable buildx's own provenance/sbom attestation — we emit
           # GitHub-native attestations + cosign signatures below so
           # customers have a single verification path via `gh

--- a/.github/workflows/sanitizer-tests.yml
+++ b/.github/workflows/sanitizer-tests.yml
@@ -2,10 +2,11 @@ name: Sanitizer tests
 
 # Workflow dispatched by scripts/test/sanitizer-gate.sh (Phase 6 of /test).
 #
-# Runs ASan+UBSan and TSan rebuilds + test suites on the yuzu-wsl2-linux
-# self-hosted runner. The runner is on Nathan's desktop (WSL2 Ubuntu 24.04)
-# per the memory note; sanitizer rebuilds are too slow to run on the
-# operator's interactive dev box, so /test --full dispatches here instead.
+# Runs ASan+UBSan and TSan rebuilds + test suites on the Big Tam
+# self-hosted pool (yuzu-bigtam-linux, native Ubuntu 26.04, GCC 15);
+# sanitizer rebuilds are too slow to run on the operator's interactive dev
+# box, so /test --full dispatches here instead. A preflight job gates both
+# legs on bigtam_pool_healthy (fail-closed skip if Big Tam is offline).
 #
 # ASAN_OPTIONS / TSAN_OPTIONS mirror .github/workflows/ci.yml so local
 # runs match CI semantics (any findings fail the job).
@@ -47,15 +48,41 @@ env:
   CCACHE_COMPRESS: "true"
 
 jobs:
+  # ── Preflight: Big Tam runner-health gate ─────────────────────────────
+  # Mirrors ci.yml's preflight. Runs on a GHA-hosted runner (always
+  # available) and queries /actions/runners via runner-health-check.py.
+  # The sanitizer jobs pin the Big Tam sub-pool (gcc-15/26.04 toolchain),
+  # so they gate on bigtam_pool_healthy with explicit `== 'true'`
+  # (fail-closed: an offline/unknown Big Tam skips the job in <30s rather
+  # than queueing 75 min into a stalled runner). Secrets are available on
+  # workflow_dispatch (the /test --full dispatch path), so the PAT resolves.
+  preflight:
+    name: "Preflight (runner health)"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      bigtam_pool_healthy: ${{ steps.health.outputs.bigtam_pool_healthy }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Probe runner health
+        id: health
+        env:
+          GH_TOKEN: ${{ secrets.RUNNER_INVENTORY_TOKEN || secrets.GITHUB_TOKEN }}
+        run: python3 scripts/ci/runner-health-check.py --mode preflight
+
   asan-ubsan:
     name: "Sanitizers (ASan+UBSan)"
-    if: ${{ inputs.suite == 'asan' || inputs.suite == 'both' || inputs.suite == '' }}
-    # Pinned to Shulgi: x64-linux-asan is a forced cold-cache rebuild and
-    # the small cloud runner can't finish it inside the job timeout. CLAUDE.md
-    # documents this workflow as intended for yuzu-wsl2-linux anyway —
-    # adding the label makes the targeting explicit instead of relying on
-    # whichever Linux X64 runner happens to be free.
-    runs-on: [self-hosted, Linux, X64, yuzu-shulgi]
+    needs: [preflight]
+    # Suite selector AND the Big Tam health gate (fail-closed `== 'true'`).
+    if: ${{ (inputs.suite == 'asan' || inputs.suite == 'both' || inputs.suite == '') && needs.preflight.outputs.bigtam_pool_healthy == 'true' }}
+    # Pinned to the Big Tam sub-pool (native Ubuntu 26.04, GCC 15): the
+    # x64-linux-asan triplet is a forced cold-cache rebuild and a small
+    # cloud runner can't finish it inside the job timeout. The Threadripper
+    # Big Tam host clears the instrumented dep tree fast; the bigtam-linux
+    # label guarantees the gcc-15 toolchain (Shulgi 24.04 can't build it).
+    runs-on: [self-hosted, Linux, X64, yuzu-bigtam-linux]
     timeout-minutes: 75
     env:
       # detect_odr_violation=0 mirrors ci.yml's sanitize-asan job: gRPC's
@@ -64,6 +91,11 @@ jobs:
       # so ASan otherwise aborts before any Yuzu test runs.
       ASAN_OPTIONS: "detect_leaks=1:halt_on_error=1:detect_odr_violation=0"
       UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1"
+      # Big Tam runs 4 runners on one host; a gateway eunit test that boots
+      # the app can transiently bring up Erlang distribution and trip the
+      # #659 insecure-default-cookie boot guard. Documented dev/CI override
+      # (the guard's policy logic is unit-tested directly); matches ci.yml.
+      YUZU_GW_ALLOW_DEFAULT_COOKIE: "1"
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -71,36 +103,52 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
+      - name: Install system packages
+        run: |
+          # Big Tam does NOT carry meson on the default PATH: ci.yml
+          # pip-installs it under ~/.local/bin and adds that to PATH per-job,
+          # which does NOT persist to this workflow. So install the toolchain
+          # here (mirrors ci.yml's linux leg) rather than verify-only.
+          # flock serializes apt across the 4 runners sharing the Big Tam
+          # host — DPkg::Lock::Timeout does NOT cover apt-get update's lists
+          # lock — reusing ci.yml's lock path so all Big Tam jobs coordinate.
+          (
+            flock -w 600 9 || { echo "::error::timed out waiting for apt lock"; exit 1; }
+            sudo apt-get -o DPkg::Lock::Timeout=300 update
+            sudo apt-get -o DPkg::Lock::Timeout=300 install -y \
+              cmake ninja-build pkg-config curl zip unzip tar python3-pip ccache \
+              bison flex libsystemd-dev gcc-15 g++-15
+          ) 9>/tmp/yuzu-ci-apt.lock
+          pip3 install --user --break-system-packages --require-hashes -r requirements-ci.txt
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Assert toolchain available
         run: |
-          # The self-hosted runner is long-lived on WSL2 and has its
-          # toolchain baked in. Fail loudly if anything is missing so
-          # the gate operator can fix the runner rather than accept
-          # silent misconfiguration.
-          for tool in meson ninja gcc-13 g++-13 ccache python3 bison flex; do
+          # Sanity-check the install above landed meson/gcc-15 on PATH and
+          # libsystemd is discoverable (the Linux Guardian systemd service
+          # guard links sd-bus at configure time). Fail loudly otherwise.
+          for tool in meson ninja gcc-15 g++-15 ccache python3 bison flex; do
               if ! command -v "$tool" >/dev/null; then
-                  echo "::error::$tool not on PATH on yuzu-wsl2-linux runner"
+                  echo "::error::$tool not on PATH on yuzu-bigtam-linux runner"
                   exit 1
               fi
           done
-          # libsystemd-dev (sd-bus) is required to configure the agent — the Linux
-          # Guardian systemd service guard links it. Fail loudly so the runner can be
-          # provisioned rather than hitting an opaque meson configure error.
           if ! pkg-config --exists libsystemd; then
-              echo "::error::libsystemd-dev (pkg-config 'libsystemd') missing on yuzu-wsl2-linux runner — sudo apt-get install -y libsystemd-dev"
+              echo "::error::libsystemd-dev (pkg-config 'libsystemd') missing on yuzu-bigtam-linux runner"
               exit 1
           fi
           meson --version
-          gcc-13 --version | head -1
+          gcc-15 --version | head -1
           ccache --version | head -1
 
-      # Install Erlang/OTP and rebar3. The self-hosted yuzu-wsl2-linux
-      # runner has kerl installed for the `dornbrn` user but workflows
-      # run as `github-runner`, so kerl is not on PATH and our
-      # ensure-erlang.sh helper finds nothing. Use the same setup-beam
-      # pattern as ci.yml / nightly.yml / release.yml — version pin
-      # must move with them on any OTP bump. ImageOS env is required
-      # because setup-beam can't auto-detect self-hosted OS.
+      # Install Erlang/OTP and rebar3 via setup-beam (the Big Tam host's
+      # global Erlang, if any, is not guaranteed on the `runner` user's
+      # PATH). Use the same setup-beam pattern as ci.yml / nightly.yml /
+      # release.yml — version pin must move with them on any OTP bump.
+      # ImageOS env is required because setup-beam can't auto-detect the
+      # self-hosted OS; DELIBERATELY ubuntu24 even on 26.04 (setup-beam has
+      # no ubuntu26 prebuilt OTP; the 24.04 build runs fine on 26.04 — same
+      # libcrypto.so.3 soname). Matches ci.yml's linux leg.
       - name: Install Erlang/OTP and rebar3
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         env:
@@ -156,13 +204,13 @@ jobs:
 
       - name: Configure (Meson + ASan/UBSan)
         env:
-          CC: ccache gcc-13
-          CXX: ccache g++-13
+          CC: ccache gcc-15
+          CXX: ccache g++-15
           PKG_CONFIG_PATH: ${{ github.workspace }}/vcpkg_installed/x64-linux-asan/lib/pkgconfig
         run: |
           rm -rf build-linux-asan
           meson setup build-linux-asan \
-            --native-file meson/native/linux-gcc13.ini \
+            --native-file meson/native/linux-gcc15.ini \
             --buildtype=debug \
             -Dcmake_prefix_path=${{ github.workspace }}/vcpkg_installed/x64-linux-asan \
             -Dbuild_tests=true \
@@ -199,14 +247,20 @@ jobs:
 
   tsan:
     name: "Sanitizers (TSan)"
-    if: ${{ inputs.suite == 'tsan' || inputs.suite == 'both' || inputs.suite == '' }}
-    # Pinned to Shulgi for the same reason as asan-ubsan: x64-linux-tsan
-    # is a forced cold-cache rebuild every run (#917). CLAUDE.md documents
-    # this workflow as intended for yuzu-wsl2-linux anyway.
-    runs-on: [self-hosted, Linux, X64, yuzu-shulgi]
+    needs: [preflight]
+    # Suite selector AND the Big Tam health gate (fail-closed `== 'true'`).
+    if: ${{ (inputs.suite == 'tsan' || inputs.suite == 'both' || inputs.suite == '') && needs.preflight.outputs.bigtam_pool_healthy == 'true' }}
+    # Pinned to the Big Tam sub-pool for the same reason as asan-ubsan:
+    # x64-linux-tsan is a forced cold-cache rebuild every run (#917) and the
+    # bigtam-linux label guarantees the gcc-15 toolchain (Shulgi 24.04 can't
+    # build it).
+    runs-on: [self-hosted, Linux, X64, yuzu-bigtam-linux]
     timeout-minutes: 75
     env:
       TSAN_OPTIONS: "halt_on_error=1:second_deadlock_stack=1"
+      # See asan-ubsan: harmless gateway-eunit default-cookie defence on the
+      # shared 4-runner Big Tam host (matches ci.yml).
+      YUZU_GW_ALLOW_DEFAULT_COOKIE: "1"
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -214,23 +268,36 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
+      - name: Install system packages
+        run: |
+          # See the ASan job: Big Tam does not carry meson on the default
+          # PATH, so install the toolchain here (flock-serialized apt across
+          # the shared 4-runner host, same lock path as ci.yml) rather than
+          # verify-only.
+          (
+            flock -w 600 9 || { echo "::error::timed out waiting for apt lock"; exit 1; }
+            sudo apt-get -o DPkg::Lock::Timeout=300 update
+            sudo apt-get -o DPkg::Lock::Timeout=300 install -y \
+              cmake ninja-build pkg-config curl zip unzip tar python3-pip ccache \
+              bison flex libsystemd-dev gcc-15 g++-15
+          ) 9>/tmp/yuzu-ci-apt.lock
+          pip3 install --user --break-system-packages --require-hashes -r requirements-ci.txt
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Assert toolchain available
         run: |
-          for tool in meson ninja gcc-13 g++-13 ccache python3 bison flex; do
+          for tool in meson ninja gcc-15 g++-15 ccache python3 bison flex; do
               if ! command -v "$tool" >/dev/null; then
-                  echo "::error::$tool not on PATH on yuzu-wsl2-linux runner"
+                  echo "::error::$tool not on PATH on yuzu-bigtam-linux runner"
                   exit 1
               fi
           done
-          # libsystemd-dev (sd-bus) is required to configure the agent — the Linux
-          # Guardian systemd service guard links it. Fail loudly so the runner can be
-          # provisioned rather than hitting an opaque meson configure error.
           if ! pkg-config --exists libsystemd; then
-              echo "::error::libsystemd-dev (pkg-config 'libsystemd') missing on yuzu-wsl2-linux runner — sudo apt-get install -y libsystemd-dev"
+              echo "::error::libsystemd-dev (pkg-config 'libsystemd') missing on yuzu-bigtam-linux runner"
               exit 1
           fi
           meson --version
-          gcc-13 --version | head -1
+          gcc-15 --version | head -1
           ccache --version | head -1
 
       # Install Erlang/OTP and rebar3 (see ASan job for full rationale).
@@ -283,13 +350,13 @@ jobs:
 
       - name: Configure (Meson + TSan)
         env:
-          CC: ccache gcc-13
-          CXX: ccache g++-13
+          CC: ccache gcc-15
+          CXX: ccache g++-15
           PKG_CONFIG_PATH: ${{ github.workspace }}/vcpkg_installed/x64-linux-tsan/lib/pkgconfig
         run: |
           rm -rf build-linux-tsan
           meson setup build-linux-tsan \
-            --native-file meson/native/linux-gcc13.ini \
+            --native-file meson/native/linux-gcc15.ini \
             --buildtype=debug \
             -Dcmake_prefix_path=${{ github.workspace }}/vcpkg_installed/x64-linux-tsan \
             -Dbuild_tests=true \

--- a/docs/ci-architecture.md
+++ b/docs/ci-architecture.md
@@ -11,15 +11,15 @@ Failure-mode runbook: `docs/ci-troubleshooting.md`.
 ## Tier summary (mirrors CLAUDE.md)
 
 - **Tier 1 — PR fast-path** (`ci.yml` on `pull_request`): one Linux variant
-  (gcc-13 debug on `yuzu-wsl2-linux`), one Windows variant (MSVC debug on
-  `yuzu-local-windows`), one macOS variant (appleclang debug on GHA-hosted
+  (gcc-15 debug on the `yuzu-bigtam-linux` pool), one Windows variant (MSVC debug on
+  the `yuzu-weetam-windows` pool), one macOS variant (appleclang debug on GHA-hosted
   `macos-15`), plus `proto-compat`. Wall target: <10 min per leg.
 - **Tier 2 — push to dev/main** (`ci.yml` on push): full 4-way Linux matrix
-  (gcc-13 / clang-19 × debug / release), 2-way Windows, 2-way macOS. **No
+  (gcc-15 / clang-21 × debug / release), 2-way Windows, 2-way macOS. **No
   sanitizers, no coverage** — those moved out (#410).
 - **Tier 3 — nightly cron** (`nightly.yml`, `0 6 * * *` UTC +
-  `workflow_dispatch`): ASan+UBSan, TSan, coverage on the self-hosted Linux
-  runner. On any leg failure, the `alert` job auto-opens or comments on a
+  `workflow_dispatch`): ASan+UBSan, TSan, coverage on the Big Tam pool
+  (`yuzu-bigtam-linux`, gated on `bigtam_pool_healthy`). On any leg failure, the `alert` job auto-opens or comments on a
   `nightly-broken` issue. **Discipline norm: no merge to main while a
   `nightly-broken` issue is open.**
 
@@ -49,35 +49,60 @@ dormant until merged.
 
 | Runner | Host | Jobs |
 |---|---|---|
-| `yuzu-wsl2-linux` | Shulgi 5950X WSL2 Ubuntu 24.04 | proto-compat, linux matrix, nightly (asan/tsan/coverage), cache-prune-linux |
-| `yuzu-bigtam-linux-{0..3}` | Big Tam Threadripper 9970X, native Ubuntu **26.04** | Linux CI pool (shared label `yuzu-bigtam-linux`) — successor to Shulgi for the Linux legs; see "Ubuntu 26.04 migration" below |
-| `yuzu-local-windows` | Shulgi native Windows 11 | windows matrix, cache-prune-windows |
+| `yuzu-bigtam-linux-{0..3}` | Big Tam Threadripper 9970X, native Ubuntu **26.04** (gcc-15/clang-21) | **all self-hosted Linux** (shared label `yuzu-bigtam-linux`): ci.yml `linux` matrix, `proto-compat`, sanitizer-tests (asan/tsan), nightly (asan/tsan/coverage), codeql Linux leg, **release.yml** (build-linux, build-gateway, docker-publish\*), cache-prune-linux. 4 runners on one host. |
+| `yuzu-weetam-windows-{0..3}` | Wee Tam 9970X native Windows 11 — 4 CCD-pinned runners, shared label `yuzu-weetam-windows` | **all self-hosted Windows**: ci.yml `windows`, codeql Windows leg, release `build-windows`, instructions-windows-validate, cache-prune-windows. Provisioned from [`deploy/windows/`](../deploy/windows/README.md). |
 | `macos-15` | GitHub-hosted | macos matrix |
 
-### Ubuntu 26.04 migration (Big Tam)
+**Retired 2026-06-21:** `yuzu-wsl2-linux` (Shulgi WSL2 Ubuntu 24.04, label
+`yuzu-shulgi`) and `yuzu-local-windows` (Shulgi native Windows) — superseded by
+Big Tam and Wee Tam. Remove them from `.github/runner-inventory.json` to silence
+the inventory sentinel. `proto-compat` and `cache-prune-linux` use the bare
+`[self-hosted, Linux, X64]` label (no compiler), so they resolve to Big Tam.
 
-Big Tam is a native **Ubuntu 26.04 (Resolute)** box whose default toolchain is
-**GCC 15 / Clang 21** — versus Shulgi's Ubuntu 24.04 (GCC 13 / Clang 19). The
-self-hosted Linux build is being moved to it. The 26.04/gcc-15 scaffolding is
-**staged but not yet live** (the live self-hosted jobs still target Shulgi@24.04
-on gcc-13/clang-19):
+### Ubuntu 26.04 migration (Big Tam) — COMPLETE
 
-- Native files `meson/native/linux-gcc15.ini` + `linux-clang21.ini` exist (the
-  24.04 `linux-gcc13.ini`/`linux-clang19.ini` stay for Shulgi).
-- The CI runner image (`Dockerfile.ci-linux`), the local `Dockerfile.ci`, and
-  the four sanitizer images (`Dockerfile.{server,agent}-{asan,tsan}`) are on
-  `ubuntu:26.04` + gcc-15/clang-21. `gcc-13` and `clang-19` remain installable
-  from 26.04's archive (gcc-13 in *universe*; clang-19 in-archive) but are not
-  the defaults.
-- `pre-release.yml`'s `install-deb` smoke matrix gained an `ubuntu:26.04` leg.
+Big Tam is a native **Ubuntu 26.04 (Resolute)** box, default toolchain **GCC 15 /
+Clang 21** (vs Shulgi's 24.04 GCC 13 / Clang 19). **Every self-hosted Linux job
+runs on Big Tam**: ci.yml `linux` (#1609), then sanitizer-tests / nightly / codeql
+Linux, then release.yml + the remaining Windows→Wee Tam stragglers (#1615). The
+supporting scaffolding:
 
-The remaining **flip** (live `runs-on`/compiler/`ImageOS` changes) is deferred
-until Big Tam is confirmed online — Shulgi (24.04) cannot build gcc-15/clang-21,
-so flipping while it is the only available Linux runner would red the board. The
-exact one-shot flip is enumerated in **`docs/ci-ubuntu-2604-cutover.md`**.
-| `yuzu-weetam-windows-{0..3}` | Wee Tam 9970X native Windows 11 — 4 CCD-pinned runners, shared label `yuzu-weetam-windows` | windows matrix (successor to Shulgi for Windows); provisioned from [`deploy/windows/`](../deploy/windows/README.md) |
-| `yuzu-local-windows` | Shulgi native Windows 11 | windows matrix, cache-prune-windows (legacy — retire once Wee Tam is proven) |
-| `macos-15` | GitHub-hosted | macos matrix |
+- Native files `meson/native/linux-gcc15.ini` + `linux-clang21.ini` are the live
+  toolchain files (they also set `-fuse-ld=mold`; see Build speed below). The
+  24.04 `linux-gcc13.ini`/`linux-clang19.ini` stay only for the GHA-hosted
+  ubuntu-24.04 canary.
+- The CI runner image (`Dockerfile.ci-linux`), the local `Dockerfile.ci`, and the
+  four sanitizer images (`Dockerfile.{server,agent}-{asan,tsan}`) are on
+  `ubuntu:26.04` + gcc-15/clang-21. `gcc-13`/`clang-19` stay installable from the
+  archive but are not the defaults.
+- `pre-release.yml`'s `install-deb` smoke matrix has an `ubuntu:26.04` leg.
+
+`ImageOS` stays `ubuntu24` on every leg (setup-beam has no `ubuntu26` prebuilt
+OTP; the 24.04 OTP runs fine on 26.04 — same `libcrypto.so.3` soname). Big Tam
+runs 4 runners on one host, so every apt step is `flock`-serialized on
+`/tmp/yuzu-ci-apt.lock`, the shared CI Postgres container is flock-serialized too
+(`scripts/ci/ensure-postgres.sh`), and meson is installed per-job via
+`pip --user` (it is not a host default). Full history + per-file detail:
+**`docs/ci-ubuntu-2604-cutover.md`**.
+
+### Build speed (Big Tam)
+
+The `runner` user (shared `HOME=/home/runner` across r0–r3) is provisioned once
+for fast, download-free builds:
+
+- **ccache** `max_size=50G`, compression on — the host default is 5 GiB, far too
+  small for ~700 TUs × variants. ci.yml/nightly cap at 30G via the
+  `CCACHE_MAXSIZE` env; release.yml now sets `CCACHE_MAXSIZE=30G` too (it had been
+  inheriting the host default).
+- **mold** linker (`apt install mold`), wired via `-fuse-ld=mold` in the gcc-15 /
+  clang-21 native files — large cut in link time on the big `yuzu-server` /
+  `yuzu-agent` binaries and the release LTO link.
+- **meson** 1.11.1 + the rest of `requirements-ci.txt` persist in the runner
+  user's `~/.local`, so the per-job `pip install --user --require-hashes` is a
+  no-op (no re-download).
+- **rpm** (rpmbuild) installed for release.yml's packaging step — absent on a
+  fresh 26.04 (it was the first-Big-Tam-release blocker). Note: Big Tam ships RPM
+  **6.0** vs Shulgi's 4.x — watch the first release.
 
 The Windows toolchain is codified in [`deploy/windows/`](../deploy/windows/README.md)
 (the native-Windows analog of `deploy/docker/Dockerfile.ci-linux`): a versioned
@@ -112,12 +137,14 @@ Resolution order inside the script:
 
 1. **Pre-set `YUZU_TEST_POSTGRES_DSN`** (runner-level env) — trusted
    as-is. The escape hatch for any bespoke runner setup.
-2. **Docker** (self-hosted Linux: `yuzu-wsl2-linux` / `yuzu-shulgi`) —
+2. **Docker** (self-hosted Linux: the `yuzu-bigtam-linux` pool) —
    idempotent persistent container `yuzu-ci-postgres` on
    `127.0.0.1:15432` (`docker start` || `docker run --restart
    unless-stopped`, image pinned to the same digest as
    `deploy/docker/Dockerfile.postgres`'s base). One-time cost per runner;
    port 15432 avoids colliding with native clusters or UAT rigs on 5432.
+   Big Tam runs 4 runners on one host, so the create path is
+   `flock`-serialized (one shared container, not four).
 3. **brew** (GHA-hosted macOS, no docker) — `postgresql@18` bottle +
    throwaway trust-auth cluster under `$RUNNER_TEMP` on
    `127.0.0.1:15432`.
@@ -133,18 +160,14 @@ Resolution order inside the script:
    Prefer the runner-level env override (path 1) if the box already runs
    Postgres with different credentials.
 
-   **`yuzu-local-windows` (Shulgi) as bootstrapped 2026-06-12 uses
-   path 1, not path 4:** the box already ran a foreign PostgreSQL 15 on
-   5432 (unknown credentials, left untouched), and the EDB GUI installer
-   fails in non-interactive SSH sessions — so PG **16.14 binaries-zip**
-   lives at `C:\yuzu-ci\pg16`, data dir `C:\yuzu-ci\pgdata16`, service
-   `postgresql-x64-16-yuzu-ci` (auto-start, `NT AUTHORITY\NetworkService`),
-   loopback-only on **5433**, superuser `yuzu`/`yuzu` (initdb-time, scram),
-   database `yuzu_test`. The machine-level
-   `YUZU_TEST_POSTGRES_DSN=postgresql://yuzu:yuzu@127.0.0.1:5433/yuzu_test`
-   feeds resolution path 1 — which always wins before the docker probe,
-   so the leg stays deterministic whether or not the box's (usually
-   headless-down) Docker Desktop engine happens to be running.
+   **Wee Tam (`yuzu-weetam-windows`) uses path 1, not path 4:** each runner
+   provides a native PostgreSQL **18** service (`postgresql-x64-18-yuzu-ci`)
+   and a machine-level `YUZU_TEST_POSTGRES_DSN` that wins before the docker
+   probe, so the leg stays deterministic regardless of any Docker engine
+   state. Provisioning specifics live in
+   [`deploy/windows/`](../deploy/windows/README.md). (The retired
+   `yuzu-local-windows` box ran a PG 16 binaries-zip service on 5433 — see
+   git history if that bootstrap pattern is ever needed again.)
 5. Nothing found → `::error`, exit 1.
 
 **Fatal on every non-success path since #1320 PR 1 (`SOFT_EXIT=1`):**
@@ -158,7 +181,7 @@ credential failure when `psql` is available (path 4), and nothing found
 probe alone produces a `::warning` and still exports the conventional
 DSN (credential **unverified** — wrong credentials then surface as
 downstream `[pg]` test failures; install `psql` on the runner's PATH,
-e.g. `C:\Program Files\PostgreSQL\16\bin` on `yuzu-local-windows`, to
+e.g. `C:\Program Files\PostgreSQL\18\bin` on the `yuzu-weetam-windows` runners, to
 get the authenticated gate instead). Locally the tests still skip when
 `YUZU_TEST_POSTGRES_DSN` is unset; when it is set but unreachable they
 fail rather than skip.

--- a/docs/ci-ubuntu-2604-cutover.md
+++ b/docs/ci-ubuntu-2604-cutover.md
@@ -1,10 +1,49 @@
 # CI cutover runbook — Shulgi (Ubuntu 24.04) → Big Tam (Ubuntu 26.04)
 
-Status: **ci.yml linux leg FLIPPED + validated on Big Tam** (2026-06-20). Remaining:
-sanitizer-tests → nightly → codeql still on Shulgi.
+Status: **CUTOVER COMPLETE** (2026-06-20/21). **Every** self-hosted job has moved
+off the old single-host runners: all Linux → Big Tam (`yuzu-bigtam-linux`), all
+Windows → Wee Tam (`yuzu-weetam-windows`). Sequence: `ci.yml` linux (#1609,
+merged) → `sanitizer-tests` + `nightly` + `codeql` Linux → **`release.yml` Linux
+legs + the remaining Windows stragglers + build-speed** (PR #1615). **`yuzu-wsl2-linux`
+(Shulgi) and `yuzu-local-windows` are retired** — remove them from
+`.github/runner-inventory.json` (item 6) to silence the inventory sentinel.
+`proto-compat` / `cache-prune-linux` keep the bare `[self-hosted, Linux, X64]`
+label (no compiler) and land on Big Tam.
 
-Branch `ci/ubuntu-2604-cutover`. Two extra shared-host fixes were needed beyond the
-plan, both because Big Tam runs **4 runners on one host** (Shulgi was one):
+The sections below are the historical runbook + per-file record; the future-tense
+"deferred" / "pre-flip" framing is preserved as the record of how the flip was
+sequenced.
+
+Branches: `ci/ubuntu-2604-cutover` (ci.yml, merged),
+`ci/bigtam-followup-self-hosted-legs` (sanitizer/nightly/codeql), and
+`ci/retire-shulgi-localwindows` (#1615 — release + Windows stragglers +
+build-speed). Several extra fixes were
+needed beyond the plan — some because Big Tam runs **4 runners on one host**
+(Shulgi was one), two surfaced only by the **cold from-source rebuild** Big Tam
+forces (its caches start empty):
+
+- **meson not on the default PATH (follow-up discovery).** ci.yml installs meson
+  via `pip3 install --user` (→ `~/.local/bin`) and adds it to `$GITHUB_PATH`
+  **per-job**; that PATH addition does NOT persist to other workflows. The
+  sanitizer-tests + codeql Linux legs were *verify-only* (asserted tools on
+  PATH, installed nothing) on the assumption the toolchain was baked into the
+  host — true on the long-lived Shulgi WSL2 runner, FALSE on Big Tam. Fix: give
+  those legs a real flock-wrapped `Install system packages` step (apt toolchain
+  + `pip3 install ... requirements-ci.txt` + `echo ~/.local/bin >> $GITHUB_PATH`),
+  mirroring ci.yml. nightly already installed, so it only needed the flock wrap.
+- **libpq breaks the sanitizer triplets when built from source (cold-build
+  discovery).** The `x64-linux-{asan,tsan}` overlay triplets are
+  `LIBRARY_LINKAGE dynamic`, so vcpkg built libpq as a `.so`. libpq is a recent
+  dep (Postgres substrate, ADR-0006) and the sanitizer caches hadn't been rebuilt
+  since it landed, so this only bit on Big Tam's cold build (would bite Shulgi
+  too on a cold rebuild). Two failures: TSan — PostgreSQL's shared-lib
+  `libpq-refs-stamp` check rejects the injected `__tsan_func_exit` ("must not
+  call exit") → vcpkg install fails; ASan — a dynamic libpq.so emits no
+  standalone `libpgcommon.a`, so `meson.build:320`'s `find_library('pgcommon',
+  required:true)` fails. Fix: per-port `if(PORT STREQUAL "libpq") set(...static)`
+  in both sanitizer triplets (matches stock x64-linux); vcpkg's libpq Makefile
+  builds the `.so`/runs refs-stamp only on the `all-shared-lib` path, so the
+  static path sidesteps both. Commit on the follow-up branch.
 - **apt lock:** the matrix legs race `apt-get`. `DPkg::Lock::Timeout` does NOT cover
   `apt-get update`'s lists lock, so the install step is wrapped in `flock -w 600 9 …
   9>/tmp/yuzu-ci-apt.lock`. **The sanitizer/nightly/codeql legs must add the SAME
@@ -96,26 +135,53 @@ Incremental order: do ci.yml first, prove it green on Big Tam, then the rest.
    (no compiler — needs no pin). The GHA-hosted **canary** stays on
    `ubuntu-24.04`/gcc-13 per the "keep GHA-hosted on 24.04" decision, so it no
    longer mirrors the primary toolchain (a known, accepted divergence).
-2. **`.github/workflows/sanitizer-tests.yml`** — repin
-   `[self-hosted, Linux, X64, yuzu-shulgi]` → `…, yuzu-bigtam-linux`; bump the
-   `gcc-13`/`g++-13` tool-presence checks + `CC: ccache gcc-13`. Add a
-   `bigtam_pool_healthy` gate (it currently has none). Leave `ImageOS: ubuntu24`.
-3. **`.github/workflows/nightly.yml`** — ASan + TSan legs repin
-   `yuzu-shulgi` → `yuzu-bigtam-linux`; the generic coverage leg is already
-   pool-labelled; bump every `gcc-13 g++-13` apt line and `CC: ccache gcc-13`.
-   Leave `ImageOS: ubuntu24`.
-4. **`.github/workflows/codeql.yml`** — Linux leg repin `yuzu-shulgi` →
-   `yuzu-bigtam-linux`; bump the `TOOLS=` list and `CC: ccache gcc-13`.
-   Leave `ImageOS: ubuntu24`.
-5. **`.github/workflows/release.yml`** — the `[self-hosted, Linux]` legs match
-   both boxes. Decide deliberately: keep release on gcc-13 (Shulgi) until the PR
-   matrix has soaked on gcc-15, **or** move it. If moving, bump the `gcc-13 g++-13`
-   tool-check + `CC: ccache gcc-13` and pin to Big Tam.
-6. **`.github/runner-inventory.json`** — update the Shulgi role (no longer the
-   live Linux runner) and the Big Tam roles (now live); if Shulgi is retired from
-   Linux CI, reflect that.
-7. **`docs/ci-architecture.md`** — update the runner-topology table + flip this
-   doc's status to "flipped".
+2. **`.github/workflows/sanitizer-tests.yml`** — **DONE (2026-06-21).** Both legs
+   repinned to `…, yuzu-bigtam-linux`; new `preflight` job gates both on
+   `bigtam_pool_healthy`; gcc-15/g++-15 + `linux-gcc15.ini`;
+   `YUZU_GW_ALLOW_DEFAULT_COOKIE=1`. The *verify-only* toolchain step was
+   replaced with a real flock-wrapped `Install system packages` step (meson is
+   not on Big Tam's default PATH — see shared-host fixes above).
+3. **`.github/workflows/nightly.yml`** — **DONE (2026-06-21).** ASan + TSan +
+   Coverage all repinned to `…, yuzu-bigtam-linux` (coverage was the generic
+   pool, but a gcc-15 build can't land on the Shulgi/gcc-13 fallback, so it is
+   pinned too; renamed "Coverage (GCC 13)"→"(GCC 15)"); new `preflight` job gates
+   all three on `bigtam_pool_healthy`; every apt line flock-wrapped (incl. the
+   best-effort `gdb` install in the TSan gdb step); gcc-15 + `linux-gcc15.ini`;
+   `YUZU_GW_ALLOW_DEFAULT_COOKIE=1`.
+4. **`.github/workflows/codeql.yml`** — **DONE (2026-06-21).** Linux matrix leg
+   repinned to `…, yuzu-bigtam-linux`; new Linux-only flock-wrapped
+   `Install system packages` step (same meson-PATH reason); `TOOLS=` +
+   `CC`/`CXX` → gcc-15, `linux-gcc15.ini`; Windows leg unchanged. **No
+   `bigtam_pool_healthy` gate** — a job-level `if` can't reference `matrix`, so
+   gating just the Linux leg of this Linux+Windows matrix job would require
+   splitting it (out of scope; CodeQL is not a required check).
+5. **`.github/workflows/release.yml`** — **DONE (2026-06-21, #1615).** All 5
+   self-hosted Linux legs (`build-linux`, `build-gateway`,
+   `docker-publish{,-postgres,-chisel}`) pinned to `…, yuzu-bigtam-linux`;
+   `build-linux` → gcc-15 (CC/CXX, verify-deps, `linux-gcc15.ini`);
+   `build-windows` → `yuzu-weetam-windows`. The docker buildx local cache moved off
+   the Shulgi-only `/mnt/d/docker-buildcache` mount to
+   `${runner.tool_cache}/yuzu-docker-buildcache`. `CCACHE_MAXSIZE=30G` added so the
+   build doesn't inherit the host default. (An interim pin to `yuzu-wsl2-linux` —
+   the runner NAME, not a label — would have queued forever; Shulgi's label is
+   `yuzu-shulgi`. release.yml only runs at tag time, so the first Big Tam release
+   is its real validation; note Big Tam ships RPM 6.0 vs Shulgi's 4.x.)
+6. **`.github/runner-inventory.json`** — **PENDING.** Remove `yuzu-wsl2-linux` and
+   `yuzu-local-windows` entirely (both retired); confirm the Big Tam + Wee Tam
+   roles are marked live. Until this lands the inventory sentinel flags the retired
+   runners as missing. No workflow gate depends on it — the pool gates are
+   label-driven, so retired runners just drop out (nothing gates on `all_healthy`).
+7. **`docs/ci-architecture.md`** — **DONE (2026-06-21, #1615).** Runner-topology
+   table consolidated (Big Tam = all Linux, Wee Tam = all Windows, both retired
+   runners listed under "Retired"), tier summary + "Ubuntu 26.04 migration" marked
+   COMPLETE, and a "Build speed" section added.
+8. **Big Tam host provisioning (build speed)** — **DONE (2026-06-21).** On the
+   `runner` user (shared `HOME=/home/runner` across r0–r3): ccache `max_size=50G`
+   (host default 5 GiB is far too small); `mold` (`apt install mold`) wired via
+   `-fuse-ld=mold` in the gcc-15/clang-21 native files; `rpm` (rpmbuild) for
+   release packaging (absent on fresh 26.04 — was the first-release blocker);
+   `requirements-ci.txt` (incl. meson 1.11.1) pre-installed in `~/.local` so the
+   per-job `pip --user --require-hashes` is a no-op (no re-download).
 
 ## Rollback
 

--- a/meson/native/linux-clang21.ini
+++ b/meson/native/linux-clang21.ini
@@ -3,9 +3,14 @@
 # NOTE: Set CC/CXX env vars to control compiler selection (e.g. CC='ccache clang-21')
 #
 # Clang 21 is the default LLVM/Clang on Ubuntu 26.04 (Resolute). This native
-# file is the Ubuntu-26.04 / Big Tam counterpart to linux-clang19.ini (Ubuntu
-# 24.04 / Shulgi). It is staged ahead of the self-hosted Linux runner cutover
-# documented in docs/ci-architecture.md — nothing references it until the flip.
+# file is the live Ubuntu-26.04 / Big Tam self-hosted Linux toolchain (the
+# clang leg of ci.yml after the Shulgi retirement); the counterpart
+# linux-clang19.ini is the old Ubuntu-24.04 / Shulgi file.
 
 [built-in options]
 cpp_std = 'c++23'
+# Link with mold (`apt install mold`) — large cut in link time. REQUIRES mold on
+# every runner that uses this file (the Big Tam pool); Clang supports
+# -fuse-ld=mold natively. Install mold before this lands in a CI run.
+c_link_args = ['-fuse-ld=mold']
+cpp_link_args = ['-fuse-ld=mold']

--- a/meson/native/linux-gcc15.ini
+++ b/meson/native/linux-gcc15.ini
@@ -2,10 +2,16 @@
 # Usage: meson setup builddir --native-file meson/native/linux-gcc15.ini
 # NOTE: Set CC/CXX env vars to control compiler selection (e.g. CC='ccache gcc-15')
 #
-# GCC 15 is the default toolchain on Ubuntu 26.04 (Resolute). This native
-# file is the Ubuntu-26.04 / Big Tam counterpart to linux-gcc13.ini (Ubuntu
-# 24.04 / Shulgi). It is staged ahead of the self-hosted Linux runner cutover
-# documented in docs/ci-architecture.md — nothing references it until the flip.
+# GCC 15 is the default toolchain on Ubuntu 26.04 (Resolute). This native file
+# is the live Ubuntu-26.04 / Big Tam self-hosted Linux toolchain (used by ci.yml
+# and release.yml after the Shulgi retirement); the counterpart linux-gcc13.ini
+# is kept only for the GHA-hosted ubuntu-24.04 canary.
 
 [built-in options]
 cpp_std = 'c++23'
+# Link with mold (`apt install mold`) — large cut in link time on the big
+# yuzu-server / yuzu-agent binaries and the release LTO link. REQUIRES mold on
+# every runner that uses this file (the Big Tam pool); GCC >= 12.1 supports
+# -fuse-ld=mold natively. Install mold before this lands in a CI run.
+c_link_args = ['-fuse-ld=mold']
+cpp_link_args = ['-fuse-ld=mold']

--- a/scripts/ci/ensure-postgres.sh
+++ b/scripts/ci/ensure-postgres.sh
@@ -63,6 +63,15 @@ fi
 
 # ── 2. Docker (self-hosted Linux) ────────────────────────────────────────
 if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+  if command -v flock >/dev/null 2>&1; then
+    exec 9>/tmp/yuzu-ci-postgres.lock
+    if ! flock -w 120 9; then
+      echo "::error::ensure-postgres: timed out waiting for /tmp/yuzu-ci-postgres.lock — another runner may be stuck managing ${CONTAINER}" >&2
+      exit "$SOFT_EXIT"
+    fi
+  else
+    echo "::warning::ensure-postgres: flock not available; shared docker container lifecycle is not serialized" >&2
+  fi
   # Digest-drift guard: the container is persistent (--restart
   # unless-stopped), so a PG_IMAGE pin bump would otherwise never reach
   # runners that already have one — tests would silently keep running the

--- a/triplets/x64-linux-asan.cmake
+++ b/triplets/x64-linux-asan.cmake
@@ -17,6 +17,24 @@ set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE dynamic)
 set(VCPKG_CMAKE_SYSTEM_NAME Linux)
 
+# libpq (Postgres substrate, ADR-0006) must be STATIC even though the rest of the
+# sanitizer dep tree is dynamic — two reasons, both surfaced by the Big Tam cold
+# sanitizer build (the deps haven't been rebuilt from source since libpq landed):
+#   1. meson.build's unix libpq block hard-requires the static
+#      libpgcommon.a/libpgport.a archives (scram/auth helpers) that ONLY the
+#      static build emits; a dynamic libpq.so has no standalone pgcommon → meson
+#      fails with "library 'pgcommon' not found".
+#   2. PostgreSQL's shared-lib `libpq-refs-stamp` check rejects the ASan-injected
+#      symbols as "calling exit". vcpkg's libpq Makefile builds the .so only on
+#      the `all-shared-lib` path; the static path (`all-static-lib`) skips the .so
+#      and that check entirely.
+# Matches the stock x64-linux triplet (which is already static). The triplet's
+# -fsanitize flags still apply to the static archive, so sanitizer coverage
+# inside libpq is preserved.
+if(PORT STREQUAL "libpq")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()
+
 # Sanitiser flags propagate to every compiled C/C++ TU in vendored
 # dependencies. `-fno-omit-frame-pointer` keeps backtraces accurate;
 # `-g` keeps file:line debug info.

--- a/triplets/x64-linux-tsan.cmake
+++ b/triplets/x64-linux-tsan.cmake
@@ -18,6 +18,25 @@ set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE dynamic)
 set(VCPKG_CMAKE_SYSTEM_NAME Linux)
 
+# libpq (Postgres substrate, ADR-0006) must be STATIC even though the rest of the
+# sanitizer dep tree is dynamic — two reasons, both surfaced by the Big Tam cold
+# sanitizer build (the deps haven't been rebuilt from source since libpq landed):
+#   1. meson.build's unix libpq block hard-requires the static
+#      libpgcommon.a/libpgport.a archives (scram/auth helpers) that ONLY the
+#      static build emits; a dynamic libpq.so has no standalone pgcommon → meson
+#      fails with "library 'pgcommon' not found".
+#   2. PostgreSQL's shared-lib `libpq-refs-stamp` check rejects TSan's injected
+#      `__tsan_func_exit` symbol as "calling exit" ("libpq must not be calling any
+#      function which invokes exit"). vcpkg's libpq Makefile builds the .so only on
+#      the `all-shared-lib` path; the static path (`all-static-lib`) skips the .so
+#      and that check entirely.
+# Matches the stock x64-linux triplet (which is already static). The triplet's
+# -fsanitize flags still apply to the static archive, so sanitizer coverage
+# inside libpq is preserved.
+if(PORT STREQUAL "libpq")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()
+
 # Sanitiser flags propagate to every compiled C/C++ TU in vendored
 # dependencies. `-fno-omit-frame-pointer` keeps backtraces accurate
 # in race reports; `-g` keeps file:line debug info. Matches what


### PR DESCRIPTION
## Summary

Retires the two old single-host self-hosted runners and moves **all** self-hosted CI to the new pools:

- **Linux → Big Tam** (`yuzu-bigtam-linux`, 4 runners, Ubuntu 26.04, gcc-15/clang-21) — retiring **Shulgi** (`yuzu-wsl2-linux`, label `yuzu-shulgi`, Ubuntu 24.04/gcc-13).
- **Windows → Wee Tam** (`yuzu-weetam-windows`) — retiring **`yuzu-local-windows`**. (Most Windows legs were already moved on `dev`; this finishes the stragglers.)

Builds on the merged `ci.yml` Linux flip (#1609) and completes the follow-up: `sanitizer-tests.yml`, `nightly.yml`, `codeql.yml`, **and `release.yml`** now target Big Tam, plus build-speed work.

## Commits
1. `ci(sanitizers)` — sanitizer-tests.yml Linux legs → Big Tam
2. `ci(nightly)` — nightly.yml asan/tsan/coverage → Big Tam
3. `ci(codeql)` — codeql.yml Linux leg → Big Tam
4. `fix(vcpkg)` — build libpq static in the asan/tsan triplets (cold-build fix; libpq `.so` trips TSan `libpq-refs-stamp` / misses `libpgcommon.a`)
5. `ci:` — retire Shulgi & local-windows; release.yml + remaining Windows legs + build-speed

## Key fixes in this PR
- **release.yml**: 5 self-hosted Linux legs (`build-linux`, `build-gateway`, `docker-publish{,-postgres,-chisel}`) → `yuzu-bigtam-linux`. The prior uncommitted pin targeted `yuzu-wsl2-linux` — that's the runner **name**, not a label (no runner carries it), so those legs would have **queued forever**; Shulgi's label is `yuzu-shulgi`. `build-linux` now builds with **gcc-15**. docker buildx local cache `/mnt/d/docker-buildcache` (a Shulgi WSL2 mount) → `${runner.tool_cache}/yuzu-docker-buildcache`.
- **Windows**: `release.yml build-windows`, `instructions-windows-validate.yml`, and `cache-prune.yml prune-windows` → `yuzu-weetam-windows` (ci.yml/codeql were already done on dev).
- **ci.yml**: declares the `linux_pool_healthy` preflight output that `proto-compat` gates on (was undeclared → always-skip); refreshes stale gcc-13/clang-19 matrix comments.

## Build speed
- **release.yml**: `CCACHE_MAXSIZE=30G` so the self-hosted build stops inheriting the host 5 GiB ccache default.
- **meson/native/linux-{gcc15,clang21}.ini**: link with **mold** (`-fuse-ld=mold`).
- Host provisioning **already done on Big Tam** (all 4 runners): `rpm` (rpmbuild — was the release blocker), `mold` 2.40, ccache `max_size=50G`, persistent `pip --user` (meson 1.11.1 in `/home/runner/.local`).

## Notes / caveats
- **release.yml runs only at tag time** — the gcc-15 toolchain + gateway + docker are all proven on Big Tam via ci.yml, but the release-specific path (static-triplet build, rpmbuild, multi-arch publish) runs on Big Tam for the first time at the next release. Worth watching: Big Tam ships **RPM 6.0** vs Shulgi's RPM 4.x.
- `proto-compat` and `prune-linux` stay on the generic `[self-hosted, Linux, X64]` label (compiler-free; resolve to Big Tam once Shulgi deregisters).
- **Docs follow-up**: `docs/ci-architecture.md` + `docs/ci-ubuntu-2604-cutover.md` need a pass to reflect the full retirement + build-speed provisioning (not in this PR).
- The `runner-inventory-sentinel` / health-check pool logic needs no change (label-driven; retired runners drop out gracefully — nothing gates on `all_healthy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
