### PR TITLE
fix(dex): credit the Linux signals the DEX Catalogue under-reports (coverage map drift)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -328,6 +328,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Linux agent. macOS coverage (16) was already correct and is unchanged. No agent change, no data
   change — Catalogue display only; the drift-net test now pins the map to the emitted set on both
   platforms.
+- **Doc honesty: retract over-claimed management-group list-view confinement (ADR-0017 / #1716).**
   `GET /api/v1/inventory/software`, MCP `query_installed_software`, and the TAR retention-paused
   list carry a per-agent management-group drop filter that is **not yet effective** under the
   *global* `Inventory:Read` / `Infrastructure:Read` gate (a confined operator is denied at the gate;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -315,7 +315,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Doc honesty: retract over-claimed management-group list-view confinement (ADR-0017 / #1716).**
+- **DEX Catalogue now credits the full Linux signal coverage (was 7, now 17 types).** The per-OS
+  coverage map (`dex_obs_platforms`) that colours the Catalogue's "monitored / not collected on
+  Linux" badges was frozen at the original 7-type conservative set from before the Linux
+  kernel/sysfs collectors existed — the collectors landed without the map being updated in the same
+  change. A Linux fleet's Catalogue therefore showed `perf.disk_latency_high`, `hw.cpu_throttled`,
+  `service.hung`, `os.time_unsynced`, `os.bugcheck`, `os.dirty_shutdown`, `disk.error`,
+  `fs.corruption`, `hw.error`, and `process.hung` as *not collected* even though the agent emits
+  them — via `poll_perf` (the `/proc` CPU/memory/diskstats breach trio), the sysfs CPU-throttle
+  poll, and the journald poll whose kernel-transport lines are classified by `dex_linux_kmsg`. The
+  map is now authoritative at 17 types, so those families render as monitored on any connected
+  Linux agent. macOS coverage (16) was already correct and is unchanged. No agent change, no data
+  change — Catalogue display only; the drift-net test now pins the map to the emitted set on both
+  platforms.
   `GET /api/v1/inventory/software`, MCP `query_installed_software`, and the TAR retention-paused
   list carry a per-agent management-group drop filter that is **not yet effective** under the
   *global* `Inventory:Read` / `Infrastructure:Read` gate (a confined operator is denied at the gate;

--- a/docs/dex-signal-catalog.md
+++ b/docs/dex-signal-catalog.md
@@ -19,8 +19,10 @@ separate sources — the macOS IOKit poll, the Windows state poll, and the Linux
 `/proc`+`statvfs` collector, see those sections below; it began macOS-only) **+
 the three A3 `perf.*` sustained-breach types** (`perf.cpu_sustained`,
 `perf.memory_pressure`, `perf.disk_latency_high` — the "Performance" display
-family, Windows state poll + the Linux `/proc` poll for cpu_sustained &
-memory_pressure; disk_latency_high stays Windows-only, see below).
+family, Windows state poll + the Linux `/proc` poll, which emits all three: cpu
+and memory from `/proc/stat`+`/proc/meminfo` and disk-latency from the
+`/proc/diskstats` await breach (ordinary disks only — exotic/fabric storage is
+excluded), see below).
 The Windows *event* catalogue is 110; the state-poll signals (`storage.low`,
 battery via `hw.error`, the `perf.*` breaches) ride alongside it without
 catalogue entries, exactly like the macOS and Linux poll mechanisms.

--- a/docs/user-manual/dex.md
+++ b/docs/user-manual/dex.md
@@ -285,10 +285,17 @@ F1 follow-up, same as the blast-radius detector's). A
 collector that reuses the same OS-neutral signal types and covers roughly ten
 of the eleven experience headings (crashes and hangs, resource pressure,
 service failures, boot/resume reports, storage pressure, battery health, and
-more). A **Linux** server collector ships too (`/proc` CPU + memory-commit pressure and
-`statvfs` storage), reusing the same signal types, so Linux servers appear in the
-Performance and Hardware/storage views; workstation-only headings (battery, Wi-Fi,
-display, GUI) are **N/A on headless servers**, not gaps. `storage.low` uses a fixed
+more). A **Linux** server collector ships too, reusing the same signal types across
+several mechanisms: a `/proc` performance poll (sustained CPU, memory-commit pressure,
+and `/proc/diskstats` disk-latency breaches — the same hysteresis as Windows), a
+`statvfs` storage poll, a `/sys` CPU-thermal-throttle poll, and a **journald** reader
+whose kernel-transport (`/dev/kmsg`) lines are classified into existing signal types
+(kernel panic, machine-check errors, filesystem corruption, disk errors, dirty
+shutdowns, hung tasks, the OOM-killer) alongside structured unit crash/hang and
+clock-unsync records. So Linux servers light not only the Performance and Hardware/
+storage views but also App reliability, Service health, System stability, and File
+system; workstation-only headings (battery, Wi-Fi, display, GUI) are **N/A on headless
+servers**, not gaps. `storage.low` uses a fixed
 5 GiB-free floor (small cloud/VM root volumes can read as low until the F1
 configurable thresholds land), and inside an unmodified container `/proc` reflects
 the *host*, so the collector targets host/VM deployment. Because the by-OS and cross-OS views

--- a/server/core/src/dex_routes.cpp
+++ b/server/core/src/dex_routes.cpp
@@ -131,18 +131,28 @@ std::size_t dex_catalogued_type_count() {
 // in sync with the agent collectors; a schema↔catalogue cross-check test guards it.
 std::vector<std::string> dex_obs_platforms(const std::string& obs_type) {
     static const char* const kLinux[] = {
-        // /proc + statvfs polls (dex_linux_proc / dex_linux_storage)
-        "perf.cpu_sustained", "perf.memory_pressure", "storage.low", "os.uptime_report",
-        // systemd-structured journal (dex_linux_journal)
-        "process.crashed", "service.crashed", "memory.exhausted"};
-    // NOTE: the expanded Linux kernel/sysfs signals — perf.disk_latency_high,
-    // hw.cpu_throttled (dex_linux_sysfs); service.hung, os.time_unsynced
-    // (journal); os.bugcheck, os.dirty_shutdown, disk.error, fs.corruption,
-    // hw.error, process.hung (dex_linux_kmsg) — land WITH their collectors in the
-    // dex-linux-signals batch (#1523). Re-add them here in the same change that
-    // brings those collectors onto this branch, and extend the drift-net test in
-    // test_dex_routes.cpp. Until then the map must not advertise a Linux signal
-    // nothing collects, or a Linux fleet reads "monitored, quiet" as healthy.
+        // poll_perf: /proc/stat + /proc/meminfo + /proc/diskstats breaches (all three
+        // via the SAME win::breach_update used on Windows) + statvfs storage + uptime
+        "perf.cpu_sustained", "perf.memory_pressure", "perf.disk_latency_high", "storage.low",
+        "os.uptime_report",
+        // poll_throttle: sysfs thermal-throttle counter (dex_linux_sysfs → dex_linux_collector)
+        "hw.cpu_throttled",
+        // systemd-structured journal records (dex_linux_journal)
+        "process.crashed", "service.crashed", "service.hung", "os.time_unsynced",
+        // kernel-transport journal lines, classified by dex_linux_kmsg
+        // (classify_kernel_message, delegated from parse_journal_line)
+        "memory.exhausted", "os.bugcheck", "os.dirty_shutdown", "disk.error", "fs.corruption",
+        "hw.error", "process.hung"};
+    // The Linux DEX observer (dex_linux_collector) drives all of the above: poll_perf
+    // (the /proc CPU + memory + diskstats breach trio — perf.disk_latency_high is the
+    // /proc/diskstats await breach, as live as cpu/mem on any ordinary sd*/nvme*/mmcblk
+    // disk; only exotic/fabric storage is excluded, dex_linux_proc.hpp is_whole_disk) +
+    // statvfs storage + the sysfs throttle counter + the journald poll, whose every
+    // `_TRANSPORT=kernel` line is delegated to dex_linux_kmsg's classify_kernel_message
+    // (so the kmsg-classified types ARE emitted at runtime via journald, not a separate
+    // unwired reader). Keep this map and the drift-net test in test_dex_routes.cpp in
+    // lockstep with the collectors — they are hand-maintained because the server suite
+    // can't introspect the agent (durable fix: generate from the collector registries).
     static const char* const kMac[] = {
         "process.crashed", "process.hung",  "os.bugcheck",     "memory.exhausted",
         "os.uptime_report", "disk.smart_failure", "hw.error",  "storage.low",

--- a/tests/unit/server/test_dex_routes.cpp
+++ b/tests/unit/server/test_dex_routes.cpp
@@ -1349,20 +1349,38 @@ TEST_CASE("DEX perf routes: dispatch, poll, degrade, and authz posture",
 // can't introspect the agent collectors, so the emitted set is pinned here; when
 // collectors are added or removed, update BOTH the collector and the set below in
 // the same change (that conscious edit is the point). ──
-TEST_CASE("dex coverage map does not overclaim Linux beyond emitted signals",
+TEST_CASE("dex coverage map matches the emitted signal set (Linux + macOS)",
           "[dex][coverage]") {
-    // What a Linux agent emits today: dex_linux_proc + dex_linux_storage polls and
-    // dex_linux_journal mappings. The expanded kmsg/sysfs set arrives with #1523.
+    // What a Linux agent emits today — dex_linux_collector drives all of these: poll_perf
+    // (the /proc CPU + memory + diskstats breach trio — perf.disk_latency_high is the
+    // /proc/diskstats await breach, as live as cpu/mem on ordinary disks) + statvfs
+    // storage (dex_linux_proc/storage), the sysfs throttle counter (dex_linux_sysfs), and
+    // the journald poll (dex_linux_journal), whose _TRANSPORT=kernel lines are classified
+    // by dex_linux_kmsg::classify_kernel_message. The server suite can't introspect the
+    // agent collectors, so this set is pinned by hand — keep it in lockstep.
     const std::set<std::string> kLinuxEmitted = {
-        "perf.cpu_sustained", "perf.memory_pressure", "storage.low", "os.uptime_report",
-        "process.crashed",    "service.crashed",      "memory.exhausted"};
+        "perf.cpu_sustained", "perf.memory_pressure",  "perf.disk_latency_high", "storage.low",
+        "os.uptime_report",   "hw.cpu_throttled",      "process.crashed",        "service.crashed",
+        "service.hung",       "os.time_unsynced",      "memory.exhausted",       "os.bugcheck",
+        "os.dirty_shutdown",  "disk.error",            "fs.corruption",          "hw.error",
+        "process.hung"};
+    // What a macOS agent emits today — dex_macos_collector drives oslog + iokit +
+    // signals/uptime. NOTE: process.resource_limit is also emitted but is NOT yet in
+    // the catalogue taxonomy (it surfaces under "Other"); adding it to a family needs
+    // the catalogued⇒Windows assumption relaxed, so it is correctly absent here for now.
+    const std::set<std::string> kMacEmitted = {
+        "process.crashed",  "process.hung",       "os.bugcheck",       "memory.exhausted",
+        "os.uptime_report", "disk.smart_failure", "hw.error",          "storage.low",
+        "hw.cpu_throttled", "service.crashed",    "network.wifi_drop", "update.failed",
+        "print.failed",     "mgmt.mdm_error",     "logon.no_dc",       "fs.corruption"};
 
     auto claims = [](const std::string& obs_type, const char* os) {
         const auto p = dex_obs_platforms(obs_type);
         return std::find(p.begin(), p.end(), os) != p.end();
     };
 
-    // Overclaim guard: every catalogued type the map marks "linux" must be emitted.
+    // Overclaim guard: every catalogued type the map marks for a platform must be in
+    // that platform's emitted set — never advertise a signal nothing collects.
     for (const auto& g : dex_signal_groups()) {
         for (const char* t : g.types) {
             if (claims(t, "linux")) {
@@ -1370,13 +1388,22 @@ TEST_CASE("dex coverage map does not overclaim Linux beyond emitted signals",
                      << t << "' but no Linux collector emits it (see dex_obs_platforms)");
                 CHECK(kLinuxEmitted.count(t) == 1);
             }
+            if (claims(t, "macos")) {
+                INFO("coverage map claims macOS collects '"
+                     << t << "' but no macOS collector emits it (see dex_obs_platforms)");
+                CHECK(kMacEmitted.count(t) == 1);
+            }
         }
     }
 
-    // Underclaim guard: every emitted Linux signal is actually advertised.
+    // Underclaim guard: every emitted signal is actually advertised by the map.
     for (const auto& t : kLinuxEmitted) {
         INFO("emitted Linux signal '" << t << "' is missing from the coverage map");
         CHECK(claims(t, "linux"));
+    }
+    for (const auto& t : kMacEmitted) {
+        INFO("emitted macOS signal '" << t << "' is missing from the coverage map");
+        CHECK(claims(t, "macos"));
     }
 
     // Windows is the whole EvtSubscribe catalogue — always present and first.

--- a/tests/unit/server/test_dex_routes.cpp
+++ b/tests/unit/server/test_dex_routes.cpp
@@ -1374,6 +1374,12 @@ TEST_CASE("dex coverage map matches the emitted signal set (Linux + macOS)",
         "hw.cpu_throttled", "service.crashed",    "network.wifi_drop", "update.failed",
         "print.failed",     "mgmt.mdm_error",     "logon.no_dc",       "fs.corruption"};
 
+    // Size sentinels: the over/under-claim loops below skip a type absent from BOTH the
+    // map and the emitted set, so a simultaneous deletion from kLinux[] + kLinuxEmitted
+    // would pass silently. Pin the counts so accidental set-shrinkage fails loudly.
+    REQUIRE(kLinuxEmitted.size() == 17);
+    REQUIRE(kMacEmitted.size() == 16);
+
     auto claims = [](const std::string& obs_type, const char* os) {
         const auto p = dex_obs_platforms(obs_type);
         return std::find(p.begin(), p.end(), os) != p.end();


### PR DESCRIPTION
## What
The DEX **Catalogue**'s per-OS "monitored / not collected" badges come from a hand-maintained map, `dex_obs_platforms()`. Its Linux list was frozen at the original **7** types from before the Linux kernel/sysfs collectors existed — the collectors landed without the map being updated in the same change. So a Linux fleet's Catalogue showed ~10 families/types as *not collected on Linux* that the agent actively emits.

This credits the **17** Linux types the agent genuinely emits (`kLinux` 7 → 17): the `poll_perf` `/proc` CPU/memory/**diskstats** breach trio, the sysfs CPU-throttle poll, and the journald poll whose `_TRANSPORT=kernel` lines are classified by `dex_linux_kmsg`. macOS was already correct (16) — unchanged. The drift-net test now pins the map to the emitted set on **both** platforms (a macOS over/under-claim guard + size sentinels). **No agent change, no data change — Catalogue display only.**

## Verification
MSVC build clean; the `[dex][coverage]` drift-net reconciles 17/17 Linux + 16/16 macOS (70 assertions); full server suite **45,451 / 2813** with live Postgres.

## Governance
Full 8-gate pipeline on the exact HEAD, **converged — 0 CRITICAL/HIGH/BLOCKING**. It earned its keep: the pipeline caught **two real BLOCKINGs I'd introduced** —
- `perf.disk_latency_high` was wrongly *excluded* (I trusted a code comment instead of tracing to the emit site); 4 reviewers + the code proved it IS emitted on Linux via the same `poll_perf` diskstats breach as CPU/mem → now correctly credited (the 17th type);
- a malformed CHANGELOG that orphaned the adjacent ADR-0017/#1716 bullet → heading restored.

Both fixed + re-confirmed clean.

## Follow-ups (filed, not blockers)
- #1745 — generate the per-OS coverage map from collector registries (durable anti-drift; the map + its drift-net are hand-maintained because the server can't introspect the agent).
- #1746 — per-OS health score under the OS filter is Windows-denominated (pre-existing; this change surfaces it through more families).

🤖 Generated with [Claude Code](https://claude.com/claude-code)