### PR TITLE
feat(scope-walking): finish 15.G — resolve-latency histogram + audit polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Scope-walking result-set operational hardening complete (Phase 15.G).** Added the
+  `yuzu_result_set_resolve_seconds` Prometheus histogram (resolve latency bucketed by result-set
+  cardinality tier, observed in `AgentRegistry::evaluate_scope`) and `describe()` HELP/TYPE for all
+  result-set metrics. Completed the audit trail: `result_set.live_reeval` (links a re-eval sibling
+  back to the original) and an aggregate system-principal `result_set.gc_sweep` row emitted by the
+  background GC sweep. The GC sweep now runs through a shared, unit-tested `run_result_set_gc` helper
+  (`result_set_maintenance.{hpp,cpp}`). See `docs/scope-walking-design.md` §9.
+
 ## [0.13.0] - 2026-07-01
 
 ### Added

--- a/docs/capability-map.md
+++ b/docs/capability-map.md
@@ -32,7 +32,7 @@ Advanced     [================================]  101/101 done (100%)
 Future       [=====================-----------]  33/50 done  (66%)
 New (Ph 8-16)[=---------------------------]     2/44 done   (5%) (5 partial — Guardian PRs 1-2 + Guardian pre-login activation done; 15.A + 28.4 + 28.6 + 28.7 fleet-viz in flight)
 ─────────────────────────────────────────────────────────────────
-Overall      [======================---------]   172/228 done (75%)
+Overall      [======================---------]   173/228 done (76%)
 ```
 
 | Domain | Total | Done | Partial | Not Started |
@@ -66,9 +66,9 @@ Overall      [======================---------]   172/228 done (75%)
 | 27. Software Catalog & Licensing | 5 | 0 | 0 | 5 |
 | 28. Response Visualization | 9 | 0 | 3 | 6 |
 | 29. Consumer Applications | 4 | 0 | 0 | 4 |
-| 30. Scope Walking & Result Sets | 4 | 3 | 1 | 0 |
+| 30. Scope Walking & Result Sets | 4 | 4 | 0 | 0 |
 | 31. System Guardian | 10 | 1 | 2 | 7 |
-| **TOTAL** | **228** | **172** | **6** | **50** |
+| **TOTAL** | **228** | **173** | **5** | **50** |
 
 > **Scaffolded vs production-quality.** The percentages above measure feature presence, not enterprise hardening. Foundation and Advanced tiers reach 100% on the "implemented and functional" bar — they do not yet reach "hardened, observable, and proven at large-fleet scale" on every domain. Known gaps at the §-level (e.g. configurable heartbeat in §1.2, unified diagnostics bundle in §1.3, runtime plugin install in §1.5) remain even where a domain is marked Done. The `docs/capability-agentic-audit-2026-05.md` audit is the source for the production-quality dimension; subsequent reviews should keep it current.
 
@@ -1146,9 +1146,9 @@ Shipped 2026-05-31 (Phase 15.C; `68427bba`, hardening `4f10a69b`). The Scope Eng
 
 Shipped 2026-05-31 (Phase 15.E; `e6361a3a`). Instruction/instruction-set paths done; **Policy `fromResultSet:` deferred to PR-E2** (result-set TTL vs. continuous policy evaluation). The `scope:` block in `InstructionDefinition`, `InstructionSet`, and `Policy` gains `fromResultSet:` as a mutually-exclusive (or composable-with-`selector:`) alternative form so YAML-defined automation can target the device set produced by a previous query. Validation rules: `fromResultSet + assignment.managementGroups` rejected at YAML load (a result set already has a fixed device set, layering management-group filtering on top is redundant); `fromResultSet` requires `assignment.mode = static` (the whole point of a result set is a fixed target — `dynamic` re-evaluation against management groups would defeat it). Resolution at instruction *invocation* time, not YAML load time, so a definition carrying `fromResultSet:` is valid YAML even if the referenced set has expired by invocation. Resolution failure surfaces as `INSTRUCTION_SCOPE_RESOLUTION_FAILED` with the result-set ID and reason in the audit row. Design: `docs/scope-walking-design.md` §7.
 
-### 30.4 Result Set Operational Hardening :large_orange_diamond: `T2`
+### 30.4 Result Set Operational Hardening :white_check_mark: `T2`
 
-Largely shipped (Phase 15.G). Shipped: live re-eval (sibling result set), background GC sweep (`ResultSetStore::gc_sweep()` wired in `server.cpp`), per-operator quota/pin caps (`429`/`409`), and Prometheus `yuzu_result_sets_total` / `yuzu_result_sets_alive` / `yuzu_result_set_gc_total` / `yuzu_result_set_quota_rejected`. Remaining: the `yuzu_result_set_resolve_seconds` histogram and a final audit-polish pass. Live re-evaluation produces a *new* result set ID rooted at the original's parent (sibling, not child) — operators can refresh a stale set against current estate state without breaking lineage. Background GC sweep every 5 minutes removes unpinned sets past TTL, cascading to member rows. Per-operator quotas enforced with `429 RESULT_SET_QUOTA` and `409 PIN_LIMIT`. Prometheus metrics — `yuzu_result_sets_total`, `yuzu_result_sets_alive`, `yuzu_result_set_resolve_seconds` histogram by cardinality bucket, GC counter, quota-rejection counter — surface health and runaway-script detection. Audit polish on every state transition. Design: `docs/scope-walking-design.md` §3.3, §9.
+Shipped (Phase 15.G): live re-eval (sibling result set), background GC sweep (`ResultSetStore::gc_sweep()` via the shared `run_result_set_gc` helper), per-operator quota/pin caps (`429`/`409`), the full Prometheus set (`yuzu_result_sets_total` / `yuzu_result_sets_alive` / `yuzu_result_set_gc_total` / `yuzu_result_set_quota_rejected` / `yuzu_result_set_resolve_seconds` histogram by cardinality tier, all `describe()`d), and audit rows for every state transition incl. `result_set.live_reeval` + the aggregate `result_set.gc_sweep`. Live re-evaluation produces a *new* result set ID rooted at the original's parent (sibling, not child) — operators can refresh a stale set against current estate state without breaking lineage. Background GC sweep every 5 minutes removes unpinned sets past TTL, cascading to member rows. Per-operator quotas enforced with `429 RESULT_SET_QUOTA` and `409 PIN_LIMIT`. Prometheus metrics — `yuzu_result_sets_total`, `yuzu_result_sets_alive`, `yuzu_result_set_resolve_seconds` histogram by cardinality bucket, GC counter, quota-rejection counter — surface health and runaway-script detection. Audit polish on every state transition. Design: `docs/scope-walking-design.md` §3.3, §9.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1538,12 +1538,12 @@ Drives the §10 walkthrough (inventory-ground → TAR-query narrow → instructi
 **Files:** `tests/unit/server/test_chrome_ir_chain.cpp`, `tests/meson.build`. Design: `docs/scope-walking-design.md` §10.
 
 ### Issue 15.G: Operational Hardening — Live Re-Eval, GC Sweep, Prometheus + Audit Polish
-**Capability:** new | **Scope:** Server | **Status:** **Largely shipped** (2026-05-31 ladder) — remaining items tracked below.
+**Capability:** new | **Scope:** Server | **Status:** **Shipped** — 15.B ladder (2026-05-31) + resolve-latency histogram & audit polish (2026-07-01).
 **Depends on:** 15.B
 
 Live re-eval (`POST /api/v1/result-sets/{id}/re-eval`); background GC sweep every 5 min; per-operator 10K result-set quota + 50 pin cap with `429 RESULT_SET_QUOTA` / `409 PIN_LIMIT`; Prometheus metrics (`yuzu_result_sets_total`, `yuzu_result_sets_alive`, `yuzu_result_set_resolve_seconds` histogram, GC counter, quota-rejection counter); audit polish on every state transition.
 
-**Shipped:** re-eval endpoint; background GC-sweep thread wired in `server.cpp` (`ResultSetStore::gc_sweep()`); Prometheus `yuzu_result_sets_total`, `yuzu_result_sets_alive`, `yuzu_result_set_gc_total`, and `yuzu_result_set_quota_rejected`; quota (`kMaxPerOwner=10000` → `429`) and pin cap (`kMaxPinsPerOwner=50` → `409`) enforced in the store. **Still open:** the `yuzu_result_set_resolve_seconds` histogram and a final audit-polish pass. Recommend narrowing 15.G to just these remainders.
+**As shipped:** re-eval endpoint; background GC-sweep thread (`ResultSetStore::gc_sweep()` via the shared, unit-tested `run_result_set_gc` helper in `result_set_maintenance.{hpp,cpp}`); the full Prometheus set (`yuzu_result_sets_total`, `yuzu_result_sets_alive`, `yuzu_result_set_gc_total`, `yuzu_result_set_quota_rejected`, and the `yuzu_result_set_resolve_seconds` histogram bucketed by cardinality tier, observed in `AgentRegistry::evaluate_scope`), all with `describe()` HELP/TYPE; quota (`kMaxPerOwner=10000` → `429`) + pin cap (`kMaxPinsPerOwner=50` → `409`); and audit rows for every transition incl. the new `result_set.live_reeval` (links the sibling to the original) and the aggregate system-principal `result_set.gc_sweep`. **Known limitation:** `device_count_delta` on `live_reeval` is omitted — the sibling lands `pending` and materialises asynchronously.
 
 **Files:** `server/core/src/result_set_store.cpp`, `server/core/src/result_set_routes.cpp`, `server/core/src/server.cpp`. Design: `docs/scope-walking-design.md` §3.3, §9.
 

--- a/docs/scope-walking-design.md
+++ b/docs/scope-walking-design.md
@@ -261,7 +261,7 @@ Every state transition writes an `AuditEvent` per `docs/observability-convention
 | Action | Result | Notes |
 |---|---|---|
 | `result_set.create` | `success` / `failure` | Includes source_kind, parent_id, device_count |
-| `result_set.live_reeval` | `success` / `failure` | Includes original_id, new_id, device_count_delta |
+| `result_set.live_reeval` | `success` | **As shipped:** `target_id` = the original set; `detail` = `new_id=<rs> source_kind=<kind>`. (`device_count_delta` is omitted — the sibling lands `pending` and materialises asynchronously, so the delta is not known at re-eval time.) |
 | `result_set.pin` / `result_set.unpin` | `success` | |
 | `result_set.delete` | `success` | Pinned sets require explicit unpin first; `delete` of an unpinned set is single-action |
 | `result_set.gc_sweep` | `success` | Aggregate row, written once per sweep with the count |
@@ -335,7 +335,7 @@ This walkthrough is the reference test for end-to-end correctness. A regression 
 | PR-D | TAR SQL frame consumes / produces result sets via §6 routes | First end-to-end loop in the dashboard |
 | PR-E | DSL `fromResultSet:` (§7) + definition/policy validation + DSL spec amendment | **Shipped** — instruction-side validation + `selector:` lowering + dispatch alias resolution + `scope_resolution_failed` audit. **Policy `fromResultSet:` deferred to PR-E2** (owner field + `PolicyEvaluator` wiring + pinned-set rule). |
 | PR-F | Reference walkthrough integration test (§10) | Regression net |
-| PR-G | Live re-eval, pin storm guards, GC sweep, Prometheus + audit polish | Operational hardening |
+| PR-G | Live re-eval, pin storm guards, GC sweep, Prometheus + audit polish — **Shipped** (2026-05-31 ladder + `yuzu_result_set_resolve_seconds` histogram, `result_set.live_reeval` + `result_set.gc_sweep` audit, 2026-07-01) | Operational hardening |
 | PR-H | Process tree viewer (separate slice — see `docs/tar-dashboard.md` §6) | Builds on PR-D's frame pattern |
 
 PR-A is in scope **for the current session** — it ships the page and the retention list against the existing scope grammar. Everything else is sequenced after.

--- a/docs/user-manual/audit-log.md
+++ b/docs/user-manual/audit-log.md
@@ -89,6 +89,11 @@ required.
 | `rbac.role_revoke` | Principal | A role is revoked from a principal |
 | `management_group.create` | ManagementGroup | A management group is created |
 | `management_group.delete` | ManagementGroup | A management group is deleted |
+| `result_set.create` | ResultSet | A result set (composable scope, "scope walking") is created via `POST /api/v1/result-sets` or a `from-inventory-query` / `from-tar-query` / `from-instruction-result` producer. `target_id` is the new `rs_<id>`; `detail` carries `source_kind=<inventory_query\|tar_query\|instruction_result\|manual_curate>` (async producers also carry `execution_id=` + `agents=`). |
+| `result_set.live_reeval` | ResultSet | A result set was re-evaluated via `POST /api/v1/result-sets/{id}/re-eval`, producing a sibling rooted at the original's parent. `target_id` is the **original** set; `detail` carries `new_id=<rs> source_kind=<kind>`. (`device_count_delta` is omitted — the sibling lands `pending` and materialises asynchronously.) |
+| `result_set.pin` / `result_set.unpin` | ResultSet | An operator pinned (TTL → never GC'd, for the duration of an investigation) or unpinned a result set. |
+| `result_set.delete` | ResultSet | A result set is deleted via `DELETE /api/v1/result-sets/{id}`. A **pinned** set must be unpinned first — a pinned delete returns `409` and is not logged as a delete. |
+| `result_set.gc_sweep` | ResultSet | The background GC sweep removed expired unpinned result sets. **System-initiated** (`principal=__system__`, no session/IP), emitted once per sweep and only when ≥1 set was removed; `detail` carries `count=<n>`. |
 | `management_group.add_member` | ManagementGroup | An agent is added to a management group |
 | `management_group.remove_member` | ManagementGroup | An agent is removed from a management group |
 | `management_group.assign_role` | ManagementGroup | A role is assigned to a principal on a management group |

--- a/server/core/meson.build
+++ b/server/core/meson.build
@@ -319,6 +319,7 @@ yuzu_server_core_lib = static_library(
     'src/quarantine_store.cpp',
     'src/result_set_store.cpp',
     'src/result_set_matcher.cpp',
+    'src/result_set_maintenance.cpp',
     'src/policy_store.cpp',
     'src/policy_evaluator.cpp',
     'src/guaranteed_state_store.cpp',

--- a/server/core/src/agent_registry.cpp
+++ b/server/core/src/agent_registry.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <chrono>
 #include <cmath>
 #include <string>
 #include <unordered_map>
@@ -20,6 +21,23 @@ namespace yuzu::server::detail {
 
 // Bring html_escape into scope for the HTML rendering methods.
 using yuzu::server::html_escape;
+
+// Coarse cardinality tier for the yuzu_result_set_resolve_seconds histogram
+// label (design docs/scope-walking-design.md §9). Bounded to six values so the
+// label never explodes Prometheus series cardinality.
+static const char* cardinality_bucket(std::size_t n) {
+    if (n <= 1)
+        return "1";
+    if (n <= 10)
+        return "10";
+    if (n <= 100)
+        return "100";
+    if (n <= 1000)
+        return "1k";
+    if (n <= 10000)
+        return "10k";
+    return "100k+";
+}
 
 // -- AgentRegistry ------------------------------------------------------------
 
@@ -1136,7 +1154,19 @@ AgentRegistry::evaluate_scope(const yuzu::scope::Expression& expr, const TagStor
         for (const auto& rsid : refs) {
             if (rs_members.contains(rsid))
                 continue;
+            const auto resolve_t0 = std::chrono::steady_clock::now();
             auto mem = rs_store->member_set_owned(rsid, owner);
+            // Resolve latency by cardinality tier (design §9, 15.G). The
+            // owner-checked member fetch is the real "resolve a result set to its
+            // device set" cost; the cheap alias->id lookup upstream is not timed.
+            const double resolve_s =
+                std::chrono::duration<double>(std::chrono::steady_clock::now() - resolve_t0)
+                    .count();
+            metrics_
+                .histogram("yuzu_result_set_resolve_seconds",
+                           {{"cardinality_bucket", cardinality_bucket(mem.size())}},
+                           yuzu::Histogram::default_buckets())
+                .observe(resolve_s);
             // Touch only sets we actually own (non-empty owned membership): keeps
             // a set actively used as scope from being GC'd mid-investigation
             // (review finding I), and never extends another operator's set TTL.

--- a/server/core/src/rest_api_v1.cpp
+++ b/server/core/src/rest_api_v1.cpp
@@ -4232,7 +4232,7 @@ void RestApiV1::register_routes(
         // dispatch and land a new pending row; sync sources are deferred to
         // PR-G (their re-eval needs the inventory evaluator on this path).
         sink.Post(R"(/api/v1/result-sets/(rs_[0-9a-f]+)/re-eval)",
-                  [auth_fn, rs_err, load_owned, run_async, instruction_store](
+                  [auth_fn, audit_fn, rs_err, load_owned, run_async, instruction_store](
                       const httplib::Request& req, httplib::Response& res) {
                       auto session = auth_fn(req, res);
                       if (!session)
@@ -4287,6 +4287,21 @@ void RestApiV1::register_routes(
                           rs_err(res, 400,
                                  "RESULT_SET_REEVAL_UNSUPPORTED: re-eval of this source_kind "
                                  "lands in PR-G");
+                      }
+                      // Forensic edge (design §9): run_async already audited the
+                      // sibling's result_set.create; this row links the sibling back
+                      // to the original so a lineage walk shows the refresh.
+                      // device_count_delta is not yet known — the sibling lands
+                      // `pending` and materialises asynchronously.
+                      if (res.status == 202) {
+                          auto rebody = nlohmann::json::parse(res.body, nullptr, false);
+                          const std::string new_id =
+                              (rebody.is_object() && rebody.contains("data") &&
+                               rebody["data"].is_object())
+                                  ? rebody["data"].value("id", "")
+                                  : "";
+                          audit_fn(req, "result_set.live_reeval", "success", "ResultSet", orig->id,
+                                   "new_id=" + new_id + " source_kind=" + orig->source_kind);
                       }
                   });
 

--- a/server/core/src/result_set_maintenance.cpp
+++ b/server/core/src/result_set_maintenance.cpp
@@ -1,0 +1,38 @@
+#include "result_set_maintenance.hpp"
+
+#include <chrono>
+#include <string>
+
+#include <yuzu/metrics.hpp>
+
+#include "audit_store.hpp"
+#include "result_set_store.hpp"
+
+namespace yuzu::server {
+
+int run_result_set_gc(ResultSetStore& store, AuditStore* audit, yuzu::MetricsRegistry& metrics) {
+    const int swept = store.gc_sweep();
+    if (swept <= 0)
+        return swept;
+
+    metrics.counter("yuzu_result_set_gc_total").increment(static_cast<double>(swept));
+
+    // Aggregate forensic row for the sweep (design §9). System-initiated, so no
+    // session/ip/user-agent; the count carries the outcome. Best-effort: a failed
+    // audit write must not wedge the maintenance thread.
+    if (audit) {
+        AuditEvent ev;
+        ev.timestamp = std::chrono::duration_cast<std::chrono::seconds>(
+                           std::chrono::system_clock::now().time_since_epoch())
+                           .count();
+        ev.principal = "__system__";
+        ev.action = "result_set.gc_sweep";
+        ev.target_type = "ResultSet";
+        ev.detail = "count=" + std::to_string(swept);
+        ev.result = "success";
+        (void)audit->log(ev);
+    }
+    return swept;
+}
+
+} // namespace yuzu::server

--- a/server/core/src/result_set_maintenance.hpp
+++ b/server/core/src/result_set_maintenance.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+/// @file result_set_maintenance.hpp
+/// Background maintenance for scope-walking result sets (Phase 15.G).
+///
+/// HTTP-agnostic so the server's result-set maintenance thread and unit tests
+/// share one code path (cf. preflight `persist_and_maybe_complete`, deployment
+/// `advance`).
+
+namespace yuzu {
+class MetricsRegistry;
+}
+
+namespace yuzu::server {
+
+class ResultSetStore;
+class AuditStore;
+
+/// Run one GC-sweep tick: delete expired unpinned result sets (pinned sets are
+/// never swept), then — only when at least one was removed — increment
+/// `yuzu_result_set_gc_total` by the count and write a single aggregate
+/// `result_set.gc_sweep` audit row under the `__system__` principal (design
+/// docs/scope-walking-design.md §9). Returns the number of sets removed.
+///
+/// `audit` may be null (audit-off, or the audit DB failed to open) — the sweep
+/// and the metric still run; only the audit row is skipped.
+int run_result_set_gc(ResultSetStore& store, AuditStore* audit, yuzu::MetricsRegistry& metrics);
+
+} // namespace yuzu::server

--- a/server/core/src/server.cpp
+++ b/server/core/src/server.cpp
@@ -60,6 +60,7 @@
 #include "nvd_sync.hpp"
 #include "oidc_provider.hpp"
 #include "quarantine_store.hpp"
+#include "result_set_maintenance.hpp"
 #include "result_set_matcher.hpp"
 #include "result_set_store.hpp"
 #include "result_sets_ui.hpp"
@@ -325,6 +326,24 @@ public:
         // hot per-acquire observe path uses the cheap name-only lookup and never
         // allocates a throwaway bucket vector per acquire.
         metrics_.histogram("yuzu_pg_acquire_wait_seconds", yuzu::Histogram::seconds_buckets_60s());
+        // Scope-walking result-set observability (Phase 15.G).
+        metrics_.describe("yuzu_result_sets_total",
+                          "Result sets created, by source_kind and result "
+                          "(materialized/pending/materialize_failed)",
+                          "counter");
+        metrics_.describe("yuzu_result_sets_alive",
+                          "Live result sets currently held, by pinned state", "gauge");
+        metrics_.describe("yuzu_result_set_gc_total",
+                          "Expired unpinned result sets removed by the background GC sweep",
+                          "counter");
+        metrics_.describe("yuzu_result_set_quota_rejected",
+                          "Result-set create/pin requests rejected for exceeding a per-operator "
+                          "quota (RESULT_SET_QUOTA / PIN_LIMIT)",
+                          "counter");
+        metrics_.describe("yuzu_result_set_resolve_seconds",
+                          "Latency to resolve a from_result_set: scope to its owner-checked device "
+                          "set, by cardinality tier",
+                          "histogram");
         // Installed-software inventory observability (ADR-0016; #1664/#1675).
         metrics_.describe("yuzu_inventory_ingest_total",
                           "Inventory-report ingest outcomes by source and outcome "
@@ -8509,14 +8528,15 @@ private:
                             }
                         }
 
-                        // 2) GC sweep on the slow cadence.
+                        // 2) GC sweep on the slow cadence (Phase 15.G): remove expired
+                        //    unpinned sets, bump yuzu_result_set_gc_total, and write the
+                        //    aggregate result_set.gc_sweep audit row (shared helper so a
+                        //    unit test drives the same path).
                         if (++tick % kGcEveryNTicks == 0) {
-                            int swept = result_set_store_->gc_sweep();
-                            if (swept > 0) {
-                                metrics_.counter("yuzu_result_set_gc_total")
-                                    .increment(static_cast<double>(swept));
+                            int swept =
+                                run_result_set_gc(*result_set_store_, audit_store_.get(), metrics_);
+                            if (swept > 0)
                                 spdlog::info("result-set GC swept {} expired set(s)", swept);
-                            }
                         }
 
                         // 3) Refresh alive gauges.

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -285,6 +285,7 @@ if build_server
       'unit/server/test_quarantine_store.cpp',
       'unit/server/test_result_set_store.cpp',
       'unit/server/test_result_set_matcher.cpp',
+      'unit/server/test_result_set_maintenance.cpp',
       'unit/server/test_rest_result_sets_async.cpp',
       'unit/server/test_chrome_ir_chain.cpp',
       'unit/server/test_result_sets_ui.cpp',

--- a/tests/unit/server/test_rest_result_sets_async.cpp
+++ b/tests/unit/server/test_rest_result_sets_async.cpp
@@ -47,6 +47,10 @@ struct DispatchCall {
     std::string execution_id;
 };
 
+struct AuditRow {
+    std::string action, result, target_id, detail;
+};
+
 struct SqliteHandleGuard {
     sqlite3* db{nullptr};
     ~SqliteHandleGuard() {
@@ -68,6 +72,7 @@ struct AsyncHarness {
 
     // Fake-dispatch knobs / recording.
     std::vector<DispatchCall> calls;
+    std::vector<AuditRow> audit_log;
     int dispatch_sent{2};   // agents "reached" by each dispatch
     bool dispatch_throws{false};
     bool wire_dispatch{true}; // false → leave the callback empty (503 path)
@@ -92,8 +97,10 @@ struct AsyncHarness {
         };
         auto perm_fn = [](const httplib::Request&, httplib::Response&, const std::string&,
                           const std::string&) -> bool { return true; };
-        auto audit_fn = [](const httplib::Request&, const std::string&, const std::string&,
-                           const std::string&, const std::string&, const std::string&) -> bool {
+        auto audit_fn = [this](const httplib::Request&, const std::string& action,
+                               const std::string& result, const std::string&,
+                               const std::string& target_id, const std::string& detail) -> bool {
+            audit_log.push_back({action, result, target_id, detail});
             return true;
         };
 
@@ -333,6 +340,15 @@ TEST_CASE("re-eval: tar_query set re-dispatches as a sibling (shares parent)",
     auto row = h.store->get(new_id);
     REQUIRE(row->parent_id.has_value());
     REQUIRE(*row->parent_id == grandparent);
+
+    // Audit polish (Phase 15.G): a result_set.live_reeval row links the sibling
+    // back to the original (target_id = original, detail carries new_id).
+    bool linked = false;
+    for (const auto& a : h.audit_log)
+        if (a.action == "result_set.live_reeval" && a.target_id == orig_id &&
+            a.detail.find("new_id=" + new_id) != std::string::npos)
+            linked = true;
+    CHECK(linked);
 }
 
 TEST_CASE("re-eval: unsupported source_kind is 400", "[result_set][async][reeval]") {

--- a/tests/unit/server/test_result_set_maintenance.cpp
+++ b/tests/unit/server/test_result_set_maintenance.cpp
@@ -1,0 +1,126 @@
+/**
+ * test_result_set_maintenance.cpp — the result-set GC-sweep tick (Phase 15.G).
+ *
+ * run_result_set_gc() must: remove expired unpinned result sets (pinned sets
+ * survive even past TTL), increment yuzu_result_set_gc_total by the count, and —
+ * only when at least one set was swept — write a single aggregate
+ * result_set.gc_sweep audit row under the __system__ principal. A null
+ * AuditStore (audit-off) is tolerated.
+ */
+
+#include "result_set_maintenance.hpp"
+
+#include "audit_store.hpp"
+#include "result_set_store.hpp"
+
+#include <yuzu/metrics.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <sqlite3.h>
+
+#include <string>
+
+#include "../test_helpers.hpp"
+
+using namespace yuzu::server;
+using yuzu::test::TempDbFile;
+
+namespace {
+
+CreateRequest req(const std::string& owner, const std::string& name = "") {
+    CreateRequest r;
+    r.owner_principal = owner;
+    r.name = name;
+    r.source_kind = std::string(source_kind::kManualCurate);
+    r.source_payload = "{}";
+    return r;
+}
+
+// Backdate a set's TTL on a second connection so gc_sweep() sees it as expired —
+// the public API deliberately cannot produce a past TTL (mirrors the technique
+// in test_result_set_store.cpp). created_at must stay <= ttl_at (schema CHECK),
+// so age the row wholesale.
+void expire(const std::filesystem::path& path, const std::string& id) {
+    sqlite3* db = nullptr;
+    REQUIRE(sqlite3_open(path.string().c_str(), &db) == SQLITE_OK);
+    const std::string sql =
+        "UPDATE result_sets SET created_at = 1, ttl_at = 2 WHERE id = '" + id + "';";
+    const int rc = sqlite3_exec(db, sql.c_str(), nullptr, nullptr, nullptr);
+    sqlite3_close(db);
+    REQUIRE(rc == SQLITE_OK);
+}
+
+} // namespace
+
+TEST_CASE("run_result_set_gc: sweeps expired unpinned, keeps pinned, audits + counts",
+          "[result_set][gc][maintenance]") {
+    TempDbFile rs_db{std::string_view{"rsmaint-rs-"}};
+    TempDbFile audit_db{std::string_view{"rsmaint-audit-"}};
+    ResultSetStore store(rs_db.path);
+    REQUIRE(store.is_open());
+    AuditStore audit(audit_db.path, /*retention_days=*/365, /*cleanup_interval_min=*/0);
+    REQUIRE(audit.is_open());
+    yuzu::MetricsRegistry metrics;
+
+    auto doomed = store.create_materialized(req("alice", "doomed"), {"a"});
+    auto kept = store.create_materialized(req("alice", "kept"), {"b"});
+    REQUIRE(doomed.has_value());
+    REQUIRE(kept.has_value());
+    REQUIRE(store.pin(kept->id).has_value());
+    expire(rs_db.path, doomed->id);
+    expire(rs_db.path, kept->id); // even past TTL, a pinned set must survive
+
+    const int swept = run_result_set_gc(store, &audit, metrics);
+
+    CHECK(swept == 1);
+    CHECK_FALSE(store.get(doomed->id).has_value()); // swept
+    CHECK(store.get(kept->id).has_value());         // pinned → survived
+    CHECK(metrics.counter("yuzu_result_set_gc_total").value() == 1.0);
+
+    AuditQuery q;
+    q.action = "result_set.gc_sweep";
+    auto rows = audit.query(q);
+    REQUIRE(rows.size() == 1);
+    CHECK(rows[0].principal == "__system__");
+    CHECK(rows[0].result == "success");
+    CHECK(rows[0].target_type == "ResultSet");
+    CHECK(rows[0].detail == "count=1");
+}
+
+TEST_CASE("run_result_set_gc: nothing expired → no metric bump, no audit row",
+          "[result_set][gc][maintenance]") {
+    TempDbFile rs_db{std::string_view{"rsmaint-noop-rs-"}};
+    TempDbFile audit_db{std::string_view{"rsmaint-noop-audit-"}};
+    ResultSetStore store(rs_db.path);
+    REQUIRE(store.is_open());
+    AuditStore audit(audit_db.path, 365, 0);
+    REQUIRE(audit.is_open());
+    yuzu::MetricsRegistry metrics;
+
+    auto fresh = store.create_materialized(req("alice", "fresh"), {"a"});
+    REQUIRE(fresh.has_value()); // ttl_at = now + 1h, not expired
+
+    CHECK(run_result_set_gc(store, &audit, metrics) == 0);
+    CHECK(store.get(fresh->id).has_value());
+    CHECK(metrics.counter("yuzu_result_set_gc_total").value() == 0.0);
+    AuditQuery q;
+    q.action = "result_set.gc_sweep";
+    CHECK(audit.query(q).empty());
+}
+
+TEST_CASE("run_result_set_gc: null AuditStore still sweeps + counts (audit-off)",
+          "[result_set][gc][maintenance]") {
+    TempDbFile rs_db{std::string_view{"rsmaint-null-rs-"}};
+    ResultSetStore store(rs_db.path);
+    REQUIRE(store.is_open());
+    yuzu::MetricsRegistry metrics;
+
+    auto doomed = store.create_materialized(req("alice", "doomed"), {"a"});
+    REQUIRE(doomed.has_value());
+    expire(rs_db.path, doomed->id);
+
+    CHECK(run_result_set_gc(store, /*audit=*/nullptr, metrics) == 1);
+    CHECK_FALSE(store.get(doomed->id).has_value());
+    CHECK(metrics.counter("yuzu_result_set_gc_total").value() == 1.0);
+}

--- a/tests/unit/server/test_scope_walking_authz.cpp
+++ b/tests/unit/server/test_scope_walking_authz.cpp
@@ -99,6 +99,43 @@ TEST_CASE("evaluate_scope: from_result_set is owner-scoped (no cross-operator ta
     }
 }
 
+// ── Resolve-latency histogram (Phase 15.G) ───────────────────────────────────
+
+TEST_CASE("evaluate_scope: records yuzu_result_set_resolve_seconds by cardinality tier",
+          "[scope][result_set][metrics]") {
+    yuzu::test::TempDbFile rs_db{std::string_view{"scope-hist-rs-"}};
+    ResultSetStore store(rs_db.path);
+    REQUIRE(store.is_open());
+
+    EventBus bus;
+    yuzu::MetricsRegistry metrics;
+    AgentRegistry registry(bus, metrics);
+    registry.register_agent(info("agent-win"));
+
+    CreateRequest cr;
+    cr.owner_principal = "alice";
+    cr.name = "alice-suspects";
+    cr.source_kind = std::string(source_kind::kManualCurate);
+    cr.source_payload = "{}";
+    auto set = store.create_materialized(cr, {"agent-win"}); // cardinality 1 → bucket "1"
+    REQUIRE(set.has_value());
+
+    auto expr = yuzu::scope::parse("from_result_set:" + set->id);
+    REQUIRE(expr.has_value());
+
+    // Nothing observed into the "1" cardinality bucket before the resolve.
+    CHECK(metrics.histogram("yuzu_result_set_resolve_seconds", {{"cardinality_bucket", "1"}})
+              .snapshot()
+              .count == 0);
+
+    registry.evaluate_scope(*expr, nullptr, nullptr, &store, "alice");
+
+    // The owner-checked member resolve was timed into the "1" bucket exactly once.
+    CHECK(metrics.histogram("yuzu_result_set_resolve_seconds", {{"cardinality_bucket", "1"}})
+              .snapshot()
+              .count == 1);
+}
+
 // ── Dispatch-time alias resolution (PR-E) ────────────────────────────────────
 
 TEST_CASE("resolve_scope_aliases: rewrites owner aliases, leaves ids/non-owners",


### PR DESCRIPTION
Completes roadmap **15.G** (result-set operational hardening). Closes #1770.

> **Stacked on #1773** (15.F). Base is `feat/tar-15f-chrome-ir-e2e` so the diff shows **only** the 15.G changes; GitHub will retarget this PR to `dev` when #1773 merges. Merge #1773 first.

## Changes
- **`yuzu_result_set_resolve_seconds` histogram** — `AgentRegistry::evaluate_scope` times the owner-checked `member_set_owned` resolve and observes it bucketed by cardinality tier (`1/10/100/1k/10k/100k+`). Added `describe()` HELP/TYPE for it **and** the four pre-existing result-set metrics.
- **`result_set.live_reeval` audit** — the re-eval handler emits a row linking the sibling back to the original (`target_id`=original, `detail=new_id=… source_kind=…`). `device_count_delta` is omitted (the sibling lands `pending` — async).
- **`result_set.gc_sweep` audit** — extracted `run_result_set_gc()` (new `result_set_maintenance.{hpp,cpp}`): `gc_sweep` + `yuzu_result_set_gc_total` + an aggregate `__system__` audit row. The maintenance thread calls it; a unit test drives the same path.

## Tests
- New `test_result_set_maintenance.cpp` (sweep / pinned-survives-expiry / nothing-expired no-op / audit-off).
- Histogram case in `test_scope_walking_authz.cpp`; `result_set.live_reeval` assertion + audit capture in `test_rest_result_sets_async.cpp`.
- **Full server suite green** (`meson test --suite server` → Ok: 1, Fail: 0).

## Docs
15.G marked **Shipped** (roadmap, capability-map §30.4 + rollup/header, `scope-walking-design.md` §9/§11 PR-G); `result_set.*` audit verbs added to `user-manual/audit-log.md`; CHANGELOG `[Unreleased]`.

## Governance
cpp-safety + security **and** quality + consistency + docs reviews: **clean** (no CRITICAL/HIGH/MEDIUM/BLOCKING). Verified: const/reference-member observe well-formed; GC-thread `audit_store_` deref is join-safe (thread joined in `stop()` before store destruction); audit detail non-injectable (server-minted `new_id`, fixed `source_kind`, parameterized binds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)