### PR TITLE
docs(vuln-scan): add ADR-0018/0019 and reconcile roadmap/capability-map

### DIFF
--- a/docs/adr/0018-server-authoritative-vulnerability-matching.md
+++ b/docs/adr/0018-server-authoritative-vulnerability-matching.md
@@ -1,0 +1,160 @@
+---
+status: proposed
+date: 2026-07-01
+owner: "@lesault (Andy Younie)"
+depends-on: 0005 (two-matcher split, first stated there); 0016 (agent daily-sync framework — the inventory transport)
+related: 0019 (tri-state findings / coverage dimension); docs/vuln-scan-engine-design.md §2/§4.4; docs/vuln-scan-roadmap.md M1a; memory vuln-scan-agent-emits-purl
+amended: 2026-07-01 (grill-with-docs session) — wire format is structured identity, not PURL (D1); two-comparator OVAL-primary routing made explicit (D2); distro-release stored + dual-trigger (D3)
+---
+
+# 0018 — Server-authoritative vulnerability matching (agent stays thin; no exceptions)
+
+> Formalises, as a standalone cross-cutting decision, what ADR-0005's "Two-matcher split" and
+> the design doc §4.4 asserted in passing: **where CVE matching happens.** Recorded because it
+> is the load-bearing architectural choice for the whole vuln_scan / CAVM workstream and every
+> successor PR inherits it.
+
+## Context
+
+vuln_scan must decide, for each installed package on each endpoint, whether it is affected by
+known vulnerabilities. That match can run **on the agent** (each endpoint matches itself against
+rules it holds) or **on the server** (endpoints report inventory; the server correlates against
+NVD/OVAL/EPSS). The current mainline does the former badly — ~40 hard-coded rules in
+`cve_rules.hpp`, substring identity, a naive comparator.
+
+The #1206 spike attempted a more capable *agent-side* design (runtime-delivered JSON rules for
+freshness). Its blocking review findings are, in retrospect, the agent-side model's inherent
+costs manifesting as bugs: no integrity check on the runtime ruleset (a trust boundary on every
+endpoint), a `g_dynamic_rules` data race (matching state on the endpoint), throw-unsafe parsing
+(endpoint trust boundary), and ruleset staleness/drift across the fleet. These do not have clean
+agent-side fixes — they are structural.
+
+## Decision
+
+**Vulnerability matching is server-authoritative.** The server holds the vulnerability data
+(NVD mirror reshaped to real `cpeMatch` ranges, OVAL/distro advisories, EPSS/KEV, the CPE
+dictionary + pgvector fuzzy identity) and is the **only** source of low-false-positive findings.
+
+- **The agent collects, never decides.** It emits a **structured typed identity `oneof`** —
+  `PackageIdentity{ ecosystem, name, epoch, version, release, arch }` for package-managed software
+  (deb/rpm/apk + language ecosystems) and `AppIdentity{ display_name, publisher, version }`
+  (Windows) / `{ bundle_id, version }` (macOS) for the GUI tail — plus kernel/OS-build/binary
+  versions **and the host's distro-release** (see D-below). It does **not** ship a ruleset, load
+  runtime rules, or run CVE matching. The ~40 hard-coded `cve_rules.hpp` rules and the #1206
+  runtime-rule pipeline are **retired**.
+  - **PURL is NOT the wire format** — it is a **server-derived projection** computed only when
+    interop needs it (SBOM/CycloneDX export, OSV.dev queries). Rationale: once matching is
+    server-authoritative and the matcher is ours, the agent→server format is a *private contract*,
+    not an interop boundary, so a standardized string envelope earns nothing and costs a re-parse;
+    every matching decision needs the *decomposed* fields anyway, and PURL's epoch/`:` encoding is
+    a known footgun that `epoch`-as-its-own-field avoids. Corrects the earlier "agent emits PURL"
+    direction (see the corrected memory note `vuln-scan-agent-emits-purl`).
+- **No exceptions — the KEV-only agent pre-filter is removed.** An earlier draft carved out one
+  exception: the agent self-flagging `(has-KEV ∧ exposes-service)` from the CISA KEV catalog as a
+  "graph-pruning / local-tripwire hint, never a finding." It is **struck** (2026-07-01). As a
+  matching optimisation it is redundant — the server holds the full inventory + KEV and
+  re-correlates the fleet in seconds (see Consequences: retroactive detection) — and it re-imports
+  exactly the collect-thin costs this ADR exists to avoid (KEV catalog on every endpoint;
+  staleness/drift; a decision at the endpoint trust boundary). The agent **never decides, full
+  stop.** The one substantive rationale — a *real-time local tripwire* — is a **latency** capability,
+  not vulnerability matching; if pursued it belongs to **DEX** (the ruleless real-time on-agent
+  signal-observation subsystem) as its own observation type with DEX's rate-limit/routing/privacy
+  contract, **not** in the vuln_scan collect-thin path. That is a separate, deferred decision for
+  the DEX owner — out of scope for vuln_scan v1.
+- **Matching quality lives server-side, as three lanes routed by the identity arm.** There is no
+  single matcher; the `ecosystem` discriminator on `PackageIdentity` (and the `oneof` arm) is the
+  router:
+  - **Lane 1 — distro package-managed (deb/rpm/apk) → OVAL-primary, NVD-fallback.** Match the *full
+    EVR* (epoch:version-release) against the host's distro-release OVAL / advisory stream (USN/RHSA/
+    Alpine secdb), using distro-native version rules (`dpkg` `~`-ordering / `rpmvercmp` / semver).
+    OVAL is **authoritative** here because it is **backport-correct** — it encodes the *release*
+    field (`1.1.1f-1ubuntu2.16`) that NVD's upstream-only CPE view structurally cannot represent,
+    so NVD-on-upstream is the dominant false-positive source and must not be primary for distro
+    packages.
+  - **Lane 2 — language ecosystems (pypi/npm/gem/cargo/…) → OSV.dev by PURL.** These are
+    package-managed with clean PURLs, so match is **deterministic and ecosystem-native — no CPE
+    guessing.** Pulling this lane *out* of the fuzzy path shrinks the fuzzy surface to Lane 3 only.
+  - **Lane 3 — OS-native GUI apps (Windows/macOS `AppIdentity`) → NOT-ASSESSED in v1; federate
+    later.** Yuzu will **not author curated detection content** — that is a standing research-team
+    cost (Tenable NASL / Qualys QID model) the project cannot commit to. So Lane 3 is *identified
+    but not assessed*: the agent collects `AppIdentity` (so the operator sees the software and it
+    counts in coverage), and every OS-native GUI app is reported **`not-assessed`** under reason
+    `os-native-assessment-not-yet-supported` (ADR-0019). **v1 does zero guessing on this lane — no
+    fuzzy-CPE, no curated signatures — hence zero false-positive risk.**
+    - **Deferred (a later update): federate, don't author.** Convert Lane 3 `not-assessed` →
+      `assessed` by *ingesting an external assessment source*, priority ladder: (1) the customer's
+      existing endpoint scanner (Microsoft Defender Vulnerability Management primary; Tenable /
+      Qualys connectors) where present — best coverage, data they already trust, and it already did
+      the software identification; (2) a self-hosted OSS *authored-content* feed (Greenbone/OpenVAS
+      NVT, Wazuh) for customers running no scanner; (3) dictionary+pgvector CPE fuzzy match (roadmap
+      R1) as the residual, with any low-confidence / ambiguous mapping routing to `not-assessed`,
+      **never** a guessed finding. Detect off the ingested/authored fixed-version, **not raw
+      NVD-CPE** (NVD's CPE applicability data is known-unreliable for this class). `AppIdentity`
+      carries the authoritative on-disk binary version (Windows version resource
+      `FileVersion`/`ProductVersion`, not registry `DisplayVersion`) so this future path has a
+      precise version to match. Federation gets its own ADR when it is built (deferred ADR-0020).
+- **Distro-release is a stored field on the identity snapshot, refreshed every collection/sync
+  (ADR-0016), driving two triggers.** (D) The agent supplies distro-release with the collected
+  inventory — not only at interactive-scan time — so both matching triggers are correct: a **live
+  scan** uses the just-collected value (catches a dist-upgrade since last inventory), and a
+  **feed-triggered server-side re-evaluation** (a new CVE/OVAL row lands → "who is now affected?"
+  fleet-wide, no agent interaction) uses the last-synced value. Same field, two consumers. The
+  agent never carries the CPE dictionary or per-distro OVAL feeds.
+- **Finding status is tri-state; coverage is a dimension separate from vulnerability — see
+  ADR-0019.** A package the feeds do not cover is reported **not-assessed**, never silently as
+  clean.
+
+## Consequences
+
+**Gained (why this is right for a fleet product):**
+- **Retroactive detection** — a new CVE/KEV re-correlates *already-collected* inventory →
+  fleet-wide "who is affected?" in seconds, with zero endpoint interaction. (The single
+  strongest argument; impossible under agent-side matching without re-scanning every host.)
+- **Freshness without agent redeploy** — update NVD/OVAL/EPSS once, whole fleet benefits.
+- **Consistency & audit** — one engine, one data version, one audit point (SOC 2). No per-agent
+  ruleset drift.
+- **Smaller distributed attack surface** — the matching/parsing trust boundary is one server,
+  not N endpoints; agents stay dumb. Deletes (does not merely fix) #1206's integrity/race/
+  throw-safety findings — they are artefacts of the agent-side model and evaporate here.
+- **Iteration velocity** — change matching logic and test against stored inventory without
+  shipping an agent release.
+
+**Costs accepted (the honest trade):**
+1. **Centralized inventory** — every endpoint's software list is stored server-side (Postgres);
+   a compliance/privacy surface (installed software is behaviour-revealing; works-council/
+   air-gap contexts). Mitigated by existing access-audit + RBAC on the `Inventory` securable.
+2. **No offline assessment** — a long-disconnected host is not evaluated until it reports in.
+   Softened because such a host cannot be *managed* while disconnected anyway.
+3. **Central compute** — correlation at 50k–250k+ endpoints is the server's load to engineer
+   (CPE→CVE indexing, dedup of identical inventories, re-correlate on new-CVE-only). Bounded and
+   cacheable; a deliberate cost, not an oversight.
+
+**Ownership.** Andy owns the matching quality bar (FP/FN acceptance); Eng owns the correlation
+engine's mechanics. "The agent collects, never decides" is a hard invariant with no exceptions —
+any future real-time local tripwire lives in DEX, not vuln_scan.
+
+**Supersedes for vuln_scan** the agent-side-matching direction of #1206: its comparator and
+kernel/binary/CIS detectors are salvaged into the correct layer (comparator → server M1a;
+kernel/binary versions → agent inventory; CIS → a separate agent config-scan track), but its
+runtime-rule pipeline, `generate-cve-rules.py`, and `update-cve-rules.yml` are not carried
+forward. See `docs/vuln-scan-roadmap.md` and the #1206 review disposition.
+
+## Ratification
+
+**Status: proposed.** This ADR is authored by the vuln_scan domain owner but is **cross-cutting**
+— it commits the platform to centralized inventory storage and central correlation load at fleet
+scale, and it redraws the agent↔server boundary. Per the observed ADR convention (platform/
+architecture leads own and accept cross-cutting ADRs; cf. ADR-0006/0007/0008 re-deciding the
+author's spike-grade ADR-0004), it should **not** be self-accepted. It moves to `accepted` only
+after sign-off from:
+
+- **Maintainer** — @Tr3kkR (owns the merge gate and the vuln_scan direction).
+- **Platform lead** — @NathanDornbrook (owns the storage substrate + fleet-scale server load
+  implications; ADR-0006/0007/0008/0012).
+- **Security architecture** — @Alex (the distributed-attack-surface argument; ADR-0015).
+
+Route via the normal review / `/governance` path rather than a status flip. Record the accepting
+reviewer + date here on acceptance.
+
+> Open question for the accepting authority: confirm the actual ADR-acceptance owner on the team
+> — the reviewer list above is inferred from ADR authorship patterns, not a documented RACI.

--- a/docs/adr/0019-tri-state-findings-coverage-dimension.md
+++ b/docs/adr/0019-tri-state-findings-coverage-dimension.md
@@ -1,0 +1,95 @@
+---
+status: proposed
+date: 2026-07-01
+owner: "@lesault (Andy Younie)"
+depends-on: 0018 (server-authoritative matching — the engine that produces these findings); 0005 (two-matcher split)
+related: docs/vuln-scan-engine-design.md §4.4; docs/vuln-scan-roadmap.md M2; docs/vuln-scan-capability-map.md V4
+---
+
+# 0019 — Vulnerability findings are tri-state; coverage is a dimension separate from vulnerability
+
+> Crystallised in the 2026-07-01 grill-with-docs session. Records *what a scan result means* for a
+> package the feeds do not cover — the difference between "we looked and it's clean" and "we never
+> looked." Load-bearing for the floor's honesty bar and for the differentiator's integrity claim.
+
+## Context
+
+The server-authoritative matcher (ADR-0018) routes each installed-software identity to a feed —
+distro packages to OVAL, the Windows/macOS-GUI and language-ecosystem tail to CPE/NVD. For a given
+`(host, package)` the naive model has two outcomes: **matched an advisory → vulnerable**, or **no
+match → clean**.
+
+That two-state model is wrong, because it collapses two genuinely different situations into
+"clean":
+
+- **(a) The package is within a feed's coverage and no advisory matches.** "No known
+  vulnerabilities" is a *true* assertion. Trusting the feed's silence is correct here — feed
+  correctness is about accuracy *within scope*.
+- **(b) No feed covers the package at all** — a side-loaded vendor `.deb`, a language package the
+  feeds don't track, or an EOL distro whose OVAL stream stopped publishing. The feed's silence here
+  does **not** mean "safe"; it means **we never looked.**
+
+"Assume the vuln feed is correct" licenses only (a). It says nothing about packages *outside* the
+feed's scope. Conflating "the feed is authoritative for what it covers" with "the feed covers
+everything" is the classic scanner lie, and in security tooling the resulting failure is a false
+**negative** — the more dangerous direction.
+
+### The failure the two-state model produces
+
+An **EOL Ubuntu 18.04** host. Canonical no longer publishes standard OVAL for it (moved to paid
+ESM). The router sends every `deb` package to the Bionic OVAL stream; the stream has no current
+rows; so **every package "matches no feed"** and the two-state model reports **"no vulnerabilities
+found"** on a host that is a swiss-cheese of unpatched CVEs. That is not a coverage gap — it is
+**false assurance**, which is *worse* than no scan, because a reader sees "clean" and moves on.
+
+## Decision
+
+**A vulnerability finding is tri-state, and coverage is tracked as a dimension separate from
+vulnerability status.**
+
+1. **Per-`(host, package)` status is one of three values:**
+   - **Vulnerable** — matched an advisory in a covering feed.
+   - **Assessed–clean** — within a covering feed's scope, no match. Reported as *"no known
+     vulnerabilities, as of feed-sync timestamp T"* (the absence of a finding has a shelf life, so
+     the assertion is timestamped to the feed version it was evaluated against).
+   - **Not-assessed** — the package is identified but **no feed covers it**. Surfaced explicitly as
+     *unknown / not assessed* — **never** rendered as clean, never silently dropped.
+
+2. **Coverage is a first-class, separate dimension.** Each host scan carries a **coverage metric**:
+   *assessed N of M installed packages; (M−N) not-assessed.* Coverage answers "how much of this box
+   did we actually evaluate," which is orthogonal to "how many vulnerabilities did we find." The two
+   dimensions are reported side by side and neither is inferable from the other.
+
+## Consequences
+
+**Gained:**
+- **Honest reporting.** The EOL-18.04 host reports "0 vulnerabilities, but only 12 of 430 packages
+  assessed" instead of a false all-clear. The gap becomes a *visible, actionable number* — operators
+  can act on low coverage (upgrade the distro, buy ESM, add a feed) instead of being lied to.
+- **Differentiator integrity.** The CAVM attack-path scoring (ADR-0018's differentiator, roadmap
+  M5) cannot credibly rank a host's risk if some installed packages are dark and unaccounted-for.
+  A per-host coverage number is the precondition for claiming scoring completeness.
+- **False-negative containment.** The most dangerous failure mode in a scanner — silently missing
+  real vulnerabilities — is surfaced as low coverage rather than hidden behind a clean verdict.
+
+**Costs accepted:**
+1. **More data model + UI surface.** Findings carry a status enum (not a boolean) and each host
+   carries coverage counters; the dashboard/REST must present coverage as a first-class figure, not
+   a footnote. Deliberate — the honesty is the point.
+2. **"Not-assessed" can look like noise on messy fleets.** A fleet full of side-loaded software
+   will show large not-assessed counts. This is truthful signal, not noise, but it needs good
+   defaults (group/aggregate not-assessed by reason: no-OVAL-stream vs no-CPE-mapping vs
+   side-loaded) so operators can triage rather than drown.
+3. **Feed-freshness must be carried.** "Assessed–clean as of T" requires threading the feed-sync
+   timestamp through to the finding, so a stale feed produces a *stale-clean* signal, not a
+   confidently-clean one.
+
+**Ownership.** Andy owns the finding-status taxonomy and the coverage-metric definition; Eng owns
+carrying the feed-version timestamp and computing coverage counters at correlation time.
+
+## Ratification
+
+**Status: proposed.** Authored by the vuln_scan domain owner. Less cross-cutting than ADR-0018
+(it does not redraw the agent↔server boundary), but it commits the finding data model and the
+reporting surface, so route it through the normal review / `/governance` path together with
+ADR-0018 rather than self-accepting. Record the accepting reviewer + date here on acceptance.

--- a/docs/vuln-scan-capability-map.md
+++ b/docs/vuln-scan-capability-map.md
@@ -1,0 +1,333 @@
+# Vuln-Scan Capability Map (standalone — to be merged)
+
+**Status of this document:** standalone working map for the vuln_scan / CAVM workstream.
+It is deliberately separate so the vuln_scan team can iterate without churning the
+fleet-wide `docs/capability-map.md`. **Merge target:** expand `§9.4 Vulnerability
+Scanning` and add a new top-level domain (provisionally **§32 — Vulnerability &
+Attack-Path Management (CAVM)**). See **Merge guidance** at the bottom.
+
+Sources of truth this map is reconciled against (2026-06-30; **last reconciled 2026-07-01**
+against ADR-0018/ADR-0019 below):
+- Plugin: `agents/plugins/vuln_scan/src/`, contract `content/definitions/vuln_scan.yaml`
+- North-star design: `docs/vuln-scan-engine-design.md` (floor = Phases 1–5, differentiator = Phases 6–8)
+- Theory: `CAVM_WhitePaper_v16` (EUC, composite score, AMAPC, choke points, crown jewels, gate model)
+- Topology: `server/core/src/fleet_topology_store.{hpp,cpp}`, `fleet_topology_types.hpp`
+- NVD infra: `nvd_client` + `nvd_db` (`NvdDatabase`) + `nvd_sync` (`NvdSyncManager`) — **wired** in `server.cpp:982-987`; feeds the fleet-topology vuln overlay (`match_inventory`). Keyword-scoped, agent plugin not joined to it.
+- Epic/issue breakdown: this workstream's sequenced plan (Epics 1–7)
+- ADR: `docs/adr/0018-server-authoritative-vulnerability-matching.md` — matching location, wire
+  format (typed identity, not PURL), Lane 1/2/3 routing
+- ADR: `docs/adr/0019-tri-state-findings-coverage-dimension.md` — finding status model + coverage dimension
+
+---
+
+## Legend
+
+**Status:** :white_check_mark: Done · :large_orange_diamond: Partial · :x: Not started
+
+**Delivery tier** (mirrors the parent map's `T1/T2/T3`, and maps to the design-doc split):
+- `T1` — **Floor / parity** (Phases 1–5): a correct, trustworthy scanner. Table stakes.
+- `T2` — **Join & asset model** (Phases 5–6): make "vulnerable **and** reachable" expressible.
+- `T3` — **Differentiator** (Phases 6–8): CAVM attack-path scoring and operational integration.
+
+---
+
+## Progress at a glance
+
+| Domain | Done | Partial | Not started |
+|---|---:|---:|---:|
+| V1 Inventory & collection (collect-thin) | 2 | 1 | 0 |
+| V2 CVE correlation & enrichment (correlate-rich) | 0 | 4 | 5 |
+| V3 Configuration & compliance scanning | 0 | 1 | 1 |
+| V4 Findings, output & reporting | 2 | 1 | 2 |
+| V5 Topology integration (vuln↔graph) | 1 | 1 | 2 |
+| V6 Asset model (crown jewels) | 0 | 0 | 2 |
+| V7 Attack-path analytics (CAVM core) | 0 | 1 | 6 |
+| V8 Operational integration | 0 | 0 | 3 |
+| **Total** | **5** | **9** | **21** |
+
+> The floor (collection + topology graph) is the strongest area; the differentiator
+> (V6/V7/V8) is almost entirely greenfield. This matches the gap analysis: Yuzu has
+> already solved the expensive *collection* problems and has almost none of the *scoring*.
+
+---
+
+## V1 — Inventory & Collection (collect-thin)
+*The agent ships thin, structured endpoint state; correlation happens server-side.*
+
+### V1.1 Installed-software / package inventory :white_check_mark: `T1`
+`vuln_scan` `inventory` action emits `name|version` rows; reuses the daily-sync
+`installed_software` source (ADR-0016). Cross-platform.
+
+### V1.2 Process / listener / connection snapshot :white_check_mark: `T1`
+`tar` plugin `fleet_snapshot.v1` (`agents/plugins/tar/src/tar_fleet_snapshot.cpp`) —
+processes, listeners, 4-tuple connections with owning PID. Feeds V5.
+
+### V1.3 Per-OS package identity (typed identity emit) :large_orange_diamond: `T1`
+Collection exists, but the agent emits only `name|version` and drops the fields correct
+matching needs (source/ecosystem, arch, full EVR). **Decided (2026-06-30, corrected 2026-07-01
+by ADR-0018 D1):** the agent emits a **structured typed identity `oneof`** — `PackageIdentity`
+(ecosystem, name, epoch, version, release, arch — lossless, decomposed, no PURL string) for
+package-managed software, and `AppIdentity` (`DisplayName`/`Publisher`/`FileVersion` on Windows,
+`CFBundleIdentifier`/version on macOS) for the GUI tail. **PURL is NOT the wire format** — it is
+a server-derived projection computed only when interop needs it (SBOM/CycloneDX export, OSV.dev
+queries for Lane 2 below). **CPE is also server-derived, never emitted by the agent** (lossy —
+cannot carry epoch/release — and dictionary-dependent). See memory `vuln-scan-agent-emits-purl`,
+ADR-0018, and `docs/vuln-scan-roadmap.md` M1a.
+> **Gap:** build the typed-identity collector per-OS (dpkg/rpm/apk + `/etc/os-release` namespace
+> + arch + EVR → `PackageIdentity`; Windows/macOS raw fields → `AppIdentity`); unify the
+> duplicate collector (vuln_scan vs `installed_apps`); add kernel + OS build rows. *(roadmap M1a)*
+
+---
+
+## V2 — CVE Correlation & Enrichment (correlate-rich)
+*The server resolves inventory against vulnerability data. **Two disjoint mechanisms exist
+today** — a hardcoded agent-plugin matcher and a live server NVD pipeline — and they are not joined.*
+*Identity model (ADR-0018): agent emits a **structured typed identity** (`PackageIdentity`/
+`AppIdentity`), never PURL. Server routes by ecosystem into three lanes: **Lane 1** distro
+packages (deb/rpm/apk) → **OVAL-primary, NVD-fallback** on the full EVR (dpkg/rpmvercmp/semver
+comparators); **Lane 2** language ecosystems (pypi/npm/gem/cargo/…) → **OSV.dev by
+server-derived PURL** (deterministic, no CPE guessing); **Lane 3** OS-native GUI apps
+(Windows/macOS) → **not-assessed in v1** (no curated detection content authored; federation
+deferred to ADR-0020). See V1.3 + memory `vuln-scan-agent-emits-purl`.*
+
+### V2.1 Agent-side built-in CVE rules :large_orange_diamond: `T1`
+The `vuln_scan` plugin matches against a **hardcoded** `cve_rules.hpp` (`std::array` of
+hand-written `CveRule`s, substring product match + "version below"). This is the closed-PR
+PoC with the #1301/#1206 defects: inverted multi-branch ranges, no distro backport
+awareness, substring (non-CPE) identity, severity from a bare label. The plugin does **not**
+consult the server NVD database (V2.2).
+> **Gap:** this path **retires under ADR-0018** (server-authoritative matching) — no in-place
+> correctness rebuild. Its comparator is salvaged into the server-side range-aware comparator
+> (roadmap M1a); the ~40 rules and the #1206 runtime-rule pipeline are not carried forward.
+> *(superseded; see ADR-0018 Consequences)*
+
+### V2.2 Server-side NVD ingestion & database :large_orange_diamond: `T1`
+**WIRED** (transport + a store), but **the match model is wrong, not just the corpus.**
+`nvd_client` (HTTPS → `services.nvd.nist.gov`, NVD 2.0 API, API-key+proxy) → `nvd_db`
+(`NvdDatabase`) → `nvd_sync` (`NvdSyncManager`, 4h). Constructed/started in `server.cpp:982-987`
+when `nvd_sync_enabled`; CLI `--nvd-sync-interval` / `--nvd-api-key` / `--no-nvd-sync`,
+env `YUZU_NVD_SYNC_INTERVAL`; status REST endpoint.
+> **Gap (two layers):**
+> 1. **Schema can't represent CPE ranges.** The store is a flat `cve(product, affected_below)`
+>    with a single upper bound — it cannot hold NVD's `cpeMatch` criteria
+>    (`versionStartIncluding/Excluding`, `versionEndIncluding/Excluding`, multiple ranges per CVE).
+>    Reshaping to the real CPE-range model is required; **"widen the keywords" does NOT fix this.**
+> 2. **Corpus is keyword-scoped** (`kInitialSyncKeywords`), not a full mirror; no API key by
+>    default → low rate limit. *(roadmap M1a)*
+> **Note:** the parent map's §9.4 "NVD database sync on server" claim is **accurate** — keep it.
+
+### V2.3 NVD → inventory correlation join :large_orange_diamond: `T2`
+`NvdDatabase::match_inventory` exists but matches by `product LIKE ?` + a **naive
+`compare_versions < affected_below`** — substring identity, no CPE, no range semantics, no
+epoch/release/semver awareness. It is consumed by the **fleet-topology vuln overlay** only
+(`FleetTopologyStore`, `include_vuln=true`); the agent plugin's findings are **not** correlated
+against it.
+> **Gap:** replace with a real correlation engine — typed-identity→CPE mapping (curated +
+> pgvector fuzzy, Lane 1's NVD-fallback and Lane 3's future federation) + range-aware comparator
+> (recover the #1206 comparator) + `cpeMatch` range test, alongside Lane 1's OVAL-primary (V2.4)
+> and Lane 2's OSV.dev-by-PURL (V2.9) — as part of the single server correlation engine.
+> *(roadmap M1a; topology attach is M3)*
+
+### V2.4 Distro advisory / OVAL backport correlation :x: `T1`
+**Not ingested.** No OVAL/OVD anywhere in code — design-doc only
+(`vuln-scan-engine-design.md` Phase 2 "backport correctness, the FP killer", item R3,
+assigned to Andy). Without it, version-only matching false-positives on backported fixes.
+**This is ADR-0018 Lane 1's authoritative path** for distro packages (OVAL-primary,
+NVD-fallback) — see V1.3/V2 intro.
+> **Gap:** OVAL/distro-advisory ingestion + backport-aware matching. *(Epic 1.1 / design Phase 2)*
+
+### V2.5 CVSS-vector enrichment :large_orange_diamond: `T1`
+NVD records carry severity, but there is no CVSS **base vector** decomposition into
+exploitability/impact sub-scores for downstream weighting.
+> **Gap:** persist + parse CVSS vectors. *(Epic 2.1)*
+
+### V2.6 EPSS (exploit-probability) enrichment :x: `T2`
+No EPSS data source. CAVM's threat weight (w=0.20) has no input.
+> **Gap:** EPSS ingestion. *(Epic 2.2)*
+
+### V2.7 KEV (known-exploited) enrichment :x: `T2`
+No CISA KEV catalog. Cannot flag actively-exploited CVEs.
+> **Gap:** KEV ingestion + per-finding flag. *(Epic 2.2)*
+
+### V2.8 Enrichment-data store (CVSS/EPSS/KEV cache) :x: `T2`
+`NvdDatabase` stores CVEs, but there is no store for the enrichment overlays (CVSS vector,
+EPSS, KEV) that scoring needs.
+> **Gap:** born-on-PG `vuln_data_store` (schema `vuln_data_store`, ADR-0008 naming;
+> fail-soft per ADR-0012) **or** extend `NvdDatabase`. *(Epic 2.1)*
+
+### V2.9 OSV.dev / language-ecosystem correlation (Lane 2) :x: `T2`
+**Not ingested.** No OSV.dev client, no language-ecosystem (pypi/npm/gem/cargo/…) matching path
+anywhere in code. **Decided (ADR-0018 Lane 2):** these ecosystems carry clean, deterministic
+PURLs (server-derived from the agent's typed identity), so matching is OSV.dev-by-PURL directly
+— no CPE guessing, and this lane is pulled *out* of the fuzzy-CPE surface (shrinking Lane 3 to
+the GUI tail only).
+> **Gap:** OSV.dev client + language-ecosystem identity in the correlation engine.
+> *(roadmap M1a+, not yet milestone-assigned — new since the 2026-07-01 lane split)*
+
+---
+
+## V3 — Configuration & Compliance Scanning
+
+### V3.1 Config-hardening checks :large_orange_diamond: `T1`
+`vuln_scan` `config_scan` + `cve_scan` actions exist (per `vuln_scan.yaml`) at a basic
+level; severity taxonomy CRITICAL/HIGH/MEDIUM/LOW/INFO defined.
+> **Gap:** depth/coverage of checks; benchmark mapping (CIS/STIG) not present.
+
+### V3.2 Benchmark / compliance-framework mapping :x: `T3`
+No mapping of findings to CIS/STIG/regulatory controls.
+> **Gap:** out of scope for the floor; revisit after V2.
+
+---
+
+## V4 — Findings, Output & Reporting
+
+### V4.1 Structured finding output :white_check_mark: `T1`
+Pipe-delimited finding rows; `summary` action aggregates. Verified end-to-end on the
+native macOS agent (8 findings: 1 HIGH/3 MEDIUM/4 INFO).
+
+### V4.2 Findings persistence :white_check_mark: `T1`
+Findings land in the response store (filterable/aggregatable) like any instruction result.
+
+### V4.3 Dashboard surfacing & charts :large_orange_diamond: `T2`
+A `vuln_scan` chart ships in the `demo.visualization.fleet-posture` InstructionSet
+(ECharts). No dedicated `/vuln` page or per-device vuln lens yet.
+> **Gap:** dedicated vuln dashboard + MCP/REST parity (agentic-first A1). *(Epic 6 surfacing)*
+
+### V4.4 Dedicated vulnerability store (current-state, dedup) :x: `T2`
+Findings are per-execution rows; there is no current-state, deduplicated, per-device
+vulnerability table to drive scoring/trend.
+> **Gap:** born-on-PG findings store keyed by (agent, package-identity, CVE/advisory), carrying
+> **tri-state status** (vulnerable/assessed-clean/not-assessed, ADR-0019) and the feed-sync
+> timestamp behind each assessed-clean verdict. *(Epic 3.2 prerequisite; ADR-0019)*
+
+### V4.5 Tri-state status & coverage metric :x: `T2`
+No status enum — today's model is implicitly boolean (a finding row exists, or it doesn't) — and
+no per-host coverage counter. **Decided (ADR-0019):** per-`(host, package)` status is
+**vulnerable / assessed-clean / not-assessed**; "assessed-clean" is timestamped to the feed
+version it was evaluated against; each scan reports a **coverage metric** (assessed N of M
+installed packages) as a first-class figure, never inferred from the vulnerability count.
+> **Gap:** thread the status enum + timestamp through the findings store (V4.4) and surface
+> coverage in the dashboard/REST (V4.3), grouped by not-assessed reason (no-OVAL-stream /
+> no-CPE-mapping / side-loaded). *(roadmap M2; ADR-0019)*
+
+---
+
+## V5 — Topology Integration (vuln ↔ graph join)
+*The join that makes "vulnerable AND reachable" expressible. Yuzu's biggest head-start.*
+
+### V5.1 Observed reachability graph :white_check_mark: `T2`
+`FleetTopologyStore` — host + service nodes, edges classified Local/InternalFleet/External,
+IP→agent_id stitching (first-claim-wins, 300s reclaim), anti-spoof UP-* invariants.
+Served via `viz_routes` + `yuzu-viz.js`. **Natively produced — no external topology tool needed.**
+
+### V5.2 Topology persistence (time-aware) :x: `T2`
+In-memory only (60s TTL, no history). Scoring and AMAPC trend need persisted snapshots.
+> **Gap:** born-on-PG `topology_snapshot_store`, keep the in-memory hot path for viz. *(Epic 3.1)*
+
+### V5.3 Vuln→service/host-node attachment :x: `T2`
+Findings and topology nodes are disjoint datasets — no join key wired.
+> **Gap:** join on (agent_id + port/proc); node gains a finding-ref set. *(Epic 3.2)*
+
+### V5.4 Vulnerability overlay in fleet viz :large_orange_diamond: `T3`
+Planned as `feat/viz-engine` PR 10 (vulnerability overlay) + per-process posture glyph
+(synthesising vuln/AV/signing/firewall/encryption). Infrastructure exists; overlay not shipped.
+> **Gap:** depends on V5.3 join. *(Epic 3.2 surfacing)*
+
+---
+
+## V6 — Asset Model (crown jewels)
+*Gating prerequisite for the entire differentiator — every CAVM score is relative to jewel reachability.*
+
+### V6.1 Crown-jewel designation :x: `T3`
+No asset-value, criticality, or crown-jewel concept anywhere in code (only false-positive
+string matches like crypto "key").
+> **Gap:** operator/CMDB-entry surface + RBAC securable + audit-on-write. *(Epic 4.1)*
+
+### V6.2 Asset value / criticality on nodes :x: `T3`
+Topology nodes carry no value/criticality field.
+> **Gap:** extend `fleet_topology_types.hpp` node with optional asset-value. *(Epic 4.1)*
+
+---
+
+## V7 — Attack-Path Analytics (CAVM core — the differentiator)
+*All depend on V2 (threat data), V5 (join + persistence), V6 (asset value). Build in order.*
+
+### V7.1 EUC edge typing (Foothold/LateralMovement/PrivEsc/DataAccess) :x: `T3`
+Edges are *network scope*, not *exploit semantics*. CAVM weights (F=0.1…DA=0.3) have
+nothing to attach to.
+> **Gap:** add `EucClass` to the edge model + classification pass; optional host-firewall
+> potential-reachability enrichment. *(Epic 5.1)*
+
+### V7.2 Composite priority score (Annex C.5) :x: `T3`
+The 0.30/0.25/0.25/0.20 weighting (asset / reachability / centrality / threat).
+> **Gap:** `cavm/priority_score`. *(Epic 6.1)*
+
+### V7.3 Crown-jewel reachability + chain centrality :x: `T3`
+No graph walks for jewel reachability or node centrality.
+> **Gap:** `cavm/reachability` over persisted topology. *(Epic 6.2)*
+
+### V7.4 AMAPC (Average Minimum Attack-Path Complexity) :x: `T3`
+The board-facing resilience metric: Dijkstra on inverse-exploitability × log₂(len),
+`C_max` monotonicity ceiling. **Note:** Guardian's "resilience" is enforcement-retry
+policy — unrelated; AMAPC does not exist today.
+> **Gap:** `cavm/amapc`. *(Epic 6.3)*
+
+### V7.5 Choke-point analysis :x: `T3`
+Sequential min-cut layers; 1.5× secondary-chokepoint flag.
+> **Gap:** `cavm/chokepoint`. *(Epic 6.4)*
+
+### V7.6 Gate model (act_now/attend/monitor/track) :x: `T3`
+Thresholds 0.90/0.70/0.60/0.50 + velocity-decay windows.
+> **Gap:** `cavm/gates`. *(Epic 6.5)*
+
+### V7.7 Visibility discount :large_orange_diamond: `T3`
+Yuzu *tracks* enrollment/visibility state, but no score consumes it (CAVM: full=0.75…not_enrolled=0.6).
+> **Gap:** feed existing visibility state into the gate model. *(Epic 6.5)*
+
+---
+
+## V8 — Operational Integration
+
+### V8.1 SOC real-time rescoring :x: `T3`
+No alert→edge-weight modulation (CAVM: PE×1.8, DA elevation). Yuzu *has* the events/SSE
+bus + Guardian signals to feed this.
+> **Gap:** event-bus subscriber modulating `priority_score`. *(Epic 7.1)*
+
+### V8.2 Board metric / AMAPC trend reporting :x: `T3`
+No Prometheus gauges or trend panel for AMAPC / score distribution.
+> **Gap:** `yuzu_cavm_amapc` gauges + dashboard trend (observability-conventions). *(Epic 7.2)*
+
+### V8.3 Remediation batching / governance gates :x: `T3`
+No co-location batching or remediation-governance surface.
+> **Gap:** defer until scoring is trusted. *(Epic 7.3)*
+
+---
+
+## Merge guidance (folding into `docs/capability-map.md`)
+
+1. **§9.4 Vulnerability Scanning** — replace the single `:white_check_mark: T1` line. The
+   floor is **not** done: the agent matcher is the defective PoC (V2.1), NVD ingest is
+   keyword-scoped and not joined to plugin findings (V2.2/V2.3), OVAL/backport correlation is
+   absent (V2.4), OSV.dev/language-ecosystem correlation is absent (V2.9), and finding status is
+   still boolean rather than tri-state (V4.5). Downgrade §9.4 to `:large_orange_diamond:`. The
+   "NVD database sync on server" claim is **accurate — keep it** (corrects the 2026-06-30
+   draft, which wrongly called NVD unwired). Fold V1–V4 in as §9.4.x sub-rows.
+2. **New domain §32 — Vulnerability & Attack-Path Management (CAVM)** — fold in V5–V8.
+   V5 cross-references §28.7 (fleet viz) and §28.9; V7.4 (AMAPC) is the headline board metric.
+3. **Tier mapping** — V-tiers already match the parent `T1/T2/T3` scheme; no remap needed.
+4. **Accuracy note** — the parent map's headline % is known-overstated
+   (memory `project_capability_map_accuracy.md`); when recomputing totals after merge,
+   the vuln_scan additions move the denominator up by ~26 capabilities, only 5 done.
+5. **Renumber** the device-table footer / domain count (parent currently tops out at §31).
+
+## Reconciliation cadence
+
+This map will drift as the matcher rebuild and CAVM scoring land. Update a V-row's status
+**in the same PR** that changes its backing code (same rule as the parent map). Re-reconcile
+against `docs/vuln-scan-engine-design.md` whenever a design-doc phase closes, and against
+`docs/adr/00NN-*.md` whenever a vuln_scan ADR is amended or newly accepted.
+
+**Reconciliation log:** 2026-07-01 — folded in ADR-0018 (D1 wire-format correction: typed
+identity, not PURL; Lane 1/2/3 routing; KEV pre-filter exception struck) and ADR-0019
+(tri-state finding status + coverage dimension). Added V2.9, V4.5.
+`docs/vuln-scan-roadmap.md` reconciled in the same pass.

--- a/docs/vuln-scan-roadmap.md
+++ b/docs/vuln-scan-roadmap.md
@@ -1,0 +1,189 @@
+# Vuln-Scan Roadmap
+
+**Status:** working roadmap for the vuln_scan / CAVM workstream (owner: Andy / @lesault).
+**Created:** 2026-06-30.
+**Last reconciled:** 2026-07-01 — against ADR-0018 (D1 wire-format correction, no-exceptions
+KEV-pre-filter strike, Lane 1/2/3 routing) and ADR-0019 (tri-state findings + coverage dimension).
+
+This roadmap is the **canonical sequencing** for the workstream. It reconciles three views into
+one ordered plan:
+- the North Star design — `docs/vuln-scan-engine-design.md` (floor = Phases 1–5, differentiator = Phases 6–8);
+- the capability map — `docs/vuln-scan-capability-map.md` (domains V1–V8);
+- the architecture decisions taken in design review (below).
+
+It supersedes the ad-hoc "Epic 1–7" framing used in early discussion. Where the capability map
+still cites "Epic N", read the milestone here instead.
+
+---
+
+## Locked architecture decisions
+
+1. **Server-authoritative matching (collect-thin / correlate-rich)** — **ADR-0018**. The agent
+   collects; the server decides. Matching moves off the agent (the ~40 hard-coded
+   `cve_rules.hpp` rules retire). **No exceptions** — an earlier draft's agent-side **KEV-only
+   pre-filter** was struck 2026-07-01; any future real-time local tripwire belongs to DEX, not
+   vuln_scan.
+2. **Agent emits a structured typed identity; CPE and PURL are both server-derived.** —
+   **ADR-0018 D1.** The wire format is `PackageIdentity`/`AppIdentity` (a decomposed `oneof`:
+   ecosystem, name, epoch, version, release, arch), **not** a PURL string. Matching then routes
+   by ecosystem into three lanes: **Lane 1** distro packages (deb/rpm/apk) → OVAL-primary,
+   NVD-fallback on the full EVR; **Lane 2** language ecosystems (pypi/npm/gem/cargo/…) →
+   OSV.dev by a server-derived PURL (deterministic, no CPE guessing); **Lane 3** OS-native GUI
+   apps (Windows/macOS) → **not-assessed** in v1 (no curated detection content authored;
+   federation deferred to ADR-0020). CPE itself is only derived for Lane 1's NVD-fallback and
+   Lane 3's future federation — see memory `vuln-scan-agent-emits-purl` and capability-map
+   V1.3/V2.
+3. **Server substrate is Postgres** (ADR-0006/0012). New server stores are born-on-PG.
+4. **Findings are tri-state; coverage is a first-class, separate dimension** — **ADR-0019**.
+   Per-`(host, package)` status is **vulnerable / assessed-clean / not-assessed** — a package
+   outside every feed's scope is never silently reported as clean. Each scan also reports a
+   **coverage metric** (assessed N of M installed packages) alongside the vulnerability count.
+
+---
+
+## Current baseline (2026-06-30)
+
+| Area | State |
+|---|---|
+| Agent matching | ~40 **hard-coded** CVEs (`cve_rules.hpp`); substring product match + naive comparator. Runs on-demand, emits pipe-delimited findings. |
+| Agent inventory | `name\|version` only; duplicate collector (vuln_scan vs `installed_apps`). No source/arch/EVR — target is a typed `PackageIdentity`/`AppIdentity` record (ADR-0018), not PURL. |
+| Server NVD | `nvd_client`+`nvd_db`+`nvd_sync` **wired**, but the store is a flat `cve(product, affected_below)` (no CPE ranges) and **keyword-scoped**. Consumed only by the topology vuln overlay; the plugin never queries it. |
+| OVAL / EPSS / KEV / CVSS-vector | **None** (design-doc only). |
+| Topology graph | `FleetTopologyStore` — observed graph, in-memory 60s, no persistence, no vuln attach. |
+| Asset value / crown jewels | **None.** |
+| CAVM scoring (composite / AMAPC / chokepoints / gates) | **None.** |
+
+---
+
+## Milestones
+
+Each milestone: **Goal · Deliverables (→ V-capabilities) · Depends on · Acceptance · Your decisions (R4/R6)**.
+
+### M1a — NVD correlation MVP (floor; prove the pipeline)
+Maps to North Star **Phase 1**: *"inventory emits normalised identity (CPE/PURL + source + arch);
+server matches against an NVD mirror with real version-range logic for a pilot product set."*
+(That design-doc phrasing predates ADR-0018 D1 — the wire format is the typed identity `oneof`,
+not CPE/PURL; CPE/PURL are both server-side derivations off it.) This milestone stands up
+**Lane 1's NVD-fallback** for a pilot distro; M1b adds the OVAL-primary override on top.
+
+- **Goal:** real server-side NVD matching for a pilot product set, replacing the hard-coded path.
+- **Deliverables:**
+  - Agent **typed-identity collector** (dpkg/rpm/apk + `/etc/os-release` namespace + arch + full
+    EVR → `PackageIdentity`; Windows `DisplayName`/`Publisher`/`FileVersion` + macOS bundle id →
+    `AppIdentity`) + kernel/OS-build rows; **unify the duplicate collector**. → V1.3, V1.1
+  - **Wire format** — structured identity record on the inventory payload; `agent_pb`+`gateway_pb` regen. → V1.3
+  - **NVD store reshape** to `cpeMatch` + `versionStart/EndIncluding/Excluding` (born-on-PG); re-ingest parsing the cpeMatch arrays; drop keyword scoping. → V2.2
+  - **Identity→CPE map** — curated/exact for the pilot set (pgvector fuzzy deferred to Lane 3
+    federation, ADR-0018/ADR-0020). → V2.3
+  - **Range-aware comparator** (recover #1206: epoch / rpmvercmp / semver). → V2.1
+  - **Correlation engine** + born-on-PG **findings store** (current-state, dedup, per-device,
+    **tri-state status** vulnerable/assessed-clean/not-assessed per ADR-0019). → V2.3, V4.4, V4.5
+  - **Dispatch rewire** — on-demand scan returns the typed identity record → server correlates → findings surface (live view). → V4.1, V4.2
+- **Depends on:** typed-identity collector (agent) before server correlation.
+- **Acceptance:** match **parity vs a hand-labelled reference host**; **no lower-bound false
+  positives** (G-bar); a package outside NVD's scope reports **not-assessed**, never a false
+  "clean" (ADR-0019).
+- **Your decisions:** pilot product set; full-NVD vs targeted mirror; API key; refresh cadence.
+
+### M1b — OVAL / backport correctness (the FP-killer, R3)
+Maps to North Star **Phase 2** (backport correctness) and **ADR-0018 Lane 1**
+(OVAL-primary, NVD-fallback for distro packages).
+
+- **Goal:** eliminate false positives on backport-fixed distro packages.
+- **Deliverables:** OVAL/distro-advisory ingestion for **one pilot distro** (e.g. Ubuntu USN/OVAL);
+  full-EVR (from `PackageIdentity`) → advisory match; **prefer-OVAL-over-NVD** routing for
+  distro-packaged software, making Lane 1's OVAL-primary/NVD-fallback split real. → V2.4, V2.3
+- **Depends on:** M1a (typed-identity emit + correlation engine).
+- **Acceptance:** zero FPs on a backport-fixed reference set; OVAL verdict overrides NVD for distro pkgs.
+- **Your decisions:** which distro(s); OVAL feed sources + freshness SLOs (R4).
+- **Open tension (flagging, not resolving):** the pre-reconciliation roadmap listed "pgvector
+  fuzzy PURL→CPE for the long tail" as an M1b deliverable, but ADR-0018 Lane 3 places pgvector
+  fuzzy CPE matching in the **deferred GUI-app federation** track (its own future ADR-0020), not
+  in distro/OVAL work. Removed from M1b here; Andy to confirm there's no separate long-tail
+  fuzzy-match need for distro packages *outside* Lane 3 before this is fully closed.
+
+### M2 — Enrichment & prioritisation
+- **Goal:** make findings rankable, not just present; make findings honest (ADR-0019).
+- **Deliverables:** EPSS + CISA KEV + CVSS-vector ingestion into the enrichment store; per-finding
+  flags/scores; **tri-state finding status + per-host coverage counters** (assessed N of M),
+  feed-sync timestamp threaded onto each "assessed-clean" verdict, not-assessed reasons grouped
+  (no-OVAL-stream / no-CPE-mapping / side-loaded). → V2.5, V2.6, V2.7, V2.8, V4.5
+- **Depends on:** M1a (findings store).
+- **Acceptance:** findings carry EPSS/KEV/CVSS; KEV-flagged actively-exploited CVEs surface first;
+  coverage is reported as a first-class number beside the vulnerability count, never inferred from it.
+- **Removed (ADR-0018, 2026-07-01):** the agent-side KEV-only pre-filter previously listed here
+  is struck — no agent-side exception survives; see Locked architecture decision #1.
+
+### M3 — Topology join (vulnerable **and** reachable)
+- **Goal:** connect findings to the reachability graph.
+- **Deliverables:** persist the topology graph (born-on-PG, keep the in-memory hot path); attach
+  findings to service/host nodes; vuln overlay in fleet viz. → V5.2, V5.3, V5.4
+- **Depends on:** M1a (findings store), existing `FleetTopologyStore`.
+- **Acceptance:** a service node renders its CVEs; "vulnerable + reachable" is queryable.
+
+### M4 — Asset model (crown jewels)
+- **Goal:** the gating prerequisite for scoring.
+- **Deliverables:** crown-jewel/asset-value designation (born-on-PG store + dashboard/REST + RBAC
+  securable + audit); value on topology nodes. → V6.1, V6.2
+- **Depends on:** M3 (nodes to annotate).
+- **Acceptance:** operator designates jewels; value flows onto nodes.
+
+### M5 — CAVM scoring (the differentiator)
+Maps to North Star **Phases 6–8** (ADR-0001/0002/0003/0005).
+
+- **Goal:** attack-path-aware prioritisation.
+- **Deliverables, in order:** EUC edge typing (Foothold/LM/PE/DA) → composite priority score
+  (C.5) → crown-jewel reachability + chain centrality → **AMAPC** → choke-point analysis
+  (2-approx MST/Steiner) → gate model (act_now/attend/monitor/track) + visibility discount.
+  → V7.1–V7.7
+- **Depends on:** M2 (threat weight), M3 (graph), M4 (asset value).
+- **Acceptance:** scored backlog matches hand-ranked reference scenarios; AMAPC stable + monotonic.
+
+### M6 — Operational integration
+- **Goal:** close the loop with SOC + leadership.
+- **Deliverables:** SOC real-time rescoring (alert → edge-weight modulation via events/SSE);
+  board metric / AMAPC-trend gauges + panel; remediation batching/governance. → V8.1, V8.2, V8.3
+- **Depends on:** M5.
+- **Acceptance:** alerts re-rank live; AMAPC trend reported; remediation batches actionable.
+
+---
+
+## Cross-walk
+
+| Milestone | North Star | Capability-map | Net-new vs reuse |
+|---|---|---|---|
+| M1a | Phase 1 | V1.1/V1.3, V2.1/V2.2/V2.3, V4.1/V4.2/V4.4/V4.5 | reshape NVD store; new collector/comparator/engine; reuse sync transport |
+| M1b | Phase 2 | V2.4, V2.3 | all new (OVAL) |
+| M2 | floor | V2.5–V2.8, V4.5 | all new |
+| M3 | floor | V5.2–V5.4 | persist + attach; reuse graph |
+| M4 | floor | V6.1–V6.2 | all new |
+| M5 | Phases 6–8 | V7.1–V7.7 | all new |
+| M6 | Phases 6–8 | V8.1–V8.3 | new; reuse events/SSE |
+
+---
+
+## Open decisions (yours, R4/R6)
+
+1. **Pilot scope** — start M1a **NVD-only, one OS family** (smallest slice that hits the
+   acceptance bar), or go straight to **M1a+M1b one distro** (proves the differentiator from
+   day one)? *Recommendation: M1a NVD-only first to de-risk the pipeline, then M1b.*
+2. **Branch scope** — keep a dedicated branch to the **agent typed-identity emit** (first PR,
+   independently testable against a reference host), or make it a **Phase-1 epic branch**?
+   *Recommendation: agent-identity-only PR first; server M1a on follow-ups.* **Branch note:**
+   `feat/vuln-scan-v1-inventory` was cut early and never carried unique commits — as of
+   2026-07-01 it is an ancestor of `dev` (stale), so PR 1 should branch fresh off current `dev`
+   rather than reuse it.
+3. **Data sources** — full-NVD vs targeted mirror; OVAL distro(s); EPSS/KEV feeds; freshness SLOs.
+
+---
+
+## Immediate next slice
+
+**PR 1: agent typed-identity collector + wire format** — unify the collector, emit the
+structured `PackageIdentity`/`AppIdentity` record (per-OS, ecosystem-discriminated `oneof`
+per ADR-0018 D1), add kernel/OS-build rows, extend the proto. Validate the identity output
+against a reference host (PURL, where it's needed at all — Lane 2 OSV.dev queries, SBOM
+export — is a server-side derivation, never emitted by the agent). No server behaviour change
+yet, so it's cleanly reviewable and independently testable. Server M1a pieces (NVD reshape →
+comparator → engine → findings store → dispatch rewire) follow on subsequent PRs. Cut this PR
+fresh off current `dev` — `feat/vuln-scan-v1-inventory` is stale (see Open decisions #2).


### PR DESCRIPTION
## Summary
- Adds ADR-0018 (server-authoritative vulnerability matching — collect-thin/correlate-rich, typed identity wire format, Lane 1/2/3 correlation routing) and ADR-0019 (tri-state finding status + coverage dimension), both `status: proposed`.
- Reconciles `docs/vuln-scan-roadmap.md` and `docs/vuln-scan-capability-map.md` against these ADRs — both docs still described the pre-amendment plan (agent-emits-PURL wire format, an agent-side KEV pre-filter exception) which ADR-0018's same-day amendment retracted.
- Adds capability-map rows V2.9 (OSV.dev / language-ecosystem correlation, Lane 2) and V4.5 (tri-state status & coverage metric), previously untracked.
- Flags one open tension for the domain owner rather than resolving it unilaterally: whether pgvector-fuzzy-CPE belongs to M1b's distro/OVAL work or is purely deferred Lane-3 GUI-app federation.

No code changes — docs only.

## Test plan
- [ ] N/A (documentation-only change)
- [ ] ADR-0018 and ADR-0019 still need sign-off per their own Ratification sections (maintainer, platform lead, security architecture) before flipping to `accepted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)