### PR TITLE
chore(changelog): move unreleased entries to per-PR fragment files (changelog.d/)

### DIFF
--- a/.claude/agents/docs-writer.md
+++ b/.claude/agents/docs-writer.md
@@ -1,6 +1,6 @@
 ---
 name: docs-writer
-description: Use on every change as part of governance gate 2 (mandatory deep-dive). Reviews every modified file for user-facing impact and produces a findings report enumerating required updates to `docs/user-manual/`, REST API docs, YAML InstructionDefinitions in `content/definitions/`, `docs/yaml-dsl-spec.md`, roadmap/capability-map, CHANGELOG, and CLAUDE.md. Read-only — output is a doc-change recommendation, not the doc edits themselves.
+description: Use on every change as part of governance gate 2 (mandatory deep-dive). Reviews every modified file for user-facing impact and produces a findings report enumerating required updates to `docs/user-manual/`, REST API docs, YAML InstructionDefinitions in `content/definitions/`, `docs/yaml-dsl-spec.md`, roadmap/capability-map, CHANGELOG (as a `changelog.d/` fragment file — never a direct CHANGELOG.md edit), and CLAUDE.md. Read-only — output is a doc-change recommendation, not the doc edits themselves.
 tools: Read, Grep, Glob, Bash
 model: sonnet
 ---
@@ -22,6 +22,7 @@ You are one of two agents (with security-guardian) that reviews every change. No
 - For new plugin actions: specify the YAML InstructionDefinition that should land in `content/definitions/` and the required addition to `docs/yaml-dsl-spec.md` section 14
 - For config changes: identify the required `docs/user-manual/server-admin.md` update
 - For DSL syntax changes: specify the grammar/semantics/example additions for `docs/yaml-dsl-spec.md`
+- For operator-visible changes: require a changelog **fragment** — `changelog.d/<PR#>-<slug>.<section>.md` per `changelog.d/README.md`. Flag any direct edit to `CHANGELOG.md` as a MUST-FIX (the `Changelog fragments` CI job will fail the PR)
 - Produce: a findings report enumerating required doc changes (with file paths, suggested wording where useful) — or "no user-facing impact" with justification
 
 ### Documentation Domains

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -96,6 +96,18 @@
     "context7@claude-plugins-official": true
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/changelog-fragment-guard.py\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -29,7 +29,7 @@ Default mode (no flag): full pipeline from preflight → tag push → workflow m
 
 Before invoking the skill, the operator should already have:
 - All commits intended for this release merged to `main` (releases tag from main, not dev — confirm `git log origin/main..origin/dev` is empty or only contains intentional dev-only changes).
-- CHANGELOG `[Unreleased]` section content moved to `## [X.Y.Z] - YYYY-MM-DD`.
+- CHANGELOG promoted: `python3 scripts/assemble-changelog.py promote X.Y.Z` run and committed — it assembles all `changelog.d/` fragments (plus any legacy `[Unreleased]` content) into `## [X.Y.Z] - YYYY-MM-DD` and deletes the fragment files. Never hand-move `[Unreleased]` content. Preflight check 4b fails while unpromoted fragments remain. Convention: `changelog.d/README.md`.
 - `meson.build` `version: 'X.Y.Z'` updated.
 - All tracked compose files updated to `${YUZU_VERSION:-<BASE_VERSION>}` defaults — the **base** version with any `-rcN`/`-betaN` suffix stripped (e.g., for tag `v0.12.0-rc0` the default is `0.12.0`, NOT `0.12.0-rc0`). The workflow's `Validate docker-compose image versions` gate inside the `Create Release` job invokes `bash scripts/check-compose-versions.sh "$BASE_VERSION"` and will hard-fail the release after the full build matrix has run if the defaults don't match. Local dry-run **must use the same base version**: `bash scripts/check-compose-versions.sh 0.12.0` (NOT `0.12.0-rc0`) — the script accepts whatever you pass and is happy with consistent garbage, so passing the rc-suffixed version locally green-lights a doomed release. Preflight (`scripts/release-preflight.sh`) does the right thing automatically because it strips the suffix internally; the lesson from v0.12.0-rc0's first cut was that local one-off `check-compose-versions.sh` invocations are misleading on RC tags.
 
@@ -300,7 +300,8 @@ After all verification passes:
 1. **Bump dev branch to next dev version.** On `dev`:
    ```bash
    # Update meson.build version to X.Y.(Z+1)-dev or (X+1).Y.0-dev (operator's call)
-   # Add new ## [Unreleased] section to CHANGELOG.md
+   # (No CHANGELOG step: the promote already left the ## [Unreleased] header +
+   # do-not-edit note in place; new entries arrive as changelog.d/ fragments.)
    git commit -m "chore(post-release): bump dev to X.Y.Z+1-dev"
    git push origin dev
    ```

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,7 @@
 
 ## Checklist
 
+- [ ] Changelog fragment added: `changelog.d/<PR#>-<slug>.<section>.md` — do **not** edit `CHANGELOG.md` (see [`changelog.d/README.md`](../changelog.d/README.md); skip only if the change has no operator-visible effect)
 - [ ] Builds on Linux (GCC and Clang)
 - [ ] Builds on Windows (MSVC)
 - [ ] Tests pass (`ctest --preset linux-debug`)

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -36,3 +36,31 @@ jobs:
 
       - name: Verify CHANGELOG.md is in reverse chronological order
         run: python3 tests/test_changelog_order.py
+
+  # Changelog fragment convention (changelog.d/ — see changelog.d/README.md):
+  # PRs add uniquely-named fragment files instead of editing CHANGELOG.md's
+  # [Unreleased] section (the perpetual merge-conflict / approval-invalidation
+  # hotspot). This job lints the fragments and fails any PR whose diff changes
+  # the [Unreleased] section content directly — with a failure message that
+  # tells the (human or agent) author exactly how to convert the edit into a
+  # fragment. The release promote (CHANGELOG.md changes + fragment deletions
+  # in the same diff) is recognised and allowed.
+  changelog-fragments:
+    name: Changelog fragments
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Lint changelog.d/ fragment files
+        run: python3 scripts/assemble-changelog.py --check
+
+      - name: Block direct edits to CHANGELOG.md [Unreleased]
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          python3 scripts/assemble-changelog.py --guard "$BASE_SHA"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> **Do not add entries to this section directly** — including you, AI coding
+> agent reading this. Unreleased changes are recorded as one-file-per-change
+> fragments under [`changelog.d/`](changelog.d/README.md) and assembled here at
+> release time by `scripts/assemble-changelog.py` (direct edits fail the
+> `Changelog fragments` CI check). Entries below predate the fragment
+> convention and will be promoted normally at the next release.
+
 ### Added
 
 - **Recurring instruction schedules now actually fire (#1191).** `ScheduleEngine::evaluate_due`/`advance_schedule` had no production caller — schedules persisted and listed but never dispatched. A new `ScheduleRunner` poller (the `PolicyEvaluator`/`PreflightRunner` shape, 30s tick, joined before the stores) closes the gap: due schedules fire through the same tracked dispatch path as operator-initiated commands, the approval gate is never bypassed (`requires_approval` OR definition `approval_mode != "auto"`, one ticket per occurrence, one-approval == one-run via the occurrence anchor), and every outcome is audited (`instruction.schedule_fired`, `instruction.approval_required`) and counted (`yuzu_schedule_{fires,fire_failures,approvals_submitted,tick_errors}_total`). Hardened against adversarial review before merge: `POST /api/schedules` requires BOTH `Schedule:Write` and `Execution:Execute` — a created schedule is a fleet-wide command-dispatch primitive with no further permission check at fire time — and re-enabling a disabled schedule requires `Execution:Execute` too (disabling never does, so a runaway schedule can always be stopped); delete and enable/disable are owner-scoped (`created_by`); one approval ticket is now scoped to the single schedule occurrence that requested it (`approvals.schedule_id`), so two schedules sharing the same (creator, definition, scope) can no longer settle on each other's ticket.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,10 @@ The `release:` job (`.github/workflows/release.yml`) runs `scripts/check-compose
 
 **Before tagging**, bump the `${YUZU_VERSION:-X.Y.Z}` default in every tracked compose file and verify locally: `bash scripts/check-compose-versions.sh 0.12.0`. Otherwise the job fails only after the full build matrix (~30–60 wasted runner-min, nothing published). New compose file ⇒ also add it to the `FILES` array in the script — auto-discovery is deliberately off.
 
+## Changelog
+
+**Never edit `CHANGELOG.md`** — add one fragment file `changelog.d/<PR#>-<slug>.<section>.md` (body = the finished `- ` bullet), assembled at release. A hook + the `Changelog fragments` CI job enforce this; see `changelog.d/README.md`.
+
 ## Routed concerns (read the doc, not this file)
 
 | Concern | Doc | Loaded by |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,25 @@ All code changes follow mandatory governance gates defined in `CLAUDE.md`. In su
 3. Write a clear PR title and description using the PR template
 4. Keep PRs small where possible; large features should be broken into incremental PRs
 
+## Changelog
+
+**Do not edit `CHANGELOG.md` in a PR** — direct edits to its `[Unreleased]`
+section are rejected by the `Changelog fragments` CI check (they made every
+second PR conflict and void its approvals). Instead, add **one new file**
+describing your change:
+
+```
+changelog.d/<PR-or-issue-number>-<short-slug>.<section>.md
+```
+
+where `<section>` is one of `added`, `changed`, `deprecated`, `removed`,
+`fixed`, `security`, and the body is the finished bullet (starting `- `)
+exactly as it should read in the changelog. Fragments are assembled into
+`CHANGELOG.md` at release time. Full convention (including guidance for AI
+coding agents): [`changelog.d/README.md`](changelog.d/README.md). Changes with
+no operator-visible effect (pure refactors, CI plumbing, test-only) can skip
+the fragment.
+
 ## Coding Standards
 
 The project follows C++23 conventions enforced by `.clang-tidy`:

--- a/changelog.d/1864-changelog-fragments.changed.md
+++ b/changelog.d/1864-changelog-fragments.changed.md
@@ -1,0 +1,14 @@
+- **Changelog moved to per-PR fragment files (`changelog.d/`).** PRs no longer edit
+  `CHANGELOG.md` — each change adds one uniquely-named fragment
+  (`changelog.d/<PR#>-<slug>.<section>.md`, body = the finished bullet), and
+  `scripts/assemble-changelog.py promote X.Y.Z` assembles fragments (plus any legacy
+  `[Unreleased]` content) into the release section at tag time. This removes the
+  standing `[Unreleased]` merge-conflict → re-approval loop that hit every second PR.
+  Enforced in depth: a committed Claude Code PreToolUse hook denies direct
+  `CHANGELOG.md` edits with fix-it instructions, the new `Changelog fragments`
+  docs-lint job lints fragments and fails PRs whose diff changes `[Unreleased]`
+  content, and `scripts/release-preflight.sh` blocks tagging while unpromoted
+  fragments remain. Pre-convention branches convert with one command:
+  `scripts/assemble-changelog.py --extract origin/dev --id <PR#>` (moves the branch's
+  `[Unreleased]` additions into fragments and restores `CHANGELOG.md` to dev's
+  version). Convention: `changelog.d/README.md`.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,88 @@
+# changelog.d/ — changelog fragments
+
+**Never edit `CHANGELOG.md` in a PR.** Unreleased changes are recorded here as
+one small file per change, and assembled into `CHANGELOG.md` at release time.
+
+Why: two PRs adding bullets to the same `[Unreleased]` section can never
+auto-merge — the second one to land always conflicted, and the rebase push
+voided the PR's approvals (the dev ruleset requires approval of the most
+recent push). Fragments are uniquely-named **new** files, so they can never
+conflict with each other. This directory exists to kill that friction.
+
+## What your PR adds
+
+Exactly one new file (more only if the change genuinely spans sections):
+
+```
+changelog.d/<PR-or-issue-number>-<short-slug>.<section>.md
+```
+
+- `<PR-or-issue-number>` — the PR number if you have it, else the issue
+  number. Its only job is uniqueness, so a date works too if neither exists.
+- `<short-slug>` — 2–5 words, kebab-case, describing the change.
+- `<section>` — where the entry belongs in [Keep a
+  Changelog](https://keepachangelog.com/en/1.1.0/) terms, one of:
+  `added` | `changed` | `deprecated` | `removed` | `fixed` | `security`
+
+**The file body is the finished changelog entry** — one or more markdown
+bullets starting with `- `, written exactly as they should appear under
+`### Added` (etc.) in `CHANGELOG.md`. Multi-line and multi-paragraph bullets
+are fine; match the voice and detail level of existing `CHANGELOG.md` entries.
+Do not put `##`/`###` headers in the file — the section comes from the
+filename.
+
+### Example
+
+`changelog.d/1832-inventory-devices-tab.added.md`:
+
+```markdown
+- **`/inventory` Devices tab shows real device-CI data.** The Serial/Model/CPU-RAM
+  columns (previously greyed placeholders) now read from `DeviceInventoryStore`, and
+  the per-device drill grows a full CI-record panel.
+```
+
+## Rules
+
+1. **Add** your own fragment; **never modify or delete** anyone else's — only
+   the release promote removes fragments.
+2. Never touch `CHANGELOG.md` itself. A committed Claude Code hook denies the
+   edit, and the `Changelog fragments` CI job fails any PR whose diff changes
+   the `[Unreleased]` section (the failure message explains how to fix it).
+3. Not every PR needs a fragment — pure refactors, CI plumbing, and test-only
+   changes with no operator-visible effect can skip it. If an operator or
+   agent would notice the change, write one.
+4. Lint locally before pushing: `python3 scripts/assemble-changelog.py --check`
+
+## For AI coding agents
+
+If you are an agent (Claude Code, etc.) preparing a change in this repo: when
+your instructions, a reviewer, or a checklist says "update the changelog",
+that means **create a fragment file here** using the naming scheme above. Do
+not open or edit `CHANGELOG.md`. Write the bullet in the same style as
+existing `CHANGELOG.md` entries: bolded lead phrase, then the operator-facing
+substance, referencing issue/PR numbers like `(#1832)` where relevant.
+
+## Converting a branch that already edited CHANGELOG.md
+
+PRs opened before this convention (or agents that edited `CHANGELOG.md` out of
+habit) convert with one short recipe, run from the repo root on the PR branch
+(the checkout line brings the tooling onto pre-convention branches):
+
+```bash
+git fetch origin dev
+git checkout origin/dev -- scripts/assemble-changelog.py changelog.d/README.md
+python3 scripts/assemble-changelog.py --extract origin/dev --id <PR#>
+```
+
+It moves the bullets your branch added to `[Unreleased]` into correctly-named
+fragment files and restores `CHANGELOG.md` to dev's version (so it can no
+longer conflict). Review, then commit the new fragment(s) **together with**
+the restored `CHANGELOG.md`, and push.
+
+## Release time (operator / release skill only)
+
+`python3 scripts/assemble-changelog.py promote X.Y.Z` merges any legacy
+`[Unreleased]` content plus every fragment into a new `## [X.Y.Z] - <date>`
+section, resets `[Unreleased]`, and deletes the fragment files; commit the
+result. `scripts/release-preflight.sh` fails if unpromoted fragments remain
+at tag time. The `/release` skill runs this as part of its pre-tag checklist.

--- a/scripts/assemble-changelog.py
+++ b/scripts/assemble-changelog.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""Changelog fragment tooling — lint, guard, and release-time assembly.
+
+Yuzu records unreleased changes as one-file-per-change *fragments* under
+``changelog.d/`` instead of editing CHANGELOG.md's ``[Unreleased]`` section
+directly. Two PRs adding bullets at the same spot in CHANGELOG.md conflicted
+every time, and the conflict-resolution push voided the PR's approvals
+(`require_last_push_approval`). Fragments are uniquely-named new files, so
+they can never conflict. Convention: changelog.d/README.md.
+
+Modes:
+
+  python3 scripts/assemble-changelog.py --check
+      Lint every fragment in changelog.d/ (filename pattern, body format).
+      Run by the `Changelog fragments` docs-lint CI job on every PR/push.
+
+  python3 scripts/assemble-changelog.py --guard <base-sha>
+      Fail if the working tree's CHANGELOG.md [Unreleased] *section content*
+      (### subsections + bullets) differs from <base-sha>'s — unless the same
+      range also deletes changelog.d/ fragments (that's the release promote).
+      Preamble prose changes under [Unreleased] are allowed. CI-only mode; it
+      assumes the working tree is the PR merge commit.
+
+  python3 scripts/assemble-changelog.py promote <X.Y.Z> [--date YYYY-MM-DD]
+      Release-time assembly: merge any legacy [Unreleased] subsections plus
+      all fragments into a new `## [X.Y.Z] - <date>` section inserted after
+      [Unreleased], reset [Unreleased] to its preamble, and DELETE the
+      fragment files. Run by the /release skill before tagging; commit the
+      result.
+
+  python3 scripts/assemble-changelog.py --extract <base-ref> --id <PR#>
+      Convert a branch that edited CHANGELOG.md directly (e.g. a PR opened
+      before the fragment convention): the bullets this branch ADDED to
+      [Unreleased] (relative to `git merge-base HEAD <base-ref>`) are written
+      out as changelog.d/<PR#>-<slug>.<section>.md fragments, and CHANGELOG.md
+      is restored to <base-ref>'s version so it matches the base branch
+      exactly (merge conflicts become impossible). Review, then commit the
+      new fragments together with the restored CHANGELOG.md.
+
+Exit codes: 0 = OK, 1 = check/guard/promote failure, 2 = usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Keep a Changelog canonical section order.
+CANONICAL_SECTIONS = ["Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"]
+SECTION_KEYS = [s.lower() for s in CANONICAL_SECTIONS]
+
+FRAGMENT_NAME_RE = re.compile(
+    r"^(?P<stem>[A-Za-z0-9][A-Za-z0-9._-]*)"
+    r"\.(?P<section>added|changed|deprecated|removed|fixed|security)\.md$"
+)
+UNRELEASED_RE = re.compile(r"^## \[unreleased\]\s*$", re.IGNORECASE)
+ANY_VERSION_HEADER_RE = re.compile(r"^## \[")
+SUBSECTION_RE = re.compile(r"^### +(?P<name>.+?)\s*$")
+
+HOW_TO_FIX = """\
+How to fix (for humans and AI agents alike):
+
+  1. Revert your CHANGELOG.md edit (`git checkout origin/dev -- CHANGELOG.md`
+     or equivalent — restore the file to its base-branch state).
+  2. Put the same bullet(s) in ONE new file instead:
+
+         changelog.d/<PR-or-issue-number>-<short-slug>.<section>.md
+
+     where <section> is one of: added | changed | deprecated | removed |
+     fixed | security, and the file body is the finished bullet(s) starting
+     with "- ", written exactly as they should appear in the changelog.
+     Example: changelog.d/1832-inventory-devices-tab.added.md
+
+Both steps in ONE recipe (run from the repo root on your PR branch; the
+checkout line brings the tooling onto branches opened before this convention):
+
+    git fetch origin dev
+    git checkout origin/dev -- scripts/assemble-changelog.py changelog.d/README.md
+    python3 scripts/assemble-changelog.py --extract origin/dev --id <PR#>
+
+then review, commit the new changelog.d/ file(s) together with the restored
+CHANGELOG.md, and push.
+
+Full convention: changelog.d/README.md. CHANGELOG.md is rewritten only at
+release time by `python3 scripts/assemble-changelog.py promote X.Y.Z`."""
+
+
+def read_text(path: Path) -> str:
+    """Read a file as UTF-8, normalizing CRLF so Windows edits never leak \\r."""
+    return path.read_text(encoding="utf-8", errors="replace").replace("\r\n", "\n").replace("\r", "\n")
+
+
+def fragment_files(fragments_dir: Path) -> list[Path]:
+    if not fragments_dir.is_dir():
+        return []
+    return sorted(
+        p for p in fragments_dir.iterdir()
+        if p.is_file() and p.name not in ("README.md", ".gitkeep")
+    )
+
+
+def check_fragments(fragments_dir: Path) -> list[str]:
+    """Return lint errors for every fragment file (empty list = pass)."""
+    errors: list[str] = []
+    for path in fragment_files(fragments_dir):
+        rel = path.relative_to(REPO_ROOT) if path.is_relative_to(REPO_ROOT) else path
+        m = FRAGMENT_NAME_RE.match(path.name)
+        if not m:
+            errors.append(
+                f"{rel}: filename must match <id-or-slug>.<section>.md with"
+                " <section> one of added|changed|deprecated|removed|fixed|security"
+                " (e.g. 1832-inventory-devices-tab.added.md)"
+            )
+            continue
+        body = read_text(path).strip()
+        if not body:
+            errors.append(f"{rel}: fragment is empty — body must be the finished changelog bullet(s)")
+            continue
+        first = body.splitlines()[0]
+        if not first.startswith("- "):
+            errors.append(
+                f"{rel}: body must start with a markdown bullet ('- ') — write the"
+                " entry exactly as it should appear under its section in CHANGELOG.md"
+            )
+        for i, line in enumerate(body.splitlines(), start=1):
+            if ANY_VERSION_HEADER_RE.match(line) or SUBSECTION_RE.match(line):
+                errors.append(
+                    f"{rel}:{i}: fragment must not contain '##'/'###' headers —"
+                    " the section comes from the filename suffix"
+                )
+                break
+    return errors
+
+
+def parse_unreleased(lines: list[str]) -> tuple[int, int, list[str], list[tuple[str, list[str]]]]:
+    """Locate [Unreleased] and split its body.
+
+    Returns (header_idx, end_idx, preamble_lines, [(section_name, body_lines)]).
+    end_idx is the index of the next `## [` header (or len(lines)).
+    """
+    header_idx = next((i for i, l in enumerate(lines) if UNRELEASED_RE.match(l)), None)
+    if header_idx is None:
+        raise ValueError("CHANGELOG.md has no `## [Unreleased]` section")
+    end_idx = next(
+        (i for i in range(header_idx + 1, len(lines)) if ANY_VERSION_HEADER_RE.match(lines[i])),
+        len(lines),
+    )
+    preamble: list[str] = []
+    sections: list[tuple[str, list[str]]] = []
+    current: list[str] | None = None
+    for line in lines[header_idx + 1:end_idx]:
+        m = SUBSECTION_RE.match(line)
+        if m:
+            current = []
+            sections.append((m.group("name"), current))
+        elif current is None:
+            preamble.append(line)
+        else:
+            current.append(line)
+    return header_idx, end_idx, preamble, sections
+
+
+def normalized_section_content(text: str) -> str:
+    """The [Unreleased] subsection content of a CHANGELOG, normalized for compare.
+
+    Preamble prose (anything before the first `###`) is deliberately excluded:
+    it holds the standing do-not-edit note and may change without penalty.
+    Missing file / missing section normalize to "".
+    """
+    if not text:
+        return ""
+    try:
+        _, _, _, sections = parse_unreleased(text.split("\n"))
+    except ValueError:
+        return ""
+    out: list[str] = []
+    for name, body in sections:
+        out.append(f"### {name.strip().lower()}")
+        out.extend(l.rstrip() for l in body if l.strip())
+    return "\n".join(out)
+
+
+def git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=REPO_ROOT, check=True,
+        capture_output=True, text=True,
+    ).stdout
+
+
+def cmd_check(fragments_dir: Path) -> int:
+    errors = check_fragments(fragments_dir)
+    if errors:
+        for e in errors:
+            print(e, file=sys.stderr)
+        print(f"\nChangelog fragment lint FAILED ({len(errors)} issue(s)).", file=sys.stderr)
+        print(f"\n{HOW_TO_FIX}", file=sys.stderr)
+        return 1
+    n = len(fragment_files(fragments_dir))
+    print(f"Changelog fragment lint OK — {n} fragment(s)")
+    return 0
+
+
+def cmd_guard(base_sha: str, changelog: Path, fragments_dir: Path) -> int:
+    try:
+        old = git("show", f"{base_sha}:CHANGELOG.md")
+    except subprocess.CalledProcessError:
+        old = ""  # no CHANGELOG at base — nothing to guard
+    new = read_text(changelog) if changelog.is_file() else ""
+    if normalized_section_content(old) == normalized_section_content(new):
+        print("CHANGELOG guard OK — [Unreleased] section content unchanged")
+        return 0
+    deleted = git(
+        "diff", "--name-only", "--diff-filter=D", base_sha, "HEAD", "--",
+        str(fragments_dir.relative_to(REPO_ROOT)),
+    ).strip()
+    if deleted:
+        print(
+            "CHANGELOG guard OK — [Unreleased] changed but changelog.d/ fragments"
+            " were deleted in the same range (release promote)"
+        )
+        return 0
+    print(
+        "CHANGELOG guard FAILED: this PR edits the `## [Unreleased]` section of"
+        " CHANGELOG.md directly.\n\n"
+        "That section is a merge-conflict hotspot — every PR editing it conflicts"
+        " with whichever PR merges first, and the rebase push voids approvals."
+        " This repo therefore records unreleased changes as fragment files.\n\n"
+        f"{HOW_TO_FIX}",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def section_bullets(text: str) -> dict[str, list[str]]:
+    """Map canonical section name -> list of bullet blocks in [Unreleased].
+
+    A bullet block starts at a `- ` line and runs until the next `- ` line or
+    the end of the subsection, trailing blank lines stripped.
+    """
+    out: dict[str, list[str]] = {name: [] for name in CANONICAL_SECTIONS}
+    if not text:
+        return out
+    try:
+        _, _, _, sections = parse_unreleased(text.split("\n"))
+    except ValueError:
+        return out
+    for name, body in sections:
+        canon = name.strip().capitalize()
+        if canon not in out:
+            continue
+        current: list[str] | None = None
+        for line in body:
+            if line.startswith("- "):
+                if current:
+                    out[canon].append("\n".join(current).rstrip())
+                current = [line]
+            elif current is not None:
+                current.append(line)
+        if current:
+            out[canon].append("\n".join(current).rstrip())
+    return out
+
+
+def slugify(bullet: str, max_len: int = 40) -> str:
+    """First few words of a bullet -> kebab-case filename slug."""
+    text = re.sub(r"[`*_\[\]()#]", "", bullet.splitlines()[0].lstrip("- ").strip())
+    words = re.findall(r"[A-Za-z0-9]+", text.lower())
+    slug = ""
+    for w in words:
+        if slug and len(slug) + 1 + len(w) > max_len:
+            break
+        slug = f"{slug}-{w}" if slug else w
+    return slug or "entry"
+
+
+def cmd_extract(base_ref: str, pr_id: str, changelog: Path, fragments_dir: Path) -> int:
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", pr_id):
+        print(f"extract: --id '{pr_id}' must be a PR/issue number or plain slug token", file=sys.stderr)
+        return 2
+    try:
+        merge_base = git("merge-base", "HEAD", base_ref).strip()
+        base_text = git("show", f"{base_ref}:CHANGELOG.md")
+        mb_text = git("show", f"{merge_base}:CHANGELOG.md")
+    except subprocess.CalledProcessError as exc:
+        print(f"extract: git failed: {exc.stderr.strip()}", file=sys.stderr)
+        return 1
+    work_text = read_text(changelog)
+
+    mb_bullets = section_bullets(mb_text)
+    work_bullets = section_bullets(work_text)
+
+    def norm(b: str) -> str:
+        return " ".join(b.split())
+
+    wrote = 0
+    for section in CANONICAL_SECTIONS:
+        known = {norm(b) for b in mb_bullets[section]}
+        added = [b for b in work_bullets[section] if norm(b) not in known]
+        if not added:
+            continue
+        name = f"{pr_id}-{slugify(added[0])}.{section.lower()}.md"
+        path = fragments_dir / name
+        if path.exists():
+            print(f"extract: {path.relative_to(REPO_ROOT)} already exists — refusing to overwrite", file=sys.stderr)
+            return 1
+        fragments_dir.mkdir(exist_ok=True)
+        path.write_text("\n\n".join(added) + "\n", encoding="utf-8")
+        print(f"extract: wrote {path.relative_to(REPO_ROOT)} ({len(added)} bullet(s))")
+        wrote += 1
+        # Bullets this branch DELETED or REWORDED (present at merge-base,
+        # gone from the worktree) can't be represented as a fragment.
+        removed = [b for b in mb_bullets[section] if norm(b) not in {norm(x) for x in work_bullets[section]}]
+        for b in removed:
+            print(
+                f"extract: WARNING — [{section}] bullet present at merge-base but not on this"
+                f" branch (deleted or reworded?): {b.splitlines()[0][:80]}",
+                file=sys.stderr,
+            )
+
+    if wrote == 0:
+        print("extract: no added [Unreleased] bullets found relative to the merge-base — nothing to do", file=sys.stderr)
+        return 1
+
+    changelog.write_text(base_text, encoding="utf-8")
+    print(f"extract: restored CHANGELOG.md to {base_ref}'s version (now identical to the base branch)")
+    print("extract: review the fragments, then commit them together with CHANGELOG.md.")
+    errors = check_fragments(fragments_dir)
+    if errors:
+        for e in errors:
+            print(e, file=sys.stderr)
+        print("extract: WARNING — lint issues above; fix before pushing", file=sys.stderr)
+    return 0
+
+
+def cmd_promote(version: str, date_str: str | None, changelog: Path, fragments_dir: Path) -> int:
+    if not re.fullmatch(r"\d+\.\d+\.\d+", version):
+        print(f"promote: '{version}' is not a base semver (X.Y.Z — no leading 'v', no -rcN)", file=sys.stderr)
+        return 2
+    errors = check_fragments(fragments_dir)
+    if errors:
+        for e in errors:
+            print(e, file=sys.stderr)
+        print("\npromote aborted — fix the fragment lint errors above first.", file=sys.stderr)
+        return 1
+
+    text = read_text(changelog)
+    lines = text.split("\n")
+    if any(re.match(rf"^## \[{re.escape(version)}\]", l) for l in lines):
+        print(f"promote: CHANGELOG.md already has a ## [{version}] section", file=sys.stderr)
+        return 1
+    header_idx, end_idx, preamble, legacy_sections = parse_unreleased(lines)
+
+    # Ordered canonical map, seeded with legacy [Unreleased] subsection bodies.
+    merged: dict[str, list[str]] = {name: [] for name in CANONICAL_SECTIONS}
+    extras: list[tuple[str, list[str]]] = []
+    for name, body in legacy_sections:
+        canon = name.strip().capitalize()
+        chunk = [l for l in body]
+        # trim leading/trailing blank lines per chunk
+        while chunk and not chunk[0].strip():
+            chunk.pop(0)
+        while chunk and not chunk[-1].strip():
+            chunk.pop()
+        if not chunk:
+            continue
+        if canon in merged:
+            merged[canon].extend(chunk + [""])
+        else:
+            extras.append((name.strip(), chunk))
+
+    frags = fragment_files(fragments_dir)
+    for path in frags:
+        section = CANONICAL_SECTIONS[SECTION_KEYS.index(FRAGMENT_NAME_RE.match(path.name).group("section"))]
+        merged[section].extend(read_text(path).strip().split("\n") + [""])
+
+    if not frags and all(not v for v in merged.values()) and not extras:
+        print("promote: nothing to promote — no fragments and no legacy [Unreleased] content", file=sys.stderr)
+        return 1
+
+    date = date_str or _dt.date.today().isoformat()
+    new_section: list[str] = [f"## [{version}] - {date}", ""]
+    for name in CANONICAL_SECTIONS:
+        if merged[name]:
+            new_section.append(f"### {name}")
+            new_section.append("")
+            body = merged[name]
+            while body and not body[-1].strip():
+                body.pop()
+            new_section.extend(body)
+            new_section.append("")
+    for name, chunk in extras:
+        print(f"promote: WARNING — non-canonical [Unreleased] subsection '### {name}' carried over verbatim", file=sys.stderr)
+        new_section.extend([f"### {name}", ""] + chunk + [""])
+
+    while preamble and not preamble[-1].strip():
+        preamble.pop()
+    while preamble and not preamble[0].strip():
+        preamble.pop(0)
+    rebuilt = (
+        lines[:header_idx + 1]
+        + ([""] + preamble if preamble else [])
+        + [""]
+        + new_section
+        + lines[end_idx:]
+    )
+    changelog.write_text("\n".join(rebuilt), encoding="utf-8")
+
+    for path in frags:
+        path.unlink()
+        print(f"promote: deleted {path.relative_to(REPO_ROOT) if path.is_relative_to(REPO_ROOT) else path}")
+    print(
+        f"promote: assembled {len(frags)} fragment(s)"
+        f"{' + legacy [Unreleased] content' if legacy_sections else ''}"
+        f" into ## [{version}] - {date}"
+    )
+    print("promote: review the diff, then commit CHANGELOG.md and the deleted fragments together.")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--changelog", type=Path, default=REPO_ROOT / "CHANGELOG.md", help=argparse.SUPPRESS)
+    parser.add_argument("--fragments-dir", type=Path, default=REPO_ROOT / "changelog.d", help=argparse.SUPPRESS)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--check", action="store_true", help="lint changelog.d/ fragments")
+    group.add_argument("--guard", metavar="BASE_SHA", help="fail on direct [Unreleased] edits vs BASE_SHA (CI)")
+    group.add_argument("--extract", metavar="BASE_REF", help="convert this branch's direct [Unreleased] edits into fragments (requires --id)")
+    group.add_argument("promote", nargs="?", metavar="promote", help="'promote' — assemble fragments into a release section")
+    parser.add_argument("version", nargs="?", help="X.Y.Z (promote mode)")
+    parser.add_argument("--date", help="override release date (YYYY-MM-DD, promote mode)")
+    parser.add_argument("--id", help="PR or issue number for the fragment filename (extract mode)")
+    args = parser.parse_args(argv[1:])
+
+    if args.check:
+        return cmd_check(args.fragments_dir)
+    if args.guard:
+        return cmd_guard(args.guard, args.changelog, args.fragments_dir)
+    if args.extract:
+        if not args.id:
+            parser.error("--extract requires --id <PR-or-issue-number>")
+        return cmd_extract(args.extract, args.id, args.changelog, args.fragments_dir)
+    if args.promote != "promote" or not args.version:
+        parser.error("usage: assemble-changelog.py promote <X.Y.Z> [--date YYYY-MM-DD]")
+    return cmd_promote(args.version, args.date, args.changelog, args.fragments_dir)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/hooks/changelog-fragment-guard.py
+++ b/scripts/hooks/changelog-fragment-guard.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+changelog-fragment-guard.py -- PreToolUse hook: deny direct CHANGELOG.md edits.
+
+This repo records unreleased changes as one-file-per-change fragments under
+changelog.d/ (see changelog.d/README.md). Direct edits to CHANGELOG.md's
+[Unreleased] section made every second PR conflict — two PRs inserting bullets
+at the same line can never auto-merge — and the conflict-resolution push voided
+the PR's approvals (dev ruleset: require_last_push_approval). The fix is
+structural: PRs create uniquely-named fragment files that cannot conflict, and
+CHANGELOG.md is only rewritten at release time by
+`python3 scripts/assemble-changelog.py promote X.Y.Z` (a Bash call, so this
+hook never blocks the release promote).
+
+Wired via .claude/settings.json -> hooks.PreToolUse (matcher Edit|Write|
+MultiEdit|NotebookEdit). Reads the PreToolUse JSON on stdin; when the target
+file is CHANGELOG.md it denies the tool call with a reason that tells the
+agent exactly what to do instead. The docs-lint `Changelog fragments` CI job
+is the server-side backstop for sessions without hooks.
+
+Design (matches erl-dialyzer-reminder.py conventions):
+  - Fail-open: ANY error -> allow the call (no output, exit 0). A convention
+    hook must never wedge a session.
+  - UTF-8 explicit on stdin (never inherit cp1252 on Windows; see memory
+    reference_hookify_ascii_only).
+  - ALWAYS exit 0; the decision is carried in the JSON, not the exit code.
+"""
+import json
+import os
+import sys
+
+EDIT_TOOLS = ("Edit", "Write", "MultiEdit", "NotebookEdit")
+
+REASON = """\
+Direct edits to CHANGELOG.md are disabled in this repo: every PR that touched
+the [Unreleased] section conflicted with whichever PR merged first, and the
+rebase push voided the PR's approvals.
+
+Do this instead -- add ONE new file (fragments can never conflict):
+
+    changelog.d/<PR-or-issue-number>-<short-slug>.<section>.md
+    <section> = added | changed | deprecated | removed | fixed | security
+
+The file body is the finished changelog bullet(s), starting with "- ", written
+exactly as they should appear under "### Added" (etc.) in CHANGELOG.md.
+Example: changelog.d/1832-inventory-devices-tab.added.md
+
+If this branch ALREADY has direct CHANGELOG.md edits (e.g. a PR opened before
+this convention), this recipe converts them to fragments and restores the file:
+
+    git fetch origin dev
+    git checkout origin/dev -- scripts/assemble-changelog.py changelog.d/README.md
+    python3 scripts/assemble-changelog.py --extract origin/dev --id <PR#>
+
+Full convention: changelog.d/README.md. CHANGELOG.md is rewritten only at
+release time via `python3 scripts/assemble-changelog.py promote X.Y.Z` (run it
+with Bash -- this guard only covers the file-edit tools). Fixing a typo in an
+already-released section is rare and operator-owned: ask the user, who can
+approve a Bash-based edit or make it themselves."""
+
+
+def main():
+    # Read stdin as UTF-8 bytes -> json (never trust locale/cp1252).
+    try:
+        raw = sys.stdin.buffer.read()
+        data = json.loads(raw.decode("utf-8", errors="replace")) if raw else {}
+    except Exception:
+        return  # fail-open
+
+    if data.get("tool_name") not in EDIT_TOOLS:
+        return
+    tool_input = data.get("tool_input") or {}
+    file_path = str(tool_input.get("file_path") or tool_input.get("notebook_path") or "")
+    if os.path.basename(file_path) != "CHANGELOG.md":
+        return
+
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": REASON,
+        }
+    }))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        sys.exit(0)  # ALWAYS exit 0 -- decision is in the JSON, never the exit code

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -47,6 +47,17 @@ else
     fail "Changelog extraction produced empty output"
 fi
 
+# ── 4b. No unpromoted changelog fragments ─────────────────────────────────
+# PRs land changelog entries as changelog.d/ fragment files; the promote step
+# (scripts/assemble-changelog.py promote X.Y.Z) must have folded them all into
+# the ## [X.Y.Z] section before tagging. See changelog.d/README.md.
+FRAG_COUNT=$(find changelog.d -maxdepth 1 -name '*.md' ! -name 'README.md' 2>/dev/null | wc -l | tr -d ' ')
+if [ "$FRAG_COUNT" -eq 0 ]; then
+    pass "changelog.d/ has no unpromoted fragments"
+else
+    fail "changelog.d/ has $FRAG_COUNT unpromoted fragment(s) — run: python3 scripts/assemble-changelog.py promote $BASE_VERSION"
+fi
+
 # ── 5. Clean working tree ─────────────────────────────────────────────────
 if git diff --quiet HEAD && git diff --cached --quiet; then
     pass "Working tree clean (no uncommitted changes)"


### PR DESCRIPTION
## Summary

Kills the standing CHANGELOG.md friction: every PR that edited the `[Unreleased]` section conflicted with whichever PR merged first, and the conflict-resolution push voided the PR's approvals (`require_last_push_approval`). This PR replaces direct edits with **one uniquely-named fragment file per change** under `changelog.d/` — new files can never conflict, so the rebase→re-approve loop is gone structurally.

## How it works

- **PRs** add `changelog.d/<PR#>-<slug>.<section>.md` (`added|changed|deprecated|removed|fixed|security`; body = the finished bullet, same prose style as today). Convention + explicit AI-agent guidance: `changelog.d/README.md`.
- **Release** runs `python3 scripts/assemble-changelog.py promote X.Y.Z` — merges any legacy `[Unreleased]` content plus all fragments into `## [X.Y.Z] - <date>`, resets `[Unreleased]`, deletes the fragments. Downstream is untouched: `release.yml`'s awk extraction, release notes, and the `CHANGELOG order` required check all see the same file shape as today. Preflight check 4b blocks tagging while unpromoted fragments remain.
- **Enforcement in depth** (aimed at contributors who work entirely through Claude Code):
  1. Committed PreToolUse hook (`scripts/hooks/changelog-fragment-guard.py`) denies direct CHANGELOG.md edits in-session, with instructions the agent can follow immediately. Fail-open, always exit 0, same conventions as the dialyzer hook.
  2. New `Changelog fragments` docs-lint job: lints fragment files on every PR/push; on PRs, fails if the diff changes `[Unreleased]` *section content* vs `base.sha`. Preamble-prose edits and the release promote (CHANGELOG change + fragment deletions in the same diff) are recognised and allowed. Failure text is written as agent-executable instructions.
  3. Convention pointers where agents/humans look: CLAUDE.md section, one-time do-not-edit note under `## [Unreleased]`, CONTRIBUTING.md, PR-template checklist item, docs-writer gate-2 requirement, /release skill promote step.
- **Backlog migration**: `--extract` mode converts a pre-convention branch in one recipe — moves the branch's `[Unreleased]` additions (vs merge-base) into correctly-named fragments and restores CHANGELOG.md to dev's exact version, making CHANGELOG conflicts impossible from then on. All 7 currently-open PRs (#1862 #1858 #1855 #1851 #1843 #1831 #1826) touch CHANGELOG.md; each converts with the recipe in `changelog.d/README.md` §"Converting a branch".

## Testing

- `--check` / `--guard` / `promote` / `--extract` exercised in scratch git repos: 5 guard scenarios (direct edit ✗, preamble-only ✓, promote ✓, unrelated ✓, released-section typo fix ✓); promote verified against a copy of the real CHANGELOG (order test + release.yml awk extraction pass; duplicate-version guard fires); full pre-convention-branch conversion recipe verified end-to-end (tooling checkout → extract → commit → clean merge → guard+lint pass).
- The PreToolUse hook went live mid-session and **denied the authoring session's own CHANGELOG.md edit** — the exact contributor experience, verified organically.
- This PR dogfoods itself: ships its own fragment and passes its own guard (the CHANGELOG note is a preamble-only change, deliberately permitted).

## Follow-ups (not in this PR)

- After the 7 open PRs convert or merge: add `Changelog fragments` to the dev ruleset's required checks (only `CHANGELOG order` is required today).
- Post the conversion comment on the 7 open PRs once this merges.
- CLAUDE.md is over its own 40k budget **upstream** (40,239 before this PR; +253 here) — needs a separate slim pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)