### PR TITLE
fix(pg): CI bug fix - harden [pg] tests against transient CI connect blips

### DIFF
--- a/tests/unit/server/test_pg_hardening.cpp
+++ b/tests/unit/server/test_pg_hardening.cpp
@@ -41,6 +41,31 @@ std::string setting(PGconn* conn, const char* name) {
     return PQgetvalue(r.get(), 0, 0);
 }
 
+// A PgPool connects lazily on the first acquire() (pg/pg_pool.hpp lazy-connect
+// design); valid() only proves the DSN parsed and carries no connectivity
+// guarantee. On a shared CI Postgres cluster a transient connect blip
+// (max_connections pressure, loopback refusal) makes that first acquire() return
+// an empty lease and arm the connect breaker (~200ms..5s), which then fails fast
+// the next attempt. For tests whose subject is pool SEMANTICS — not connect
+// reliability — ride out a transient blip with a bounded retry; on final failure
+// surface the real libpq reason (pool.last_error()) so a genuine outage is
+// self-explaining instead of a bare empty-lease assertion. Deliberate-failure
+// tests (unreachable endpoint, throwing observer) keep the raw acquire(). (#1961)
+[[nodiscard]] PgPool::Lease acquire_or_explain(PgPool& pool,
+                                               std::chrono::seconds budget = 10s) {
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    PgPool::Lease lease = pool.acquire();
+    while (!lease && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(250ms); // let the connect-breaker window lapse
+        lease = pool.acquire();
+    }
+    if (!lease)
+        UNSCOPED_INFO("PgPool::acquire failed after ~"
+                      << budget.count() << "s of retries — last_error: " << pool.last_error()
+                      << " (connect_breaker_open=" << pool.connect_breaker_open() << ")");
+    return lease;
+}
+
 } // namespace
 
 TEST_CASE("PgPool injects statement_timeout and lock_timeout GUCs", "[pg][hardening]") {
@@ -50,7 +75,7 @@ TEST_CASE("PgPool injects statement_timeout and lock_timeout GUCs", "[pg][harden
                  .statement_timeout_ms = 7000,
                  .lock_timeout_ms = 3000}};
     REQUIRE(pool.valid());
-    auto lease = pool.acquire();
+    auto lease = acquire_or_explain(pool);
     REQUIRE(static_cast<bool>(lease));
     // Postgres renders integer-ms settings in a human unit.
     CHECK(setting(lease.get(), "statement_timeout") == "7s");
@@ -61,7 +86,7 @@ TEST_CASE("PgPool injects TCP keepalives", "[pg][hardening]") {
     YUZU_REQUIRE_PG_DB(db);
     PgPool pool{{.conninfo = db.dsn(), .size = 1, .keepalives_idle_s = 45}};
     REQUIRE(pool.valid());
-    auto lease = pool.acquire();
+    auto lease = acquire_or_explain(pool);
     REQUIRE(static_cast<bool>(lease));
     // libpq exposes the negotiated keepalive via PQparameterStatus only for
     // server params; assert the connection is live (keepalive is a socket
@@ -118,8 +143,8 @@ TEST_CASE("PgPool acquire-wait observer fires on a successful checkout", "[pg][h
     };
     PgPool pool{std::move(opts)};
     REQUIRE(pool.valid());
-    { auto l = pool.acquire(); REQUIRE(static_cast<bool>(l)); }
-    { auto l = pool.acquire(); REQUIRE(static_cast<bool>(l)); }
+    { auto l = acquire_or_explain(pool); REQUIRE(static_cast<bool>(l)); }
+    { auto l = acquire_or_explain(pool); REQUIRE(static_cast<bool>(l)); }
     CHECK(waits.load() == 2);
     // A reachable database never arms the breaker, so /readyz stays ready even
     // while the pool is busy (gov UP-2: saturation must not evict a healthy
@@ -158,15 +183,36 @@ TEST_CASE("CH-9: pool dtor waits for an outstanding lease, no deadlock", "[pg][c
         auto pool = std::make_unique<PgPool>(PgPool::Options{.conninfo = db.dsn(), .size = 2});
         REQUIRE(pool->valid());
         std::atomic<bool> released{false};
+        std::atomic<bool> holding{false};
         std::thread holder([&] {
-            auto lease = pool->acquire(); // holds a connection...
-            REQUIRE(static_cast<bool>(lease));
-            std::this_thread::sleep_for(200ms); // ...then returns it
-            released.store(true);
+            // Assertions stay on the MAIN thread — Catch2 macros are not
+            // thread-safe; the holder only SIGNALS state through atomics.
+            auto lease = acquire_or_explain(*pool);
+            if (lease) {
+                holding.store(true);                // lease is now HELD...
+                std::this_thread::sleep_for(200ms); // ...across the reset()...
+                released.store(true);               // ...then returns at scope exit
+            }
         });
-        std::this_thread::sleep_for(50ms); // ensure the holder has the lease
-        pool.reset();                      // dtor blocks until the lease returns
-        holder.join();
+        // Barrier, NOT a bare sleep: destroy the pool only once the holder
+        // genuinely HOLDS a lease. A fixed sleep raced two ways — if
+        // acquire_or_explain retried past a transient connect blip, or the holder
+        // thread merely scheduled late, the pool could be reset while the holder
+        // holds NO lease and is about to call acquire() again: a use-after-free on
+        // the freed pool. Waiting on `holding` guarantees leased_==1 at reset time,
+        // which is the exact precondition CH-9 exists to test. Cap the wait above
+        // acquire_or_explain's 10s budget but under the 15s watchdog; the fixture
+        // connect-probe makes a genuine miss almost impossible. WALL-CLOCK bounded,
+        // never an iteration count: on Windows the ~15.6ms default timer resolution
+        // stretches each 5ms sleep, so an N-iteration loop would overrun the
+        // watchdog (the MSVC steady_clock-granularity class behind flake #473).
+        const auto barrier_end = std::chrono::steady_clock::now() + 12s;
+        while (!holding.load() && std::chrono::steady_clock::now() < barrier_end)
+            std::this_thread::sleep_for(5ms);
+        if (holding.load())
+            pool.reset();          // lease held → the dtor MUST block until it returns
+        holder.join();             // always join before scope exit — never a dangling thread
+        REQUIRE(holding.load());   // (main-thread assert) the holder did hold a lease
         CHECK(released.load());
     });
     // Watchdog: a correct pool completes well under the deadline; a deadlock

--- a/tests/unit/test_helpers.hpp
+++ b/tests/unit/test_helpers.hpp
@@ -36,7 +36,9 @@
 #include <string_view>
 
 #if defined(YUZU_TEST_ENABLE_PG)
+#include <chrono>
 #include <format>
+#include <thread>
 
 #include <libpq-fe.h>
 
@@ -190,6 +192,34 @@ public:
             error_ = "could not parse YUZU_TEST_POSTGRES_DSN to rewrite dbname";
             return;
         }
+
+        // Post-create connectivity probe (#1961): CREATE DATABASE on the admin
+        // connection proves the database EXISTS, not that the cluster will accept a
+        // FRESH connection to it at the moment a pool later connects. PgPool
+        // connects lazily on first acquire() and valid() only proves the DSN parsed
+        // (pg/pg_pool.hpp), so a transient create-then-connect gap on a shared CI
+        // cluster — max_connections pressure, a loopback refusal — surfaces far
+        // downstream as an empty lease in whichever [pg] test happened to run,
+        // reported without a reason. Prove connectability HERE, with a brief retry,
+        // so available() means CONNECTABLE (not merely CREATED) and a genuine outage
+        // fails this fixture with the real libpq reason.
+        {
+            std::string probe_err;
+            const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+            for (;;) {
+                yuzu::server::pg::PgConn probe{PQconnectdb(dsn_.c_str())};
+                if (PQstatus(probe.get()) == CONNECTION_OK)
+                    break;
+                probe_err = PQerrorMessage(probe.get());
+                if (std::chrono::steady_clock::now() >= deadline) {
+                    error_ = "post-create connect probe failed: " +
+                             (probe_err.empty() ? std::string("unknown error") : probe_err);
+                    return;
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            }
+        }
+
         available_ = true;
     }
 
@@ -298,7 +328,7 @@ private:
         SKIP("YUZU_TEST_POSTGRES_DSN not set - Postgres test skipped");                            \
     }                                                                                              \
     yuzu::test::PostgresTestDb var;                                                                \
-    INFO("PostgresTestDb: " << var.error());                                                       \
+    INFO("[YUZU_REQUIRE_PG_DB] fixture status (blank == database came up OK): " << var.error());   \
     REQUIRE(var.available())
 
 #endif // YUZU_TEST_ENABLE_PG


### PR DESCRIPTION
Fixes #1961. Surfaced during CI on #1960 (an unrelated guardian PR), where the `Windows MSVC debug` leg flaked on this test and a plain re-run went green.

## Root cause (not a pool bug — a test assumption)

`PgPool` connects **lazily on first `acquire()`**; its constructor only parses the DSN, and `valid()` returns true when the DSN *parsed* — it carries **no connectivity guarantee** (documented design, `pg/pg_pool.hpp`). So `valid()==true` followed by a first `acquire()` returning an empty lease is expected whenever `connect_one()` hits a transient libpq connect failure — most plausibly `max_connections` pressure or a loopback-TCP blip on the **shared** Windows CI Postgres cluster running ~1200 test cases, each spinning up an ephemeral DB. The failed connect arms the connect breaker, so the next attempt fails fast too.

CH-9's subject is the pool **destructor waiting for an outstanding lease** — connect reliability is orthogonal noise to it, yet a single transient blip failed its `REQUIRE(static_cast<bool>(lease))`. And the failure was **undiagnosable**: the real libpq reason *is* captured in `pool.last_error()` and logged, but the bare `REQUIRE` never printed it; the only surviving diagnostic was the fixture's `INFO`, which showed an empty `PostgresTestDb:` — empty *because the fixture had succeeded*, a pure red herring.

**Production `PgPool` is correct and is not touched. This change is test-only.**

## Fix

1. **Fixture connect-probe** (`test_helpers.hpp`, `PostgresTestDb`). After `CREATE DATABASE`, probe one throwaway connection to the ephemeral `dsn()` (brief retry, 5s budget) before setting `available_`. Now `available()` means **connectable**, not merely **created** — closing the create-then-connect gap for *every* `[pg]` test. A genuine failure fails the fixture with the real `PQerrorMessage` instead of an empty acquire assertion downstream.

2. **Bounded acquire-retry** (`test_pg_hardening.cpp`, `acquire_or_explain`). A small helper that rides out a transient connect blip (retry past the breaker's ~200ms–5s window, 10s budget) at the acquire sites whose subject is pool *semantics* (the GUC/keepalive/observer tests and CH-9). On final failure it surfaces `pool.last_error()` + breaker state via `UNSCOPED_INFO`. **Deliberate-failure tests keep the raw `acquire()`** — the unreachable-endpoint breaker test and the throwing-observer test still assert the empty/throwing lease.

3. **De-confused fixture INFO** (`YUZU_REQUIRE_PG_DB`). The `INFO` now reads `[YUZU_REQUIRE_PG_DB] fixture status (blank == database came up OK): …`, so a later assertion failure in a `[pg]` test no longer shows a misleading bare `PostgresTestDb:`.

4. **CH-9 restructured** to close a lifetime hazard a naive retry wrapper would open (caught in adversarial review of this very change — see below). The old test gated `pool.reset()` on a bare 50ms sleep; with a retrying acquire, a blip could let the main thread free the pool while the holder held no lease and was about to call `acquire()` again — a use-after-free. The holder now signals a **lease-held atomic** (and all Catch2 assertions moved to the main thread, removing a pre-existing cross-thread `REQUIRE`), and the main thread waits on a **wall-clock-bounded** barrier for that signal before `reset()`. This guarantees `leased_==1` at destroy time — the exact property CH-9 tests — with no UAF and no watchdog overrun from Windows timer granularity.

## Verification

Adversarially reviewed, and the review earned its keep — it caught a use-after-free that the first cut of this change introduced (retry-in-holder-thread racing `pool.reset()`), which the empirical run could not surface (local Postgres never blipped, so the retry body never ran). A follow-up pass then caught a Windows timer-granularity bug in the barrier (`N × 5ms` ≈ 37s on Windows, overrunning the watchdog). Both fixed and re-verified closed.

Exercised against a **real Postgres 16** locally (Docker `postgres:16`, `YUZU_TEST_POSTGRES_DSN` set), which this dev box normally skips:
- **Full `[pg]` suite: 2385 assertions in 138 cases, all pass** — including CH-9 (now via the handshake + retry), the GUC/keepalive/observer hardening tests, and the new fixture connect-probe on every one of the 138 cases.
- **CH-9 stress: 35× green** across two runs.
- **Full server suite** (non-pg regression + pg-for-real): 3256 cases / 50187 assertions green.
- Compiles clean under MSVC (`-Dbuild_tests=true`, `YUZU_TEST_ENABLE_PG`).

Because this is a *flaky* test, CI going green can't by itself *prove* the flake gone — which is exactly why the diagnosability piece is included: the next occurrence (if any) will carry the real libpq reason instead of an empty message.

## Cost

The fixture probe adds one throwaway connect round-trip per `[pg]` test (~138), a small and deliberate reliability cost for making `available()` mean connectable.
