### PR TITLE
ci: satisfy required matrix checks on docs-only PRs via stubs (#1978)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,15 @@ on:
       - '.github/workflows/runner-inventory-sentinel.yml'
   pull_request:
     branches: [main, dev]
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.github/runner-inventory.json'
-      - '.github/workflows/runner-inventory-sentinel.yml'
+    # No paths-ignore here (issue #1978). Filtering this whole workflow out
+    # for docs-only PRs left the required contexts (Preflight, Proto
+    # backward-compat, Linux/Windows/macOS debug) permanently "Expected —
+    # waiting for status", so a non-admin could never merge a docs-only PR
+    # (they had to be admin-bypassed). Instead the workflow always runs and
+    # the `preflight` job's `code_changed` output gates the heavy build jobs:
+    # a docs-only PR skips them, and a *skipped* required check is satisfied
+    # whereas an *absent* one is not. The `push:` trigger above keeps its
+    # paths-ignore — post-merge docs pushes need no build and gate nothing.
   workflow_dispatch:
 
 # Scorecard Token-Permissions hardening: ci.yml builds and tests only —
@@ -95,6 +97,12 @@ jobs:
     name: "Preflight (runner health)"
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    # Job-level permissions REPLACE the workflow default (contents: read), so
+    # both are listed. pull-requests: read is required by the code-vs-docs gate
+    # below, which lists the PR's changed files via the REST API (issue #1978).
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       # Pool gate for the [self-hosted, Linux, X64] jobs (proto-compat, linux):
       # true iff >=1 eligible Linux runner (any yuzu-bigtam-* OR the yuzu-wsl2-linux
@@ -110,6 +118,12 @@ jobs:
       yuzu_wsl2_linux_healthy: ${{ steps.health.outputs.yuzu_wsl2_linux_healthy }}
       yuzu_local_windows_healthy: ${{ steps.health.outputs.yuzu_local_windows_healthy }}
       all_healthy: ${{ steps.health.outputs.all_healthy }}
+      # code_changed (issue #1978): false iff every changed file in a PR is in
+      # the docs/ignore set the pull_request trigger used to carry. Gates the
+      # heavy build jobs (proto-compat, linux, windows, macos) so a docs-only
+      # PR skips them instead of blocking forever on absent required checks.
+      # Always true for non-PR events (push / workflow_dispatch build always).
+      code_changed: ${{ steps.codegate.outputs.code_changed }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -124,7 +138,54 @@ jobs:
       # otherwise only runs at release time, so a regex regression would surface
       # too late (after the full build matrix). No build deps — just bash.
       - name: Shell gate tests
-        run: bash tests/shell/test_check_compose_versions.sh
+        run: |
+          bash tests/shell/test_check_compose_versions.sh
+          bash tests/shell/test_detect_code_change.sh   # docs-only gate classifier (#1978)
+
+      # ── Docs-only vs code gate (issue #1978) ───────────────────────────
+      # Decide whether the heavy build matrix runs for this PR. The
+      # classification (which paths count as docs-only, the 3000-file API-cap
+      # truncation guard) lives in scripts/ci/detect-code-change.sh and is
+      # covered by tests/shell/test_detect_code_change.sh. Fail-closed
+      # throughout: a non-PR event, an API/permission failure, an empty list,
+      # or a truncated list all build rather than silently skip.
+      - name: Determine code-vs-docs change set (docs-only gate)
+        id: codegate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "code_changed=true" >> "$GITHUB_OUTPUT"
+            echo "Non-PR event (${{ github.event_name }}) — building unconditionally."
+            exit 0
+          fi
+          # Fail-closed on any API/permission failure: build rather than block.
+          if ! files=$(gh api --paginate \
+                "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+                --jq '.[].filename'); then
+            echo "code_changed=true" >> "$GITHUB_OUTPUT"
+            echo "PR files API failed — building to be safe (fail-closed)."
+            exit 0
+          fi
+          echo "Changed files in PR #${{ github.event.pull_request.number }}:"
+          printf '%s\n' "$files"
+          if [[ -z "$files" ]]; then
+            echo "code_changed=true" >> "$GITHUB_OUTPUT"
+            echo "Empty changed-file list — building to be safe (fail-closed)."
+            exit 0
+          fi
+          # changed_files is the authoritative total; the script fails closed if
+          # the API list is shorter (truncated past the 3000-file cap). Wrap the
+          # call so a classifier error fails toward BUILD (never toward a blocked
+          # PR), independent of the runner's default shell error mode.
+          if ! code_changed=$(printf '%s\n' "$files" \
+                | bash scripts/ci/detect-code-change.sh "${{ github.event.pull_request.changed_files }}"); then
+            echo "code_changed=true" >> "$GITHUB_OUTPUT"
+            echo "Classifier errored — building to be safe (fail-closed)."
+            exit 0
+          fi
+          echo "code_changed=$code_changed" >> "$GITHUB_OUTPUT"
+          echo "Result: code_changed=$code_changed"
 
   # ── Lint (disabled — clang-format reorders Windows headers and breaks MSVC builds) ──
   # lint:
@@ -149,7 +210,9 @@ jobs:
     needs: [preflight]
     # Pool gate: runs if any [self-hosted, Linux, X64] runner is online
     # (yuzu-bigtam-* or the Shulgi fallback). Fail-closed `== 'true'`.
-    if: needs.preflight.outputs.linux_pool_healthy == 'true'
+    # `&& code_changed` (issue #1978): a docs-only PR skips this required job
+    # (skipped == satisfied), so it no longer blocks the merge on an absent check.
+    if: needs.preflight.outputs.linux_pool_healthy == 'true' && needs.preflight.outputs.code_changed == 'true'
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 5
     steps:
@@ -175,7 +238,8 @@ jobs:
     # bigtam_pool_healthy (>=1 yuzu-bigtam-linux runner online) rather than the
     # broader linux_pool. Fail-closed `== 'true'` (NOT `!= 'false'`) — an offline
     # Big Tam skips this job fast instead of queueing against an empty pool.
-    if: needs.preflight.outputs.bigtam_pool_healthy == 'true'
+    # `&& code_changed` (issue #1978): docs-only PRs skip this required job.
+    if: needs.preflight.outputs.bigtam_pool_healthy == 'true' && needs.preflight.outputs.code_changed == 'true'
     # Self-hosted: Big Tam (Threadripper 9970X, native Ubuntu 26.04). Persistent
     # ccache + vcpkg state between runs on the same workspace amortizes the
     # install cost. Trade-off: the runner process serializes this matrix, so
@@ -480,7 +544,8 @@ jobs:
     # Skip if the self-hosted Windows job pool is unhealthy/empty. Fail-closed
     # `== 'true'`. Pool-gated (yuzu-weetam-windows-* or the yuzu-local-windows
     # Shulgi fallback) — mirrors the Linux pool gate.
-    if: needs.preflight.outputs.windows_pool_healthy == 'true'
+    # `&& code_changed` (issue #1978): docs-only PRs skip this required job.
+    if: needs.preflight.outputs.windows_pool_healthy == 'true' && needs.preflight.outputs.code_changed == 'true'
     # Self-hosted: 32-core / 48 GB host. gRPC alone takes ~90 min on the
     # GitHub-hosted 4-vCPU windows-2022 runners; self-hosted with cl /MP
     # finishes in a fraction of that and avoids the GitHub Actions minute
@@ -780,6 +845,11 @@ jobs:
   # ── macOS (Apple Clang) ────────────────────────────────────────────────
   macos:
     name: "macOS ${{ matrix.build_type }}"
+    needs: [preflight]
+    # code_changed (issue #1978): docs-only PRs skip this required job
+    # (skipped == satisfied). No self-hosted pool gate — GitHub-hosted — so
+    # it otherwise runs on every code PR.
+    if: needs.preflight.outputs.code_changed == 'true'
     runs-on: macos-15  # Apple Silicon, Xcode 16 / Apple Clang 16
     timeout-minutes: 90
     strategy:
@@ -972,6 +1042,50 @@ jobs:
         with:
           path: ${{ github.workspace }}/vcpkg_installed
           key: ${{ steps.cache-vcpkg-macos.outputs.cache-primary-key }}
+
+  # ── Docs-only required-check stubs (issue #1978) ──────────────────────
+  # The linux/windows/macos required contexts are MATRIX-expanded names
+  # ("Linux gcc-15 debug", "Windows MSVC debug", "macOS debug"). A matrix job
+  # skipped at the job level is skipped BEFORE the matrix expands, so it emits
+  # none of its inner check-run names (actions/runner#952). Gating the real
+  # jobs on code_changed therefore leaves those required contexts "Expected —
+  # waiting" forever on a docs-only PR — the exact hang #1978 must avoid.
+  #
+  # This job emits those exact names as `success` when, and only when, the real
+  # matrix jobs are skipped for a docs-only PR. It is itself a matrix job, so
+  # the SAME runner#952 behaviour makes it collision-free: on a code PR it is
+  # skipped before expansion and emits nothing, leaving the real job as the
+  # sole producer of each name. Exactly one producer per required name per run
+  # (real job on code PRs, this stub on docs-only PRs) — no duplicate/masking.
+  #
+  # proto-compat is a NON-matrix job: its skipped run reports "Proto
+  # backward-compat: skipped", which already satisfies the required check, so
+  # it needs no stub. preflight always runs; "CHANGELOG order" (docs-lint.yml)
+  # runs on every PR. Together that satisfies all six required contexts on a
+  # docs-only PR without a build.
+  docs-required-checks:
+    name: ${{ matrix.check }}
+    needs: [preflight]
+    if: needs.preflight.outputs.code_changed == 'false'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        # MUST stay byte-identical to the matrix-expanded names the real jobs
+        # produce on a PR and that the dev ruleset requires. If a real job's
+        # name template or its PR matrix leg changes, update these in lockstep.
+        check:
+          - "Linux gcc-15 debug"
+          - "Windows MSVC debug"
+          - "macOS debug"
+    steps:
+      - name: Satisfy required check (docs-only PR — no build)
+        run: |
+          echo "Docs-only PR (#1978): '${{ matrix.check }}' is not built."
+          echo "This stub emits the required check name as success so the PR is"
+          echo "not blocked on an absent matrix context. Any PR that touches"
+          echo "code runs the real '${{ matrix.check }}' build instead."
 
   # ── CI canary (PR-8 of overhaul plan) ─────────────────────────────────
   # Detects whether a PR (or a push to main) touches CI infrastructure

--- a/docs/ci-architecture.md
+++ b/docs/ci-architecture.md
@@ -122,6 +122,16 @@ stalled runner. Requires the `RUNNER_INVENTORY_TOKEN` PAT secret
 (fine-grained, Administration:read on Tr3kkR/Yuzu); without it preflight
 returns false and self-hosted jobs are skipped with a clear reason.
 
+As of #1978, preflight also emits a `code_changed` output (from
+`scripts/ci/detect-code-change.sh`); the build jobs additionally gate on
+`&& code_changed == 'true'`, so a docs-only PR skips the whole matrix. The
+matrix-expanded required contexts (`Linux gcc-15 debug`, `Windows MSVC debug`,
+`macOS debug`) would otherwise stay "Expected" forever on a docs-only PR
+(a top-level-skipped matrix job emits none of its inner check names), so a
+`docs-required-checks` stub emits those exact names as success when
+`code_changed == 'false'`. `ci.yml` no longer path-filters `pull_request`;
+the `push:` trigger keeps its docs `paths-ignore`.
+
 ## Postgres for server tests (`YUZU_TEST_POSTGRES_DSN`)
 
 ADR-0006 decision 8: every tier that runs server tests gets a real

--- a/scripts/ci/detect-code-change.sh
+++ b/scripts/ci/detect-code-change.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# detect-code-change.sh — classify a PR's changed-file list as code vs docs-only
+# for the ci.yml docs-only gate (issue #1978).
+#
+# Reads changed file paths from stdin (one per line) and prints exactly "true"
+# or "false" (the code_changed value) to stdout. Nothing else goes to stdout;
+# all diagnostics go to stderr.
+#
+#   arg $1  authoritative total changed-file count (GitHub's
+#           pull_request.changed_files). Guards the "List pull requests files"
+#           REST endpoint's 3000-file cap: if the piped list is shorter than
+#           this count the list was truncated, and we FAIL CLOSED to "true"
+#           (build) rather than trust a partial view that might hide a code
+#           file past the cap.
+#
+# The docs-only ignore set mirrors the pull_request `paths-ignore` ci.yml used
+# to carry, with GitHub's root-anchored filter semantics — a bare `*.md`,
+# `LICENSE`, or `.gitignore` pattern matches ONLY the repository root, never a
+# nested path:
+#   - docs/**                        (any depth under docs/)
+#   - root-level *.md                (README.md, but NOT sdk/README.md)
+#   - LICENSE, .gitignore            (root only)
+#   - .github/runner-inventory.json
+#   - .github/workflows/runner-inventory-sentinel.yml
+# Anything else -> code_changed=true. Fail-closed throughout: any uncertainty
+# (empty list, truncated list) builds rather than silently skipping the matrix.
+#
+# KEEP IN SYNC: this ignore set must match the `push:` trigger's paths-ignore
+# in .github/workflows/ci.yml — editing one without the other diverges PR-time
+# and post-merge build behaviour.
+#
+# Run tests:  bash tests/shell/test_detect_code_change.sh
+set -euo pipefail
+
+expected_total="${1:-}"
+
+mapfile -t files || true
+count=${#files[@]}
+
+emit() { printf '%s\n' "$1"; exit 0; }
+
+# Fail-closed: nothing to classify.
+if (( count == 0 )); then
+  echo "detect-code-change: empty file list -> building (fail-closed)" >&2
+  emit true
+fi
+
+# Fail-closed: the files API is capped at 3000 entries. If the caller passed
+# the authoritative changed-file count and it does not match what we received,
+# the list is truncated (or otherwise inconsistent) and a code file may sit
+# beyond the cap — build rather than trust the partial list.
+if [[ "$expected_total" =~ ^[0-9]+$ ]] && (( count != expected_total )); then
+  echo "detect-code-change: received $count of $expected_total files (truncated/mismatch) -> building (fail-closed)" >&2
+  emit true
+fi
+
+for f in "${files[@]}"; do
+  [[ -z "$f" ]] && continue
+  case "$f" in
+    docs/*) ;;                                        # docs/** (any depth)
+    LICENSE|.gitignore) ;;                             # root-only exact match
+    .github/runner-inventory.json) ;;
+    .github/workflows/runner-inventory-sentinel.yml) ;;
+    *.md)
+      # GitHub's `*.md` filter is root-only; a nested .md is NOT ignored.
+      if [[ "$f" == */* ]]; then
+        echo "detect-code-change: nested markdown is code-side per old paths-ignore -> building: $f" >&2
+        emit true
+      fi
+      ;;
+    *)
+      echo "detect-code-change: non-docs path -> building: $f" >&2
+      emit true
+      ;;
+  esac
+done
+
+emit false

--- a/tests/shell/test_detect_code_change.sh
+++ b/tests/shell/test_detect_code_change.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# test_detect_code_change.sh — fixture tests for scripts/ci/detect-code-change.sh
+#
+# The classifier is the docs-only gate for ci.yml (issue #1978): it decides
+# whether a PR skips the self-hosted build matrix. A silent regression (an
+# ignore arm dropped, `*.md` accidentally matching nested paths, the truncation
+# guard removed) would either block every docs PR again or, worse, let real
+# code merge without the required build. This exercises the code/docs/mixed,
+# root-vs-nested pattern semantics, the ignore set, and the 3000-file
+# truncation guard hermetically — no network, no GitHub.
+#
+# Run:  bash tests/shell/test_detect_code_change.sh
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || { cd "$(dirname "$0")/../.." && pwd; })"
+SCRIPT="$ROOT/scripts/ci/detect-code-change.sh"
+[ -f "$SCRIPT" ] || { echo "missing $SCRIPT" >&2; exit 2; }
+
+pass=0 fail=0
+# expect <want true|false> <desc> <authoritative-total> <newline-separated files>
+expect() {
+  local want="$1" desc="$2" total="$3" files="$4"
+  local got
+  got=$(printf '%s' "$files" | bash "$SCRIPT" "$total")
+  if [ "$got" = "$want" ]; then
+    printf '  [pass] %s\n' "$desc"; pass=$((pass + 1))
+  else
+    printf '  [FAIL] %s (want %s, got %s)\n' "$desc" "$want" "$got"; fail=$((fail + 1))
+  fi
+}
+
+# --- docs-only: skip the build ---
+expect false "adr + nested docs (docs/**)"        2 $'docs/adr/0022-headless.md\ndocs/adr-0022-execution-plan.md'
+expect false "root markdown README.md"            1 $'README.md'
+expect false "root LICENSE"                        1 $'LICENSE'
+expect false "root .gitignore"                     1 $'.gitignore'
+expect false "runner-inventory ignore files"      2 $'.github/runner-inventory.json\n.github/workflows/runner-inventory-sentinel.yml'
+
+# --- code-side: run the full matrix ---
+expect true  "single C++ source"                  1 $'server/core/src/server.cpp'
+expect true  "mixed docs + code"                  2 $'docs/x.md\nserver/a.cpp'
+expect true  "workflow change (ci.yml itself)"    1 $'.github/workflows/ci.yml'
+
+# --- root-anchored semantics (C3 / K1): nested != root ---
+expect true  "nested markdown is code-side"       1 $'sdk/README.md'
+expect true  "changelog fragment (nested .md)"    1 $'changelog.d/1978-fix.fixed.md'
+expect true  "nested LICENSE is code-side"        1 $'gateway/_checkouts/grpcbox/LICENSE'
+
+# --- more root-anchored / boundary cases (K3) ---
+expect false "root LICENSE.md (root *.md, not README)" 1 $'LICENSE.md'
+expect true  "docs + nested markdown mixed"       2 $'docs/guide.md\nsdk/README.md'
+
+# --- fail-closed guards ---
+expect true  "truncation guard: 3 seen of 4"      4 $'docs/a.md\ndocs/b.md\ndocs/c.md'
+expect false "3000 docs files at cap boundary"    3000 "$(printf 'docs/f%d.md\n' $(seq 1 3000))"
+expect true  "empty file list"                     0 ''
+
+echo "----"
+echo "detect-code-change: pass=$pass fail=$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

Fixes #1978. Docs-only PRs to `dev` could not be merged by a non-admin: the `dev` ruleset requires `Preflight (runner health)`, `Proto backward-compat`, `Linux gcc-15 debug`, `Windows MSVC debug`, `macOS debug` and `CHANGELOG order`. All but the last come from `ci.yml`, whose `pull_request` trigger carried a `paths-ignore` for docs — so a docs-only PR never triggered `ci.yml`, leaving those required contexts permanently **"Expected — waiting for status"** and the PR blocked. Only a repo admin could bypass-merge (e.g. #1914).

## Change

Move the docs-vs-code decision **in-workflow** instead of at the trigger:

- Drop `paths-ignore` from the `pull_request` trigger so `ci.yml` always runs on PRs. The `push:` trigger keeps its `paths-ignore` (post-merge docs pushes need no build and gate nothing).
- `preflight` classifies the PR's changed files into a `code_changed` output via **`scripts/ci/detect-code-change.sh`** (covered by **`tests/shell/test_detect_code_change.sh`**, wired into preflight's shell-gate).
- `proto-compat` / `linux` / `windows` / `macos` gate on `code_changed == 'true'`.

### Why a stub job (the load-bearing bit)

`proto-compat` is a non-matrix job — when skipped it reports `Proto backward-compat: skipped`, which satisfies the required check. The three **matrix** jobs are different: a matrix job skipped at the job level is skipped **before matrix expansion**, so it emits **none** of its inner check-run names ([actions/runner#952](https://github.com/actions/runner/issues/952)). Simply gating them would leave `Linux gcc-15 debug` / `Windows MSVC debug` / `macOS debug` absent and the PR still blocked.

So a new **`docs-required-checks`** stub — itself a matrix over those three exact names, `if: code_changed == 'false'` — emits them as `success` on docs-only PRs. Being a matrix job, the *same* runner#952 behaviour makes it collision-free on code PRs (skipped before expansion → emits nothing), so there is **exactly one producer per required name per run** (real job on code PRs, stub on docs-only PRs). The stub's names are byte-identical to the real jobs' PR-effective names and to the ruleset's required contexts.

### Fail-closed

Detection builds (never silently skips) on any uncertainty: non-PR event, files-API/permission failure, empty list, or a list truncated past the files-API 3000-file cap (guarded against `pull_request.changed_files`). The classifier call is wrapped to fail toward *build*, and preflight gains `pull-requests: read` for the files API.

## Validation

- `tests/shell/test_detect_code_change.sh` — 16 hermetic cases (docs/code/mixed, root-vs-nested `.md`, LICENSE/.gitignore, truncation, empty), all pass; now run in CI's preflight shell-gate.
- Two-phase independent review (Kimi + Codex) across v1→v2: v1's plain-skip design was caught (runner#952) and redesigned; v2 passed with required-name parity verified against the live ruleset.
- Governance (sre + consistency-auditor): no blocking findings; fail-closed exhaustive, required-name parity byte-verified, no changelog fragment required (`changelog.d` Rule 3 exempts CI plumbing).

This PR touches `ci.yml`/`scripts/`, so it is itself a code-side change — the **full real matrix runs on it**, self-testing that the normal code path is unaffected. The docs-only skip path is confirmed on the first docs-only PR after merge.
