### PR TITLE
docs(adr): ADR-0023 -> accepted; drop resolved numbering note

### DIFF
--- a/docs/adr/0023-vulnerability-correlation-engine.md
+++ b/docs/adr/0023-vulnerability-correlation-engine.md
@@ -1,17 +1,12 @@
 ---
-status: proposed
+status: accepted
 date: 2026-07-05
 owner: "@lesault (Andy Younie)"
-number-provisional: true  # 0021/0022 are claimed by open PRs #1897/#1896 and the repo has a 0016 collision — confirm the final number with @Tr3kkR before merge
 depends-on: 0018 (server-authoritative matching — the lane routing this consumes); 0019 (tri-state + coverage, as amended 2026-07-05 to add `potential` and a confidence axis); 0016 (daily-sync framework — the inventory transport + the on-demand-refresh extension); 0012 (born-on-PG store contract); 0006 (Postgres substrate)
 related: docs/vuln-scan-roadmap.md M1a; docs/postgres-migration-ladder.md; future Lane-3 federation ADR (number TBD, deferred); ADR-0017 (management-group confinement)
 ---
 
 # 0023 — Vulnerability correlation engine + tri-state findings store
-
-> **Provisional number.** 0021/0022 are already claimed by open PRs (#1897 CAVM, #1896 dashboard) and
-> the repo already carries a duplicate 0016. The final number must be confirmed with maintainer @Tr3kkR
-> before this ADR merges. Content, not the digit, is the decision.
 
 ## Context
 
@@ -216,7 +211,7 @@ code):**
 
 ## Ratification
 
-**Status: proposed.** Cross-cutting: it redraws the agent↔server boundary (a server-initiated push),
+**Status: accepted.** Cross-cutting: it redraws the agent↔server boundary (a server-initiated push),
 commits a new born-on-PG store + background load, and adds an RBAC securable. Per the ADR-0018 convention,
 it should **not** be self-accepted. It moves to `accepted` after sign-off from **@Tr3kkR** (maintainer /
 merge gate / final ADR number), **@NathanDornbrook** (fleet-scale server load; ADR-0006/0012), and


### PR DESCRIPTION
## What changed

Two amendments to the already-merged ADR-0023 (vulnerability correlation engine + tri-state findings store):

1. **Status: `proposed` -> `accepted`** (both the frontmatter field and the restated line in the Ratification section).
2. **Removed the provisional-number note** (the frontmatter `number-provisional` comment and the intro blockquote), which flagged that ADR-0021/0022 were contested by open PRs #1897/#1896 at the time this ADR was drafted, and that 0023's own number might need reconfirming with @Tr3kkR before merge.

## Why

Both things the note was waiting on are resolved:

- **#1897 and #1896's number collisions are settled.** #1897 ("CAVM MVP scores on observed reachability") was independently claimed alongside #1904/#1927 ("Spark Reflex," which has the number embedded in already-shipped code) — #1897 moved to **ADR-4002** rather than #1904, since #1904's number was load-bearing in code. #1896 ("vulnerability management dashboard + attack path explorer") was independently claimed alongside #1918/#1926 ("headless platform / use-case engines") — #1896 moved to **ADR-4001**. Both now use the 4xxx range per @Tr3kkR's new numbering convention, specifically to avoid this class of collision going forward.
- **ADR-0023 itself already merged under its original number** (PR #1914, 2026-07-07), so the "confirm the final number before merge" instruction is moot.

The note is removed rather than patched with the new numbers, since it no longer describes a live uncertainty — it would just be a stale historical footnote either way.

## Note on the Ratification section's own process

This ADR's Ratification section states it "should not be self-accepted" and names three required reviewers (@Tr3kkR, @NathanDornbrook, @Alex) with no recorded sign-off. This PR sets status to `accepted` directly at the author's (@lesault's) explicit instruction, overriding that convention — flagging it here for visibility rather than silently proceeding.

No other content changed in either edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014W6UK5Dx1uLXUpjX3HPKZS