### PR TITLE
fix(agent): contain escaped exceptions in dispatch ThreadPool (#2037)

### DIFF
--- a/agents/core/src/agent.cpp
+++ b/agents/core/src/agent.cpp
@@ -43,6 +43,7 @@ __declspec(allocate(".CRT$XCB"))
 #include "dex_linux_proc.hpp" // A4 Linux heartbeat perf reads (parse_proc_stat / parse_commit_pct)
 #include "dex_perf_breach.hpp" // A4: heartbeat device-utilization tags (perf counter reads)
 #include "net_quality_sampler.hpp" // slice 4a: heartbeat network-quality facts
+#include "thread_pool.hpp" // bounded dispatch pool + per-task exception firewall (#2037)
 
 #ifdef _WIN32
 #include <winsock2.h> // gethostname (must precede windows.h)
@@ -142,76 +143,10 @@ std::string read_file_contents(const std::filesystem::path& p) {
 // (Subscribe RPC: stream CommandResponse -> stream CommandRequest)
 using SubscribeStream = grpc::ClientReaderWriter<pb::CommandResponse, pb::CommandRequest>;
 
-// ── Bounded Thread Pool ──────────────────────────────────────────────────────
-// Replaces unbounded std::thread-per-command dispatch. Workers pull tasks from
-// a shared queue protected by a mutex + condition variable. If the queue exceeds
-// max_queue_size, submit() returns false so the caller can reject the command.
+// ThreadPool (bounded dispatch pool + per-task exception firewall, #2037) now
+// lives in thread_pool.hpp so the firewall behaviour is unit-testable in
+// isolation. Used unqualified below via namespace yuzu::agent.
 
-class ThreadPool {
-public:
-    explicit ThreadPool(size_t num_threads, size_t max_queue_size = 1000)
-        : max_queue_size_{max_queue_size} {
-        // Clamp thread count: min 4, max 32
-        num_threads = std::max<size_t>(num_threads, 4);
-        num_threads = std::min<size_t>(num_threads, 32);
-        workers_.reserve(num_threads);
-        for (size_t i = 0; i < num_threads; ++i) {
-            workers_.emplace_back([this] {
-                while (true) {
-                    std::function<void()> task;
-                    {
-                        std::unique_lock lock(mu_);
-                        cv_.wait(lock, [this] { return stop_ || !tasks_.empty(); });
-                        if (stop_ && tasks_.empty())
-                            return;
-                        task = std::move(tasks_.front());
-                        tasks_.pop();
-                    }
-                    task();
-                }
-            });
-        }
-        spdlog::info("Thread pool started: {} workers, max queue {}", num_threads, max_queue_size);
-    }
-
-    // Returns false if the queue is full (backpressure).
-    bool submit(std::function<void()> task) {
-        {
-            std::lock_guard lock(mu_);
-            if (stop_)
-                return false;
-            if (tasks_.size() >= max_queue_size_)
-                return false;
-            tasks_.push(std::move(task));
-        }
-        cv_.notify_one();
-        return true;
-    }
-
-    ~ThreadPool() {
-        {
-            std::lock_guard lock(mu_);
-            stop_ = true;
-        }
-        cv_.notify_all();
-        for (auto& w : workers_) {
-            if (w.joinable())
-                w.join();
-        }
-    }
-
-    // Non-copyable, non-movable
-    ThreadPool(const ThreadPool&) = delete;
-    ThreadPool& operator=(const ThreadPool&) = delete;
-
-private:
-    std::vector<std::thread> workers_;
-    std::queue<std::function<void()>> tasks_;
-    std::mutex mu_;
-    std::condition_variable cv_;
-    bool stop_ = false;
-    size_t max_queue_size_;
-};
 
 // Context implementations
 // These are passed to plugins; they bridge the C ABI callbacks to gRPC streams.
@@ -2060,146 +1995,26 @@ public:
                     // Each task captures the shared_ptr to guarantee the stream
                     // outlives all writers (fixes use-after-free risk from #66).
                     bool submitted = thread_pool_->submit([this, target, cmd, stream]() {
-                        // -- Stagger/delay: prevent thundering herd on large-fleet dispatch --
-                        const int32_t stagger_s =
-                            std::min(cmd.stagger_seconds(), int32_t{300}); // cap 5 min
-                        const int32_t delay_s =
-                            std::min(cmd.delay_seconds(), int32_t{300}); // cap 5 min
-                        if (stagger_s > 0 || delay_s > 0) {
-                            int32_t random_stagger = 0;
-                            if (stagger_s > 0) {
-                                std::random_device rd;
-                                std::mt19937 gen(rd());
-                                std::uniform_int_distribution<int32_t> dist(0, stagger_s);
-                                random_stagger = dist(gen);
-                            }
-                            const int32_t total_delay = std::min(
-                                (delay_s > 0 ? delay_s : 0) + random_stagger, int32_t{600});
-                            spdlog::debug("Command {} stagger {}s + delay {}s = {}s",
-                                          cmd.command_id(), random_stagger, delay_s, total_delay);
-
-                            if (total_delay > 0) {
-                                std::this_thread::sleep_for(std::chrono::seconds(total_delay));
-                            }
-
-                            // Check expiration after the delay — skip stale commands
-                            if (cmd.has_expires_at() && cmd.expires_at().millis_epoch() > 0) {
-                                auto now_ms =
-                                    std::chrono::duration_cast<std::chrono::milliseconds>(
-                                        std::chrono::system_clock::now().time_since_epoch())
-                                        .count();
-                                if (now_ms > cmd.expires_at().millis_epoch()) {
-                                    spdlog::warn("Command {} expired after stagger/delay "
-                                                 "(expired_at={}, now={})",
-                                                 cmd.command_id(), cmd.expires_at().millis_epoch(),
-                                                 now_ms);
-                                    pb::CommandResponse expired_resp;
-                                    expired_resp.set_command_id(cmd.command_id());
-                                    expired_resp.set_status(pb::CommandResponse::REJECTED);
-                                    expired_resp.set_output("command expired after stagger/delay");
-                                    auto epoch =
-                                        std::chrono::duration_cast<std::chrono::milliseconds>(
-                                            std::chrono::system_clock::now().time_since_epoch())
-                                            .count();
-                                    expired_resp.mutable_sent_at()->set_millis_epoch(epoch);
-
-                                    std::lock_guard lock(stream_write_mu_);
-                                    stream->Write(expired_resp, grpc::WriteOptions());
-                                    return;
-                                }
-                            }
-                        }
-
-                        metrics_
-                            .counter("yuzu_agent_commands_executed_total",
-                                     {{"plugin", cmd.plugin()}})
-                            .increment();
-                        CommandContextImpl ctx_impl{
-                            .stream = stream,
-                            .write_mu = &stream_write_mu_,
-                            .command_id = cmd.command_id(),
-                            .start_time = std::chrono::steady_clock::now(),
-                        };
-                        auto* raw_ctx = reinterpret_cast<YuzuCommandContext*>(&ctx_impl);
-
-                        // Convert protobuf parameter map -> C ABI YuzuParam array
-                        // Direct construction: single vector of YuzuParam pointing at proto map
-                        // entries (no intermediate string copies — proto owns the data).
-                        const auto& proto_params = cmd.parameters();
-                        std::vector<YuzuParam> params;
-                        params.reserve(proto_params.size());
-                        for (const auto& [k, v] : proto_params) {
-                            params.push_back(YuzuParam{k.c_str(), v.c_str()});
-                        }
-
-                        // Defence-in-depth: wrap the plugin's execute() so a
-                        // thrown C++ exception cannot propagate up into the
-                        // command-dispatch thread and terminate() the whole
-                        // agent process. Plugins are expected to convert
-                        // failures into a non-zero `rc`; this is the safety
-                        // net for the cases they miss. Observed 2026-05-12:
-                        // agent_logging.get_log threw filesystem_error from
-                        // fs::exists on EACCES and brought the agent down
-                        // mid-test. The plugin bug is fixed separately;
-                        // this catch is so the next plugin's mistake
-                        // doesn't have the same blast radius.
-                        int rc;
+                        // Outer exception firewall (#2037). The ThreadPool worker
+                        // already contains any escaped exception so the agent
+                        // process survives; catching here additionally lets the
+                        // server receive a terminal FAILURE instead of waiting on
+                        // its own timeout for a command whose dispatch task threw
+                        // outside the plugin execute() guard.
                         try {
-                            rc = target->execute(raw_ctx, cmd.action().c_str(), params.data(),
-                                                 params.size());
+                            execute_command_task(target, cmd, stream);
                         } catch (const std::exception& e) {
-                            spdlog::error("Plugin {} action {} threw std::exception: {}",
-                                          cmd.plugin(), cmd.action(), e.what());
-                            std::string msg = "plugin threw exception: ";
-                            msg += e.what();
-                            ctx_impl.append_output(msg.c_str());
-                            rc = 1;
+                            spdlog::error("Command {} dispatch failed outside plugin execute: {}",
+                                          cmd.command_id(), e.what());
+                            send_dispatch_failure(stream, cmd.command_id(),
+                                                  std::string("agent dispatch error: ") + e.what());
                         } catch (...) {
-                            spdlog::error("Plugin {} action {} threw non-std exception",
-                                          cmd.plugin(), cmd.action());
-                            ctx_impl.append_output("plugin threw non-std exception");
-                            rc = 1;
+                            spdlog::error("Command {} dispatch failed outside plugin execute "
+                                          "(non-std exception)",
+                                          cmd.command_id());
+                            send_dispatch_failure(stream, cmd.command_id(),
+                                                  "agent dispatch error: non-std exception");
                         }
-
-                        // Flush any buffered output before sending timing/status
-                        ctx_impl.flush_output();
-
-                        auto end_time = std::chrono::steady_clock::now();
-                        auto exec_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                           end_time - ctx_impl.start_time)
-                                           .count();
-
-                        // Send timing metadata before the final status
-                        {
-                            pb::CommandResponse timing_resp;
-                            timing_resp.set_command_id(cmd.command_id());
-                            timing_resp.set_status(pb::CommandResponse::RUNNING);
-                            timing_resp.set_output("__timing__|exec_ms=" + std::to_string(exec_ms));
-
-                            std::lock_guard lock(stream_write_mu_);
-                            stream->Write(timing_resp, grpc::WriteOptions());
-                        }
-
-                        // Send final status
-                        {
-                            pb::CommandResponse final_resp;
-                            final_resp.set_command_id(cmd.command_id());
-                            final_resp.set_status(rc == 0 ? pb::CommandResponse::SUCCESS
-                                                          : pb::CommandResponse::FAILURE);
-                            final_resp.set_exit_code(rc);
-
-                            auto now_epoch =
-                                std::chrono::duration_cast<std::chrono::milliseconds>(
-                                    std::chrono::system_clock::now().time_since_epoch())
-                                    .count();
-                            final_resp.mutable_sent_at()->set_millis_epoch(now_epoch);
-
-                            std::lock_guard lock(stream_write_mu_);
-                            stream->Write(final_resp, grpc::WriteOptions());
-                        }
-
-                        spdlog::info("Command {} finished (rc={}, exec={}ms)", cmd.command_id(), rc,
-                                     exec_ms);
                     });
 
                     if (!submitted) {
@@ -2362,6 +2177,185 @@ private:
         std::lock_guard lock(stream_write_mu_);
         if (guardian_sink_stream_)
             guardian_sink_stream_->Write(resp, grpc::WriteOptions());
+    }
+
+    // Per-command dispatch task (#2037): runs one CommandRequest through its
+    // plugin and streams timing + terminal status back. Extracted from the
+    // dispatch lambda so the ThreadPool exception firewall and the
+    // FAILURE-on-throw path around it stay small and readable. A `return`
+    // here skips this command's remaining status writes exactly as it did
+    // inside the lambda.
+    void execute_command_task(const YuzuPluginDescriptor* target, const pb::CommandRequest& cmd,
+                              const std::shared_ptr<SubscribeStream>& stream) {
+        // -- Stagger/delay: prevent thundering herd on large-fleet dispatch --
+        const int32_t stagger_s = std::min(cmd.stagger_seconds(), int32_t{300}); // cap 5 min
+        const int32_t delay_s = std::min(cmd.delay_seconds(), int32_t{300});     // cap 5 min
+        if (stagger_s > 0 || delay_s > 0) {
+            int32_t random_stagger = 0;
+            if (stagger_s > 0) {
+                std::random_device rd;
+                std::mt19937 gen(rd());
+                std::uniform_int_distribution<int32_t> dist(0, stagger_s);
+                random_stagger = dist(gen);
+            }
+            const int32_t total_delay =
+                std::min((delay_s > 0 ? delay_s : 0) + random_stagger, int32_t{600});
+            spdlog::debug("Command {} stagger {}s + delay {}s = {}s", cmd.command_id(),
+                          random_stagger, delay_s, total_delay);
+
+            if (total_delay > 0) {
+                std::this_thread::sleep_for(std::chrono::seconds(total_delay));
+            }
+
+            // Check expiration after the delay — skip stale commands
+            if (cmd.has_expires_at() && cmd.expires_at().millis_epoch() > 0) {
+                auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                  std::chrono::system_clock::now().time_since_epoch())
+                                  .count();
+                if (now_ms > cmd.expires_at().millis_epoch()) {
+                    spdlog::warn("Command {} expired after stagger/delay "
+                                 "(expired_at={}, now={})",
+                                 cmd.command_id(), cmd.expires_at().millis_epoch(), now_ms);
+                    pb::CommandResponse expired_resp;
+                    expired_resp.set_command_id(cmd.command_id());
+                    expired_resp.set_status(pb::CommandResponse::REJECTED);
+                    expired_resp.set_output("command expired after stagger/delay");
+                    auto epoch = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                     std::chrono::system_clock::now().time_since_epoch())
+                                     .count();
+                    expired_resp.mutable_sent_at()->set_millis_epoch(epoch);
+
+                    std::lock_guard lock(stream_write_mu_);
+                    stream->Write(expired_resp, grpc::WriteOptions());
+                    return;
+                }
+            }
+        }
+
+        metrics_.counter("yuzu_agent_commands_executed_total", {{"plugin", cmd.plugin()}})
+            .increment();
+        CommandContextImpl ctx_impl{
+            .stream = stream,
+            .write_mu = &stream_write_mu_,
+            .command_id = cmd.command_id(),
+            .start_time = std::chrono::steady_clock::now(),
+        };
+        auto* raw_ctx = reinterpret_cast<YuzuCommandContext*>(&ctx_impl);
+
+        // Convert protobuf parameter map -> C ABI YuzuParam array
+        // Direct construction: single vector of YuzuParam pointing at proto map
+        // entries (no intermediate string copies — proto owns the data).
+        const auto& proto_params = cmd.parameters();
+        std::vector<YuzuParam> params;
+        params.reserve(proto_params.size());
+        for (const auto& [k, v] : proto_params) {
+            params.push_back(YuzuParam{k.c_str(), v.c_str()});
+        }
+
+        // Defence-in-depth: wrap the plugin's execute() so a
+        // thrown C++ exception cannot propagate up into the
+        // command-dispatch thread and terminate() the whole
+        // agent process. Plugins are expected to convert
+        // failures into a non-zero `rc`; this is the safety
+        // net for the cases they miss. Observed 2026-05-12:
+        // agent_logging.get_log threw filesystem_error from
+        // fs::exists on EACCES and brought the agent down
+        // mid-test. The plugin bug is fixed separately;
+        // this catch is so the next plugin's mistake
+        // doesn't have the same blast radius.
+        int rc;
+        try {
+            rc = target->execute(raw_ctx, cmd.action().c_str(), params.data(), params.size());
+        } catch (const std::exception& e) {
+            spdlog::error("Plugin {} action {} threw std::exception: {}", cmd.plugin(),
+                          cmd.action(), e.what());
+            std::string msg = "plugin threw exception: ";
+            msg += e.what();
+            ctx_impl.append_output(msg.c_str());
+            rc = 1;
+        } catch (...) {
+            spdlog::error("Plugin {} action {} threw non-std exception", cmd.plugin(),
+                          cmd.action());
+            ctx_impl.append_output("plugin threw non-std exception");
+            rc = 1;
+        }
+
+        // Flush any buffered output before sending timing/status
+        ctx_impl.flush_output();
+
+        auto end_time = std::chrono::steady_clock::now();
+        auto exec_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(end_time - ctx_impl.start_time)
+                .count();
+
+        // Send timing metadata before the final status
+        {
+            pb::CommandResponse timing_resp;
+            timing_resp.set_command_id(cmd.command_id());
+            timing_resp.set_status(pb::CommandResponse::RUNNING);
+            timing_resp.set_output("__timing__|exec_ms=" + std::to_string(exec_ms));
+
+            std::lock_guard lock(stream_write_mu_);
+            stream->Write(timing_resp, grpc::WriteOptions());
+        }
+
+        // Log before the terminal write so nothing that can throw runs AFTER a
+        // terminal status has been sent — otherwise the dispatch firewall's
+        // catch would send a second terminal status (FAILURE after SUCCESS) for
+        // the same command_id (#2037 hardening).
+        spdlog::info("Command {} finished (rc={}, exec={}ms)", cmd.command_id(), rc, exec_ms);
+
+        // Send final status (must be the last statement — see above)
+        {
+            pb::CommandResponse final_resp;
+            final_resp.set_command_id(cmd.command_id());
+            final_resp.set_status(rc == 0 ? pb::CommandResponse::SUCCESS
+                                          : pb::CommandResponse::FAILURE);
+            final_resp.set_exit_code(rc);
+
+            auto now_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                 std::chrono::system_clock::now().time_since_epoch())
+                                 .count();
+            final_resp.mutable_sent_at()->set_millis_epoch(now_epoch);
+
+            std::lock_guard lock(stream_write_mu_);
+            stream->Write(final_resp, grpc::WriteOptions());
+        }
+    }
+
+    // Best-effort terminal FAILURE for a command whose dispatch task threw
+    // outside the plugin execute() guard (#2037). Invoked from the dispatch
+    // exception firewall so the server receives a terminal status instead of
+    // waiting on its timeout. Must not itself throw — the Write is guarded.
+    void send_dispatch_failure(const std::shared_ptr<SubscribeStream>& stream,
+                               const std::string& command_id, const std::string& message) noexcept {
+        try {
+            pb::CommandResponse resp;
+            resp.set_command_id(command_id);
+            resp.set_status(pb::CommandResponse::FAILURE);
+            resp.set_exit_code(1);
+            // Carry the reason in the structured error field, NOT output: the
+            // server finalizes a terminal frame onto prior RUNNING rows in place
+            // only when output is empty (agent_service_impl.cpp). A non-empty
+            // output would instead INSERT a second row and leave any already-
+            // streamed RUNNING output rows un-finalized (#2037 UP-1).
+            resp.mutable_error()->set_code("agent_dispatch_error");
+            resp.mutable_error()->set_message(message);
+            auto epoch = std::chrono::duration_cast<std::chrono::milliseconds>(
+                             std::chrono::system_clock::now().time_since_epoch())
+                             .count();
+            resp.mutable_sent_at()->set_millis_epoch(epoch);
+            std::lock_guard lock(stream_write_mu_);
+            if (stream)
+                stream->Write(resp, grpc::WriteOptions());
+        } catch (...) {
+            // Last-resort log, itself guarded: this function is noexcept, so a
+            // throw from spdlog here would be an immediate terminate() — the
+            // exact failure #2037 exists to prevent.
+            try {
+                spdlog::error("Command {} failed to send dispatch-failure response", command_id);
+            } catch (...) {}
+        }
     }
 
     // #1420 / #1434 — single quiesce-and-join chokepoint for the three

--- a/agents/core/src/thread_pool.hpp
+++ b/agents/core/src/thread_pool.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+// ── Bounded Thread Pool ──────────────────────────────────────────────────────
+// Replaces unbounded std::thread-per-command dispatch. Workers pull tasks from
+// a shared queue protected by a mutex + condition variable. If the queue exceeds
+// max_queue_size, submit() returns false so the caller can reject the command.
+//
+// Exception firewall (#2037): each task runs inside a try/catch(...) so that a
+// task which lets an exception escape cannot propagate out of the worker's
+// top-level callable — which would call std::terminate() -> abort() and kill the
+// whole agent process. On Windows that abort surfaces as exception code
+// 0xC0000409 (FAST_FAIL_FATAL_APP_EXIT), easily mistaken for a /GS stack-buffer
+// overrun. Callers that need a per-task failure signal must still handle their
+// own exceptions; this firewall is the last-resort net that keeps one task's
+// failure from taking down the process or the other workers.
+
+#include <algorithm>
+#include <condition_variable>
+#include <cstddef>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
+
+#include <spdlog/spdlog.h>
+
+namespace yuzu::agent {
+
+class ThreadPool {
+public:
+    explicit ThreadPool(std::size_t num_threads, std::size_t max_queue_size = 1000)
+        : max_queue_size_{max_queue_size} {
+        // Clamp thread count: min 4, max 32
+        num_threads = std::max<std::size_t>(num_threads, 4);
+        num_threads = std::min<std::size_t>(num_threads, 32);
+        workers_.reserve(num_threads);
+        for (std::size_t i = 0; i < num_threads; ++i) {
+            workers_.emplace_back([this] {
+                while (true) {
+                    std::function<void()> task;
+                    {
+                        std::unique_lock lock(mu_);
+                        cv_.wait(lock, [this] { return stop_ || !tasks_.empty(); });
+                        if (stop_ && tasks_.empty())
+                            return;
+                        task = std::move(tasks_.front());
+                        tasks_.pop();
+                    }
+                    // Exception firewall (#2037): a task must never let an
+                    // exception escape this callable — that would terminate() the
+                    // whole agent. Contain it here so the worker survives and
+                    // keeps pulling the next task. The log calls are themselves
+                    // wrapped: spdlog can throw (alloc/sink/fmt failure), and a
+                    // throw from this last-resort handler would re-open the very
+                    // terminate() hole we are closing.
+                    try {
+                        task();
+                    } catch (const std::exception& e) {
+                        try {
+                            spdlog::error("ThreadPool task threw std::exception (contained, "
+                                          "worker survives): {}",
+                                          e.what());
+                        } catch (...) {}
+                    } catch (...) {
+                        try {
+                            spdlog::error("ThreadPool task threw a non-std exception "
+                                          "(contained, worker survives)");
+                        } catch (...) {}
+                    }
+                }
+            });
+        }
+        spdlog::info("Thread pool started: {} workers, max queue {}", num_threads, max_queue_size);
+    }
+
+    // Returns false if the queue is full (backpressure).
+    bool submit(std::function<void()> task) {
+        {
+            std::lock_guard lock(mu_);
+            if (stop_)
+                return false;
+            if (tasks_.size() >= max_queue_size_)
+                return false;
+            tasks_.push(std::move(task));
+        }
+        cv_.notify_one();
+        return true;
+    }
+
+    ~ThreadPool() {
+        {
+            std::lock_guard lock(mu_);
+            stop_ = true;
+        }
+        cv_.notify_all();
+        for (auto& w : workers_) {
+            if (w.joinable())
+                w.join();
+        }
+    }
+
+    // Non-copyable, non-movable
+    ThreadPool(const ThreadPool&) = delete;
+    ThreadPool& operator=(const ThreadPool&) = delete;
+
+private:
+    std::vector<std::thread> workers_;
+    std::queue<std::function<void()>> tasks_;
+    std::mutex mu_;
+    std::condition_variable cv_;
+    bool stop_ = false;
+    std::size_t max_queue_size_;
+};
+
+} // namespace yuzu::agent

--- a/changelog.d/2037-agent-dispatch-exception-firewall.fixed.md
+++ b/changelog.d/2037-agent-dispatch-exception-firewall.fixed.md
@@ -1,0 +1,8 @@
+- **Agent no longer crashes under concurrent `execute_bundle` dispatch on Windows (#2037).** A C++
+  exception thrown outside the plugin's `execute()` call (e.g. in metrics, output-flush, protobuf
+  construction, or the gRPC stream write) escaped the dispatch thread pool's worker and triggered
+  `std::terminate()`/`abort()`, killing the whole agent process — observed as `yuzu-agent.exe`
+  exiting with 0xC0000409 under bundles with 3+ concurrent steps. The dispatch thread pool now
+  contains any escaped exception at the worker boundary, and the affected command/step returns a
+  terminal `FAILURE` status (with error detail `agent dispatch error: <what>`) instead of hanging
+  until the server's timeout or bringing down the agent.

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -6,10 +6,10 @@ Last updated: 2026-07-06
 
 | Suite | Executable | Test Files | Status |
 |-------|-----------|------------|--------|
-| Agent unit tests | `yuzu_agent_tests` | 20 files | Active |
+| Agent unit tests | `yuzu_agent_tests` | 21 files | Active |
 | Server unit tests | `yuzu_server_tests` | 38 files | Active (requires `build_server=true`) |
 
-**Totals:** 52 test files (+3: `test_spark_disk.cpp`, `test_spark_engine.cpp`, `test_spark_mechanism.cpp` — the ADR-0021 SparkEngine + File/Registry/Service mechanisms). Test case count has grown significantly since the RC sprint added REST API tests, MCP tests, and store tests. Note: these per-suite file counts and the "Tested" tables below have drifted from `tests/meson.build`'s actual source list on prior updates too — treat as directionally accurate, not authoritative; `tests/meson.build` is the source of truth for what's actually compiled.
+**Totals:** 53 test files (+1: `test_thread_pool.cpp` — the #2037 dispatch-pool exception firewall; +3: `test_spark_disk.cpp`, `test_spark_engine.cpp`, `test_spark_mechanism.cpp` — the ADR-0021 SparkEngine + File/Registry/Service mechanisms). Test case count has grown significantly since the RC sprint added REST API tests, MCP tests, and store tests. Note: these per-suite file counts and the "Tested" tables below have drifted from `tests/meson.build`'s actual source list on prior updates too — treat as directionally accurate, not authoritative; `tests/meson.build` is the source of truth for what's actually compiled.
 
 Run all tests: `meson test -C build-linux --print-errorlogs`
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -138,6 +138,7 @@ agent_test_exe = executable(
     'unit/test_dex_linux_sysfs.cpp',
     'unit/test_dex_rate_limiter.cpp',
     'unit/test_resilience_strategy.cpp',
+    'unit/test_thread_pool.cpp',
     'unit/test_spark_disk.cpp',
     'unit/test_spark_engine.cpp',
     'unit/test_spark_mechanism.cpp',
@@ -165,7 +166,9 @@ agent_test_exe = executable(
   # so Linux real-mechanism Service spark tests can compile-gate on it, exactly
   # as agents/core/meson.build gates guard_systemd.cpp/spark_service.cpp.
   cpp_args: test_partial_init_args + agent_platform_args,
-  dependencies: [yuzu_agent_core_dep, yuzu_sdk_dep, agent_test_proto_dep, nlohmann_dep, catch2_dep, agent_test_openssl_dep],
+  # spdlog_dep (brings fmt): test_thread_pool.cpp instantiates spdlog logging in
+  # thread_pool.hpp directly in the test TU, so it needs fmt symbols linked here.
+  dependencies: [yuzu_agent_core_dep, yuzu_sdk_dep, agent_test_proto_dep, nlohmann_dep, catch2_dep, agent_test_openssl_dep, spdlog_dep],
   # Ensure the fixture plugins are built before the test runs so the lookups
   # inside test_plugin_loader.cpp find them under MESON_BUILD_ROOT/tests/.
   link_depends: [reserved_name_fixture_plugin, invalid_name_fixture_plugin],

--- a/tests/unit/test_thread_pool.cpp
+++ b/tests/unit/test_thread_pool.cpp
@@ -1,0 +1,134 @@
+// Tests for the agent dispatch ThreadPool, focused on the #2037 exception
+// firewall: a task that lets an exception escape must NOT terminate the process
+// or kill the worker — it must be contained so the pool keeps serving tasks.
+//
+// Note: without the firewall, the "throwing task" cases below would call
+// std::terminate()/abort() and take the whole test binary down (surfacing on
+// Windows as exit code 0xC0000409), so these cases are self-proving.
+
+#include "thread_pool.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <stdexcept>
+
+#include <catch2/catch_test_macros.hpp>
+
+using yuzu::agent::ThreadPool;
+
+namespace {
+
+// Wait until `pred()` holds or the bounded spin budget is exhausted. Uses a
+// condition_variable so it is not a busy-loop; returns pred()'s final value.
+template <typename Pred> bool wait_for(std::mutex& m, std::condition_variable& cv, Pred pred) {
+    std::unique_lock lock(m);
+    return cv.wait_for(lock, std::chrono::seconds(10), pred);
+}
+
+// RAII cleanup that also runs on exception unwind. Used so a failing REQUIRE
+// mid-test still releases parked worker threads before ~ThreadPool joins them.
+template <typename F> struct ScopeExit {
+    F f;
+    ~ScopeExit() { f(); }
+};
+template <typename F> ScopeExit(F) -> ScopeExit<F>;
+
+} // namespace
+
+TEST_CASE("ThreadPool contains a throwing task and keeps running", "[thread_pool]") {
+    ThreadPool pool(4);
+
+    std::mutex m;
+    std::condition_variable cv;
+    int completed = 0;
+    constexpr int kNormalTasks = 8;
+
+    auto bump = [&] {
+        {
+            std::lock_guard lock(m);
+            ++completed;
+        }
+        cv.notify_all();
+    };
+
+    // A task that throws a std::exception — must be contained by the firewall.
+    REQUIRE(pool.submit([] { throw std::runtime_error("boom (std)"); }));
+    // A task that throws a non-std value — the catch(...) arm.
+    REQUIRE(pool.submit([] { throw 42; }));
+
+    // Normal tasks submitted after the throwers must still all run, proving the
+    // workers survived the exceptions.
+    for (int i = 0; i < kNormalTasks; ++i) {
+        REQUIRE(pool.submit(bump));
+    }
+
+    const bool all_ran = wait_for(m, cv, [&] { return completed == kNormalTasks; });
+    REQUIRE(all_ran);
+    REQUIRE(completed == kNormalTasks);
+}
+
+TEST_CASE("ThreadPool runs every submitted task", "[thread_pool]") {
+    std::atomic<int> ran{0};
+    constexpr int kTasks = 200;
+    {
+        ThreadPool pool(4);
+        for (int i = 0; i < kTasks; ++i) {
+            REQUIRE(pool.submit([&] { ran.fetch_add(1, std::memory_order_relaxed); }));
+        }
+        // ~ThreadPool drains and joins.
+    }
+    REQUIRE(ran.load() == kTasks);
+}
+
+TEST_CASE("ThreadPool applies backpressure when the queue is full", "[thread_pool]") {
+    constexpr std::size_t kWorkers = 4;
+    constexpr std::size_t kQueueCap = 2;
+    ThreadPool pool(kWorkers, kQueueCap);
+
+    std::mutex m;
+    std::condition_variable cv;
+    int entered = 0; // workers currently parked inside a blocking task
+    bool release = false;
+
+    // Guarantee the parked workers are released even if a REQUIRE below throws
+    // (e.g. a wait_for timeout on a loaded runner). Declared after m/cv/release
+    // so it destructs before ~ThreadPool joins — otherwise the whole test binary
+    // would hang instead of failing cleanly (qa-B1).
+    ScopeExit release_on_exit{[&] {
+        {
+            std::lock_guard lock(m);
+            release = true;
+        }
+        cv.notify_all();
+    }};
+
+    auto blocker = [&] {
+        {
+            std::lock_guard lock(m);
+            ++entered;
+        }
+        cv.notify_all();
+        std::unique_lock lock(m);
+        cv.wait(lock, [&] { return release; });
+    };
+
+    // Occupy every worker so nothing drains the queue. Submit one blocker at a
+    // time and wait until it is actually running before submitting the next —
+    // otherwise the occupy submits would race the small queue cap and spuriously
+    // hit backpressure here rather than in the assertion below.
+    for (std::size_t i = 0; i < kWorkers; ++i) {
+        REQUIRE(pool.submit(blocker));
+        REQUIRE(wait_for(m, cv, [&] { return entered == static_cast<int>(i + 1); }));
+    }
+
+    // Fill the queue to capacity — these are accepted but not yet run.
+    for (std::size_t i = 0; i < kQueueCap; ++i) {
+        REQUIRE(pool.submit([] {}));
+    }
+    // The next submit must be rejected: queue is full.
+    REQUIRE_FALSE(pool.submit([] {}));
+
+    // release_on_exit unblocks the workers so ~ThreadPool joins cleanly.
+}

--- a/tests/unit/test_thread_pool.cpp
+++ b/tests/unit/test_thread_pool.cpp
@@ -38,8 +38,6 @@ template <typename F> ScopeExit(F) -> ScopeExit<F>;
 } // namespace
 
 TEST_CASE("ThreadPool contains a throwing task and keeps running", "[thread_pool]") {
-    ThreadPool pool(4);
-
     std::mutex m;
     std::condition_variable cv;
     int completed = 0;
@@ -52,6 +50,11 @@ TEST_CASE("ThreadPool contains a throwing task and keeps running", "[thread_pool
         }
         cv.notify_all();
     };
+
+    // Declared AFTER the state the tasks capture so ~ThreadPool joins the workers
+    // before m/cv are destroyed — otherwise a worker could still touch a
+    // destroyed mutex/cv during teardown (UB; TSan would flag it).
+    ThreadPool pool(4);
 
     // A task that throws a std::exception — must be contained by the firewall.
     REQUIRE(pool.submit([] { throw std::runtime_error("boom (std)"); }));
@@ -85,24 +88,11 @@ TEST_CASE("ThreadPool runs every submitted task", "[thread_pool]") {
 TEST_CASE("ThreadPool applies backpressure when the queue is full", "[thread_pool]") {
     constexpr std::size_t kWorkers = 4;
     constexpr std::size_t kQueueCap = 2;
-    ThreadPool pool(kWorkers, kQueueCap);
 
     std::mutex m;
     std::condition_variable cv;
     int entered = 0; // workers currently parked inside a blocking task
     bool release = false;
-
-    // Guarantee the parked workers are released even if a REQUIRE below throws
-    // (e.g. a wait_for timeout on a loaded runner). Declared after m/cv/release
-    // so it destructs before ~ThreadPool joins — otherwise the whole test binary
-    // would hang instead of failing cleanly (qa-B1).
-    ScopeExit release_on_exit{[&] {
-        {
-            std::lock_guard lock(m);
-            release = true;
-        }
-        cv.notify_all();
-    }};
 
     auto blocker = [&] {
         {
@@ -113,6 +103,23 @@ TEST_CASE("ThreadPool applies backpressure when the queue is full", "[thread_poo
         std::unique_lock lock(m);
         cv.wait(lock, [&] { return release; });
     };
+
+    // Pool declared AFTER m/cv/release/blocker so ~ThreadPool joins the workers
+    // before that state is destroyed (workers touch m/cv until they return —
+    // destroying those first is UB, which TSan would flag).
+    ThreadPool pool(kWorkers, kQueueCap);
+
+    // ScopeExit declared AFTER the pool so on scope exit — including a REQUIRE
+    // unwind — it destructs BEFORE ~ThreadPool: release+notify happens-before the
+    // join, so the parked workers are freed and the join can't hang (qa-B1),
+    // while the join still completes before m/cv die.
+    ScopeExit release_on_exit{[&] {
+        {
+            std::lock_guard lock(m);
+            release = true;
+        }
+        cv.notify_all();
+    }};
 
     // Occupy every worker so nothing drains the queue. Submit one blocker at a
     // time and wait until it is actually running before submitting the next —


### PR DESCRIPTION
## Summary

Fixes #2037 — `yuzu-agent.exe` intermittently crashed on Windows with `STATUS_STACK_BUFFER_OVERRUN` (0xC0000409) under concurrent `execute_bundle` dispatch.

**Diagnosis (WinDbg on both preserved crash dumps):** the fault is `ucrtbase!abort+0x4e` with fastfail **subcode 7 (`FAST_FAIL_FATAL_APP_EXIT`)** — a controlled `abort()` via `std::terminate`, **not** a `/GS` stack-buffer overrun (which is subcode 2 in `__report_gsfailure`). `0xC0000409` is the generic name Windows gives *every* `__fastfail`, so the WER label is misleading. Root cause: the dispatch `ThreadPool` worker ran `task()` with no exception guard, and the command lambda only wrapped `target->execute()`; any throw elsewhere in the task body (metrics, `flush_output`, protobuf construction, `stream->Write`) escaped the worker's top-level callable → `terminate()` → `abort()`, killing the agent. Three concurrent bundle steps on an already-busy multithreaded process made an escaped throw likely enough to hit — explaining the 3-step-only, non-deterministic signature.

## Changes

- **`thread_pool.hpp` (new)** — `ThreadPool` extracted out of `agent.cpp` so the firewall is unit-testable; the worker loop now wraps `task()` in `try/catch(...)`. A throwing task can no longer terminate the process or kill a worker.
- **`agent.cpp`** — dispatch-lambda body extracted verbatim into `execute_command_task()`; the thin lambda `try/catch(...)`es it and emits a terminal `FAILURE` via `send_dispatch_failure()`, so an escaped throw no longer leaves the command hung until the server timeout.
- **`test_thread_pool.cpp` (new)** — a throwing task is contained and the pool keeps serving; every submitted task runs; queue-full applies backpressure.

## Governance

Full pipeline run (Gates 2–6, 13 agent reviews). Verdict **PASS** after one hardening round, folded into this commit:

- **qa-B1 (BLOCKING):** the backpressure *test* could hang the binary on a failing assertion (parked workers never released) → RAII release-guard.
- **UP-1 (verified vs server):** `send_dispatch_failure` now carries the reason in `resp.error()`, not `output` — the server finalizes a terminal frame onto prior `RUNNING` rows in place only when `output` is empty (`agent_service_impl.cpp`); a non-empty `output` would INSERT a second row and orphan them.
- **cpp-S1:** the firewall's own `spdlog` calls are guarded (a throw there would re-open the terminate hole).
- **cpp-safety-I1:** the "finished" log moved before the terminal write → no double terminal frame.
- cpp-safety proved no deadlock (`stream_write_mu_` is RAII-released before the lambda catch runs).

**Verification:** agent binary + `libyuzu_agent_core` link clean (gcc 15.2); full agent suite **768 cases / 100409 assertions** pass, including the 3 new firewall tests (stable across repeated runs).

## Follow-ups (filed separately)

- Sibling worker-thread firewalls (`update_thread_`/`sync_thread_`/snapshot pump/heartbeat + `server.cpp` bare `std::thread` lambdas — same terminate() class).
- `yuzu_agent_dispatch_exceptions_total` metric so the now-quiet contained failures are alertable.
- Dispatch-path fault-injection test + TSan nightly for the `stream_write_mu_` write path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)