### PR TITLE
feat(issues): PreToolUse guard for gh issue create + hooks fire on Windows (ADR-3001 pillar 4)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -102,7 +102,17 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/changelog-fragment-guard.py\"",
+            "command": "if command -v py >/dev/null 2>&1; then py -3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/changelog-fragment-guard.py\"; else python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/changelog-fragment-guard.py\"; fi",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Bash|PowerShell",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if command -v py >/dev/null 2>&1; then py -3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/issue-standard-guard.py\"; else python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/issue-standard-guard.py\"; fi",
             "timeout": 10
           }
         ]
@@ -113,7 +123,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/erl-dialyzer-reminder.py\"",
+            "command": "if command -v py >/dev/null 2>&1; then py -3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/erl-dialyzer-reminder.py\"; else python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/erl-dialyzer-reminder.py\"; fi",
             "timeout": 15
           }
         ]

--- a/changelog.d/adr3001-hook-interpreter-wiring.fixed.md
+++ b/changelog.d/adr3001-hook-interpreter-wiring.fixed.md
@@ -1,0 +1,9 @@
+- **Claude Code hooks now fire on Windows.** The `.claude/settings.json` hook
+  commands invoked `python3`, which on Windows resolves to the Microsoft Store
+  App-Execution-Alias stub — it exits nonzero and emits no output, so every
+  hook failed open and was silently dead on Windows (the changelog-fragment
+  guard and the dialyzer reminder both). The wiring now resolves a real
+  interpreter across platforms (`py -3` where the Windows launcher exists,
+  `python3` otherwise). A local self-check
+  (`scripts/hooks/selfcheck-issue-guard.py`) proves the hook fires through the
+  actual wiring — the class of failure CI, being Linux-only, cannot see.

--- a/changelog.d/adr3001-issue-standard-guard-hook.added.md
+++ b/changelog.d/adr3001-issue-standard-guard-hook.added.md
@@ -1,0 +1,9 @@
+- **Issue-standard guard (ADR-3001 pillar 4).** A `PreToolUse` hook
+  (`scripts/hooks/issue-standard-guard.py`) now holds `gh issue create` in
+  Claude sessions to `docs/agents/issue-standard.md`: it denies a filing whose
+  labels break the contract (exactly one type; `roadmap` XOR a priority plus a
+  triage state; no automation-owned labels at filing), asks for a human check
+  on a `security`-labelled create or when no duplicate-search probe ran earlier
+  in the session, and best-effort checks the body sections when they are
+  statically visible. It fails open on every ambiguity. Ships with the first
+  automated tests `scripts/hooks/` has ever had.

--- a/scripts/hooks/issue-standard-guard.py
+++ b/scripts/hooks/issue-standard-guard.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""
+issue-standard-guard.py -- PreToolUse hook: hold `gh issue create` to the
+issue-lifecycle standard (docs/agents/issue-standard.md, ADR-3001 pillar 4).
+
+Fires on Bash/PowerShell tool calls (matcher Bash|PowerShell in
+.claude/settings.json). It does nothing unless the command actually contains a
+`gh issue create` invocation, so the common case -- any other shell command --
+is a stdin-parse + one cheap regex and returns immediately.
+
+What it enforces, and why only these three things (ADR-3001 A1, "PR 3"):
+
+  * LABELS -- enforceable. `gh issue create` has no `--label-file`, so every
+    label is a literal `--label`/`-l` token in the command string. The gh/agent
+    path of the standard (section 4) is: exactly one TYPE, and then either
+    `roadmap` (parked scope: no priority, no triage state) XOR one PRIORITY
+    (P0/P1/P2) alongside one TRIAGE STATE. Automation-owned labels are never set
+    at filing. A contract violation -> deny with the exact fix.
+
+  * SECURITY label -> ask (never silently allow, never hard-deny). A public
+    `security` issue is hardening/defense-in-depth ONLY; an *exploitable*
+    vulnerability must go through private advisory reporting (SECURITY.md),
+    never a public issue. Only a human can make that call, so we surface it.
+
+  * DEDUPE -- read from the SESSION TRANSCRIPT, not the current command. The
+    standard (section 2) makes a duplicate search mandatory before filing. The
+    transcript records what actually ran, so this is far harder to fake than
+    inspecting the create command itself (which an agent controls): a probe has
+    to have executed earlier in the session as a real `gh search issues` /
+    `gh issue list --search` tool call. No probe seen -> ask (a legitimate
+    out-of-band dedupe is possible, so we confirm rather than block).
+
+  BODY is deliberately best-effort. `--body-file -`, heredocs and `$VAR` all
+  defeat static inspection, so the body-section check applies ONLY when the body
+  is a literal token, and even then it only asks; when unresolvable it is
+  skipped, never denied.
+
+Shell parsing is quote- and boundary-aware (see _split_shell_segments): the
+command is sliced into simple commands at UNQUOTED `;`, `&`, `|`, `&&`, `||` and
+newlines BEFORE tokenising each segment, so a second create on the next line
+cannot mask a bad first one and a quoted operator (`--title ";"`) cannot
+truncate the flag list. A heredoc / `--body-file -` body sits on its own lines,
+which become their own (non-create) segments and are ignored -- deliberately
+WITHOUT a naive heredoc pre-strip, which misread a `<<` inside a quoted body
+(`cout << x`, a bit-shift, an Erlang `<<Bin>>`) as a redirect and corrupted the
+command. Line continuations are normalised first. Anything still mis-sliced
+degrades to a segment shlex rejects -> fail-open.
+
+Design (matches changelog-fragment-guard.py -- the PreToolUse sibling, NOT
+erl-dialyzer-reminder.py's Stop-hook `{"decision":"block"}` shape):
+  - Fail-open: ANY ambiguity or error -> allow (no output, exit 0). A convention
+    hook must never wedge a session; the close-on-merge workflow and PR review
+    are the server-side backstops.
+  - UTF-8 explicit on stdin and the transcript (never inherit cp1252 on Windows;
+    see memory reference_hookify_ascii_only).
+  - ALWAYS exit 0; the decision is carried in the JSON, never the exit code.
+  - Claude sessions only. Other agents and humans remain bound by the text of
+    the standard and by PR review.
+"""
+import json
+import os
+import re
+import shlex
+import sys
+
+SHELL_TOOLS = ("Bash", "PowerShell")
+
+STD = "docs/agents/issue-standard.md"
+ADVISORY_URL = "https://github.com/Tr3kkR/Yuzu/security/advisories/new"
+
+# Bound work before the O(n^2) shlex tokeniser runs. A real `gh issue create`
+# command line is a few KB at most; anything larger fails open (a huge body
+# belongs in --body-file anyway). Guards against a crafted megabyte-long token
+# stalling the hook (which blocks the tool call synchronously).
+MAX_COMMAND_LEN = 20_000
+
+# Cheap pre-filter run on EVERY shell command. Regex, not a fixed-space
+# substring, so `gh   issue   create` (a shell collapses the whitespace) is not
+# a silent bypass; case-insensitive and `.exe`/`.cmd`-aware so `gh.exe issue
+# create` on Windows is not a bypass either. Permissive on purpose -- the real
+# parser decides; a false hit only costs one wasted tokenise.
+_CREATE_GATE = re.compile(r"gh(?:\.exe|\.cmd)?\s+issue\s+create\b", re.IGNORECASE)
+
+# Line continuation `\<newline>` -- a shell removes it entirely, so we normalise
+# it away before the gate/parser (else it splits the `gh issue create` phrase).
+_LINE_CONT = re.compile(r"\\\r?\n")
+
+# Label taxonomy -- docs/agents/triage-labels.md. Lower-case; labels are
+# casefolded before comparison because GitHub resolves label names
+# case-insensitively (so `--label SECURITY` applies the real `security` label).
+TYPE_LABELS = frozenset({
+    "bug", "enhancement", "task", "decision",
+    "spike", "documentation", "question", "operational",
+})
+TRIAGE_STATES = frozenset({
+    "needs-triage", "needs-info", "ready-for-agent", "ready-for-human", "wontfix",
+})
+PRIORITIES = frozenset({"p0", "p1", "p2"})
+AUTOMATION_OWNED = frozenset({
+    "do-not-close", "fixed-on-dev", "automation-broken",
+    "triage-sweep", "nightly-broken", "runner-inventory-drift",
+})
+ROADMAP = "roadmap"
+SECURITY = "security"
+
+# Body sections mandated by the standard section 3, in order.
+BODY_SECTIONS = ("Context", "Evidence", "Acceptance criteria", "Origin")
+
+
+def _is_unresolvable(value):
+    """True if a --body value cannot be inspected statically (var/subst/stdin)."""
+    if value in ("-", ""):
+        return True
+    return "$" in value or "`" in value
+
+
+def _split_labels(value):
+    """`bug,P1,needs-triage` -> ['bug','P1','needs-triage'] (drops empties)."""
+    return [p.strip() for p in value.split(",") if p.strip()]
+
+
+def _split_shell_segments(command):
+    """Slice a command into simple-command segments at UNQUOTED separators.
+
+    Splits on `;`, `&`, `&&`, `|`, `||` and newlines that are outside single
+    quotes, double quotes and backticks. A quoted operator (e.g. inside
+    `--title ";"`) is therefore NOT a boundary, and a create on the next line
+    does not merge into the previous one. A heredoc body sits on its own lines,
+    which become their own segments here and are dropped downstream because they
+    are not a `gh issue create`. Escapes are honoured outside single quotes and
+    inside double quotes/backticks.
+    """
+    segments = []
+    buf = []
+    quote = None  # "'", '"', "`" or None
+    i = 0
+    n = len(command)
+    while i < n:
+        c = command[i]
+        if quote:
+            if c == "\\" and quote != "'" and i + 1 < n:
+                buf.append(c)
+                buf.append(command[i + 1])
+                i += 2
+                continue
+            buf.append(c)
+            if c == quote:
+                quote = None
+            i += 1
+            continue
+        if c == "\\" and i + 1 < n:
+            buf.append(c)
+            buf.append(command[i + 1])
+            i += 2
+            continue
+        if c in ("'", '"', "`"):
+            quote = c
+            buf.append(c)
+            i += 1
+            continue
+        if c in ("\n", ";"):
+            segments.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        if c == "&":
+            segments.append("".join(buf))
+            buf = []
+            i += 2 if (i + 1 < n and command[i + 1] == "&") else 1
+            continue
+        if c == "|":
+            segments.append("".join(buf))
+            buf = []
+            i += 2 if (i + 1 < n and command[i + 1] == "|") else 1
+            continue
+        buf.append(c)
+        i += 1
+    segments.append("".join(buf))
+    return segments
+
+
+def _is_gh_token(tok):
+    """True if a token invokes gh: `gh`, `gh.exe`, `gh.cmd`, or a path to one."""
+    base = tok.replace("\\", "/").rsplit("/", 1)[-1].casefold()
+    return base in ("gh", "gh.exe", "gh.cmd")
+
+
+def _find_create_arg_lists(command):
+    """Return the flag-token list for every real `gh issue create` invocation.
+
+    Segments the command first (so operators/newlines/heredocs are handled),
+    then within each segment finds `gh` `issue` `create` as three contiguous
+    tokens (a path-prefixed `/usr/bin/gh` counts; a create only inside a quoted
+    string does not, since it is one token). A segment shlex cannot parse is
+    skipped -> fail-open.
+    """
+    out = []
+    for segment in _split_shell_segments(command):
+        try:
+            tokens = shlex.split(segment, posix=True)
+        except ValueError:
+            continue  # unbalanced quotes etc. -> skip this segment
+        i, n = 0, len(tokens)
+        while i < n:
+            if (
+                _is_gh_token(tokens[i])
+                and i + 2 < n
+                and tokens[i + 1] == "issue"
+                and tokens[i + 2] == "create"
+            ):
+                out.append(tokens[i + 3:])
+                i += 3
+            else:
+                i += 1
+    return out
+
+
+def _parse_create_flags(args):
+    """Extract (labels, body, body_resolvable, web, is_help) from a create's flags.
+
+    Handles `-l x`, `-lx`, `--label x`, `--label=x`, comma lists and repeats for
+    labels; `-b`/`--body`(`=`) for the body; `-F`/`--body-file`(`=`), `-e`/
+    `--editor` and any var/subst body as unresolvable; `-w`/`--web` (browser
+    form sets labels interactively) and `-h`/`--help` as skip signals.
+    """
+    labels = []
+    body = None
+    body_resolvable = True
+    web = False
+    is_help = False
+    i, n = 0, len(args)
+    while i < n:
+        tok = args[i]
+        if tok in ("-l", "--label"):
+            if i + 1 < n:
+                labels.extend(_split_labels(args[i + 1]))
+                i += 2
+                continue
+            i += 1
+            continue
+        if tok.startswith("--label="):
+            labels.extend(_split_labels(tok[len("--label="):]))
+            i += 1
+            continue
+        # Glued short form `-lbug`. (`--label` is caught above and never reaches
+        # here; only a `-l...` short cluster does.)
+        if tok.startswith("-l") and len(tok) > 2 and not tok.startswith("--"):
+            labels.extend(_split_labels(tok[2:]))
+            i += 1
+            continue
+        if tok in ("-b", "--body"):
+            if i + 1 < n:
+                val = args[i + 1]
+                if _is_unresolvable(val):
+                    body_resolvable = False
+                else:
+                    body = val
+                i += 2
+                continue
+            i += 1
+            continue
+        if tok.startswith("--body="):
+            val = tok[len("--body="):]
+            if _is_unresolvable(val):
+                body_resolvable = False
+            else:
+                body = val
+            i += 1
+            continue
+        if tok in ("-F", "--body-file"):
+            body_resolvable = False
+            i += 2 if i + 1 < n else 1
+            continue
+        if tok.startswith("--body-file="):
+            body_resolvable = False
+            i += 1
+            continue
+        if tok in ("-e", "--editor"):
+            body_resolvable = False
+            i += 1
+            continue
+        if tok in ("-w", "--web"):
+            web = True
+            i += 1
+            continue
+        if tok in ("-h", "--help"):
+            is_help = True
+            i += 1
+            continue
+        i += 1
+    return labels, body, body_resolvable, web, is_help
+
+
+def _evaluate_labels(labels):
+    """Return (deny_reasons, ask_reasons) for one create's label set.
+
+    Labels are casefolded so a mis-cased `SECURITY`/`DO-NOT-CLOSE` (which GitHub
+    applies as the real label) still trips the security/automation checks.
+    """
+    deny = []
+    ask = []
+    label_set = {lbl.casefold() for lbl in labels}
+    types = sorted(label_set & TYPE_LABELS)
+    states = sorted(label_set & TRIAGE_STATES)
+    prios = sorted(label_set & PRIORITIES)
+    autos = sorted(label_set & AUTOMATION_OWNED)
+    has_roadmap = ROADMAP in label_set
+
+    # exactly one type (any path)
+    if len(types) == 0:
+        deny.append(
+            "no TYPE label -- add exactly one of: "
+            + ", ".join(sorted(TYPE_LABELS))
+        )
+    elif len(types) > 1:
+        deny.append(f"multiple TYPE labels {types} -- keep exactly one")
+
+    # roadmap XOR (priority + triage state), on the gh path
+    if has_roadmap:
+        if prios:
+            deny.append(
+                f"`roadmap` carries no priority -- remove {prios} "
+                "(parked scope is not prioritised)"
+            )
+        if states:
+            deny.append(
+                f"`roadmap` carries no triage state -- remove {states} "
+                "(parked scope is excluded from triage)"
+            )
+    else:
+        if len(prios) == 0:
+            deny.append(
+                "no PRIORITY -- the gh/agent path sets one of P0/P1/P2 "
+                "(or use `roadmap` for parked scope)"
+            )
+        elif len(prios) > 1:
+            deny.append(f"multiple PRIORITY labels {prios} -- keep exactly one")
+        if len(states) == 0:
+            deny.append(
+                "no TRIAGE STATE -- add exactly one of: "
+                + ", ".join(sorted(TRIAGE_STATES))
+            )
+        elif len(states) > 1:
+            deny.append(f"multiple TRIAGE STATE labels {states} -- keep exactly one")
+
+    # automation-owned labels are never set at filing
+    if autos:
+        deny.append(
+            f"automation-owned label(s) {autos} must not be set at filing -- "
+            "automation applies them (a maintainer may add `do-not-close` later "
+            "via `gh issue edit`)"
+        )
+
+    # security -> ask (a human must confirm public-issue eligibility)
+    if SECURITY in label_set:
+        ask.append(
+            "carries the `security` label. PUBLIC security issues are "
+            "hardening / defense-in-depth ONLY -- an exploitable vulnerability "
+            f"goes through PRIVATE advisory reporting ({ADVISORY_URL}), never a "
+            "public issue (SECURITY.md, standard section 6). Confirm this is "
+            "non-exploitable before filing."
+        )
+    return deny, ask
+
+
+def _evaluate_body(body, body_resolvable):
+    """Best-effort body-section check. Returns ask_reasons (never deny)."""
+    if not body_resolvable or body is None:
+        return []  # unresolvable -> skip, never deny
+    missing = [
+        s for s in BODY_SECTIONS
+        if not re.search(r"(?mi)^#{1,6}\s*" + re.escape(s) + r"\b", body)
+    ]
+    if missing:
+        return [
+            "body is missing required section(s) "
+            f"{missing} -- the standard (section 3) wants "
+            "## Context / ## Evidence (with file:line) / "
+            "## Acceptance criteria / ## Origin"
+        ]
+    return []
+
+
+def _is_search_flag(tok):
+    """A real search flag token: --search, --search=x, -S, or glued -Sx."""
+    return (
+        tok == "--search"
+        or tok.startswith("--search=")
+        or tok == "-S"
+        or (tok.startswith("-S") and len(tok) > 2)
+    )
+
+
+def _looks_like_probe(command):
+    """True if a command tokenises to a real dedupe search.
+
+    Tokenised (not substring): `gh ... search issues`, or `gh ... issue list`
+    with a real `--search`/`-S` flag TOKEN. Position-independent so global flags
+    before the subcommand (`gh --repo X issue list --search y`) still count, and
+    glued short forms (`-Sfoo`) count. Rejects a probe mentioned only inside a
+    quoted string/comment (it would be one token) and `-S` inside an unrelated
+    value like `Foo-Section` (that is not a standalone token).
+    """
+    try:
+        toks = shlex.split(command, posix=True)
+    except ValueError:
+        return False
+    if not any(_is_gh_token(t) for t in toks):
+        return False
+    n = len(toks)
+    # `search issues` as a contiguous pair
+    if any(toks[i] == "search" and toks[i + 1] == "issues" for i in range(n - 1)):
+        return True
+    # `issue list` as a contiguous pair, plus a search flag anywhere
+    if any(toks[i] == "issue" and toks[i + 1] == "list" for i in range(n - 1)):
+        if any(_is_search_flag(t) for t in toks):
+            return True
+    return False
+
+
+def _iter_tool_commands(transcript_path):
+    """Yield the command string of every shell tool_use in the transcript."""
+    with open(transcript_path, "r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            msg = rec.get("message", rec)
+            content = msg.get("content") if isinstance(msg, dict) else None
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    if block.get("name") in SHELL_TOOLS:
+                        yield str((block.get("input") or {}).get("command") or "")
+
+
+def _dedupe_probe_seen(transcript_path):
+    """True if a duplicate-search probe ran earlier this session.
+
+    Fail-open: if the transcript cannot be read we return True (no ask) rather
+    than nagging on our own inability to inspect.
+    """
+    if not transcript_path:
+        return True
+    transcript_path = os.path.expanduser(transcript_path)
+    if not os.path.isfile(transcript_path):
+        return True
+    try:
+        for cmd in _iter_tool_commands(transcript_path):
+            if "gh" in cmd and _looks_like_probe(cmd):
+                return True
+    except Exception:
+        return True  # fail-open
+    return False
+
+
+def _emit(decision, reason):
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": decision,
+            "permissionDecisionReason": reason,
+        }
+    }))
+
+
+def main():
+    try:
+        raw = sys.stdin.buffer.read()
+        data = json.loads(raw.decode("utf-8", errors="replace")) if raw else {}
+    except Exception:
+        return  # fail-open
+
+    if not isinstance(data, dict) or data.get("tool_name") not in SHELL_TOOLS:
+        return
+    tool_input = data.get("tool_input")
+    command = tool_input.get("command") if isinstance(tool_input, dict) else None
+    if not isinstance(command, str):
+        return
+    command = _LINE_CONT.sub("", command)  # a shell removes `\<newline>` entirely
+    if not _CREATE_GATE.search(command):
+        return  # cheap gate -- the vast majority of shell calls stop here
+    if len(command) > MAX_COMMAND_LEN:
+        return  # oversized -> fail-open (avoids the shlex O(n^2) path)
+
+    create_arg_lists = _find_create_arg_lists(command)
+    if not create_arg_lists:
+        return  # `gh issue create` only inside a quoted string -> not a real create
+
+    deny_reasons = []
+    ask_reasons = []
+    real_creates = 0
+    for args in create_arg_lists:
+        labels, body, body_resolvable, web, is_help = _parse_create_flags(args)
+        if web or is_help:
+            continue  # browser form / help -> nothing to enforce here
+        real_creates += 1
+        d, a = _evaluate_labels(labels)
+        deny_reasons.extend(d)
+        ask_reasons.extend(a)
+        ask_reasons.extend(_evaluate_body(body, body_resolvable))
+
+    if real_creates == 0:
+        return  # every create was --web/--help
+
+    # Dedupe is session-level, evaluated once for the whole command.
+    if not _dedupe_probe_seen(data.get("transcript_path")):
+        ask_reasons.append(
+            "no duplicate-search probe (`gh search issues` or "
+            "`gh issue list --search`) was seen in this session before this "
+            "filing. The standard (section 2) requires a dedupe search. Confirm "
+            "you checked for duplicates, or run a probe first."
+        )
+
+    # deny wins over ask wins over allow.
+    if deny_reasons:
+        # de-dupe while preserving order (several creates can raise the same reason)
+        seen = set()
+        uniq = [r for r in deny_reasons if not (r in seen or seen.add(r))]
+        bullets = "\n".join(f"  - {r}" for r in uniq)
+        _emit(
+            "deny",
+            "This `gh issue create` does not meet the issue-lifecycle standard "
+            f"({STD}, ADR-3001 section 4):\n{bullets}\n\n"
+            "Fix the --label flags and retry. Full label contract: "
+            "docs/agents/triage-labels.md.",
+        )
+        return
+    if ask_reasons:
+        seen = set()
+        uniq = [r for r in ask_reasons if not (r in seen or seen.add(r))]
+        bullets = "\n".join(f"  - {r}" for r in uniq)
+        _emit(
+            "ask",
+            f"This `gh issue create` needs a human check ({STD}):\n{bullets}",
+        )
+        return
+    # otherwise allow (emit nothing)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        sys.exit(0)  # ALWAYS exit 0 -- decision is in the JSON, never the exit code

--- a/scripts/hooks/issue-standard-guard.py
+++ b/scripts/hooks/issue-standard-guard.py
@@ -54,6 +54,8 @@ erl-dialyzer-reminder.py's Stop-hook `{"decision":"block"}` shape):
   - UTF-8 explicit on stdin and the transcript (never inherit cp1252 on Windows;
     see memory reference_hookify_ascii_only).
   - ALWAYS exit 0; the decision is carried in the JSON, never the exit code.
+  - Operator escape hatch (ADR-3001 charter): `YUZU_ISSUE_STANDARD_ACK=1` in the
+    environment short-circuits the hook to allow, for a deliberate override.
   - Claude sessions only. Other agents and humans remain bound by the text of
     the standard and by PR review.
 """
@@ -81,9 +83,26 @@ MAX_COMMAND_LEN = 20_000
 # parser decides; a false hit only costs one wasted tokenise.
 _CREATE_GATE = re.compile(r"gh(?:\.exe|\.cmd)?\s+issue\s+create\b", re.IGNORECASE)
 
-# Line continuation `\<newline>` -- a shell removes it entirely, so we normalise
-# it away before the gate/parser (else it splits the `gh issue create` phrase).
+# Line continuations -- a shell removes them entirely, so we normalise them away
+# before the gate/parser (else they split the `gh issue create` phrase). Bash
+# uses `\<newline>`; PowerShell uses `` `<newline> `` (backtick), stripped only
+# for the PowerShell tool since a backtick means command-substitution in Bash.
 _LINE_CONT = re.compile(r"\\\r?\n")
+_PS_LINE_CONT = re.compile(r"`\r?\n")
+
+# The ADR-3001 pillar-4 charter mandates an explicit operator escape hatch: set
+# this to "1" to proceed through a known non-conformant create (docs/adr/3001,
+# "Mechanical enforcement at creation").
+ACK_ENV = "YUZU_ISSUE_STANDARD_ACK"
+
+# A command word may be preceded by `VAR=val` assignments and these wrappers;
+# `gh` must be the command word itself, so `echo gh issue create ...` (echo is
+# not a wrapper) is NOT treated as a filing.
+_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+WRAPPERS = frozenset({
+    "command", "builtin", "exec", "env", "sudo", "doas",
+    "nice", "time", "xargs", "winpty", "stdbuf",
+})
 
 # Label taxonomy -- docs/agents/triage-labels.md. Lower-case; labels are
 # casefolded before comparison because GitHub resolves label names
@@ -127,8 +146,10 @@ def _split_shell_segments(command):
     `--title ";"`) is therefore NOT a boundary, and a create on the next line
     does not merge into the previous one. A heredoc body sits on its own lines,
     which become their own segments here and are dropped downstream because they
-    are not a `gh issue create`. Escapes are honoured outside single quotes and
-    inside double quotes/backticks.
+    are not a `gh issue create`. An unquoted word-initial `#` starts a comment
+    (Bash and PowerShell both) -- the shell never passes it to gh, so we drop it
+    too, otherwise `--label P1 # --label bug` would count the commented label.
+    Escapes are honoured outside single quotes and inside double quotes/backticks.
     """
     segments = []
     buf = []
@@ -152,6 +173,12 @@ def _split_shell_segments(command):
             buf.append(c)
             buf.append(command[i + 1])
             i += 2
+            continue
+        if c == "#" and (not buf or buf[-1] in " \t"):
+            # unquoted word-initial comment -> drop to end of line (the newline,
+            # if any, still splits the segment on the next iteration)
+            while i < n and command[i] != "\n":
+                i += 1
             continue
         if c in ("'", '"', "`"):
             quote = c
@@ -185,14 +212,29 @@ def _is_gh_token(tok):
     return base in ("gh", "gh.exe", "gh.cmd")
 
 
+def _command_word_index(tokens):
+    """Index of the command word: skip leading `VAR=val` assignments and wrappers.
+
+    Returns -1 if the tokens are all assignments/wrappers. This is what makes
+    `gh` have to BE the command (so `echo gh issue create ...` is not a filing)
+    while still allowing `sudo gh ...` / `command gh ...` / `VAR=1 gh ...`.
+    """
+    for i, t in enumerate(tokens):
+        if _ASSIGN_RE.match(t) or t in WRAPPERS:
+            continue
+        return i
+    return -1
+
+
 def _find_create_arg_lists(command):
     """Return the flag-token list for every real `gh issue create` invocation.
 
-    Segments the command first (so operators/newlines/heredocs are handled),
-    then within each segment finds `gh` `issue` `create` as three contiguous
-    tokens (a path-prefixed `/usr/bin/gh` counts; a create only inside a quoted
-    string does not, since it is one token). A segment shlex cannot parse is
-    skipped -> fail-open.
+    Segments the command first (so operators/newlines/comments are handled),
+    then requires `gh` (or `/path/to/gh`, `gh.exe`, `gh.cmd`) to be the segment's
+    COMMAND WORD followed by `issue create`. Requiring command position (not a
+    scan of every token) means `echo gh issue create ...` is not a filing, and a
+    create only inside a quoted string is not one either (it is a single token).
+    A segment shlex cannot parse is skipped -> fail-open.
     """
     out = []
     for segment in _split_shell_segments(command):
@@ -200,18 +242,16 @@ def _find_create_arg_lists(command):
             tokens = shlex.split(segment, posix=True)
         except ValueError:
             continue  # unbalanced quotes etc. -> skip this segment
-        i, n = 0, len(tokens)
-        while i < n:
-            if (
-                _is_gh_token(tokens[i])
-                and i + 2 < n
-                and tokens[i + 1] == "issue"
-                and tokens[i + 2] == "create"
-            ):
-                out.append(tokens[i + 3:])
-                i += 3
-            else:
-                i += 1
+        ci = _command_word_index(tokens)
+        if ci < 0:
+            continue
+        if (
+            _is_gh_token(tokens[ci])
+            and ci + 2 < len(tokens)
+            and tokens[ci + 1] == "issue"
+            and tokens[ci + 2] == "create"
+        ):
+            out.append(tokens[ci + 3:])
     return out
 
 
@@ -470,6 +510,11 @@ def _emit(decision, reason):
 
 
 def main():
+    # ADR-3001 pillar 4: explicit operator escape hatch. Checked first so it
+    # short-circuits every path, matching the charter's "operator bypass".
+    if os.environ.get(ACK_ENV) == "1":
+        return
+
     try:
         raw = sys.stdin.buffer.read()
         data = json.loads(raw.decode("utf-8", errors="replace")) if raw else {}
@@ -482,6 +527,8 @@ def main():
     command = tool_input.get("command") if isinstance(tool_input, dict) else None
     if not isinstance(command, str):
         return
+    if data.get("tool_name") == "PowerShell":
+        command = _PS_LINE_CONT.sub("", command)  # PowerShell backtick-newline
     command = _LINE_CONT.sub("", command)  # a shell removes `\<newline>` entirely
     if not _CREATE_GATE.search(command):
         return  # cheap gate -- the vast majority of shell calls stop here

--- a/scripts/hooks/issue-standard-guard.py
+++ b/scripts/hooks/issue-standard-guard.py
@@ -87,12 +87,12 @@ ADVISORY_URL = "https://github.com/Tr3kkR/Yuzu/security/advisories/new"
 # stalling the hook (which blocks the tool call synchronously).
 MAX_COMMAND_LEN = 20_000
 
-# Cheap pre-filter run on EVERY shell command. Regex, not a fixed-space
-# substring, so `gh   issue   create` (a shell collapses the whitespace) is not
-# a silent bypass; case-insensitive and `.exe`/`.cmd`-aware so `gh.exe issue
-# create` on Windows is not a bypass either. Permissive on purpose -- the real
-# parser decides; a false hit only costs one wasted tokenise.
-_CREATE_GATE = re.compile(r"gh(?:\.exe|\.cmd)?\s+issue\s+create\b", re.IGNORECASE)
+# Cheap pre-filter run on EVERY shell command. Gates on the distinctive
+# `issue create` phrase (case-insensitive), NOT `gh...issue create`, so a global
+# flag between them (`gh --repo X issue create`) is not a silent bypass. `gh   issue
+# create` (collapsed whitespace) also matches. Permissive on purpose -- the real
+# parser confirms the `gh` command word; a false hit only costs one tokenise.
+_CREATE_GATE = re.compile(r"\bissue\s+create\b", re.IGNORECASE)
 
 # Line continuations -- a shell removes them entirely, so we normalise them away
 # before the gate/parser (else they split the `gh issue create` phrase). Bash
@@ -110,17 +110,17 @@ ACK_ENV = "YUZU_ISSUE_STANDARD_ACK"
 # redirections, and these wrappers (matched by BASENAME so `/usr/bin/env`
 # counts); `gh` must be the command word itself, so `echo gh issue create ...`
 # (echo is not a wrapper) is NOT treated as a filing.
-_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")           # Bash `VAR=val`
+_PS_VAR_RE = re.compile(r"^\$[A-Za-z_]\w*$")                   # PowerShell `$var`
 # A redirection operator, optionally with a leading fd and/or a glued target:
-# `>`, `>>`, `2>`, `&>`, `>out.txt`, `2>err`.
-_REDIR_RE = re.compile(r"^(?:\d*(?:>>|<<|<|>)|&>)")
+# `>`, `>>`, `2>`, `&>`, `>&`, `<&`, `<>`, `>out.txt`, `2>&1`.
+_REDIR_RE = re.compile(r"^(?:\d*(?:>>|>&|<&|<>|<<<|<<|<|>)|&>>|&>)")
 WRAPPERS = frozenset({
     "command", "builtin", "exec", "env", "sudo", "doas",
     "nice", "time", "xargs", "winpty", "stdbuf", "timeout", "nohup", "ionice",
 })
-# Wrappers that consume a leading option/value token (best-effort): `timeout 5`,
-# `nice -n 10`, `stdbuf -oL`.
-ARG_WRAPPERS = frozenset({"timeout", "nice", "stdbuf", "ionice"})
+# gh global flags (before the subcommand) that consume a value.
+_GH_VALUE_FLAGS = frozenset({"--repo", "-R", "--hostname"})
 # Shell keywords / grouping tokens that precede a command in the same segment.
 CONTROL = frozenset({
     "if", "then", "elif", "else", "fi", "do", "done", "while", "until",
@@ -220,9 +220,18 @@ def _split_shell_segments(command):
             i += 1
             continue
         if c == "&":
-            segments.append("".join(buf))
+            if i + 1 < n and command[i + 1] == "&":
+                segments.append("".join(buf))  # `&&`
+                buf = []
+                i += 2
+                continue
+            if (buf and buf[-1] in "<>") or (i + 1 < n and command[i + 1] == ">"):
+                buf.append(c)  # `>&`, `<&`, `&>`, `2>&1` -- part of a redirect
+                i += 1
+                continue
+            segments.append("".join(buf))  # background `&`
             buf = []
-            i += 2 if (i + 1 < n and command[i + 1] == "&") else 1
+            i += 1
             continue
         if c == "|":
             segments.append("".join(buf))
@@ -254,33 +263,58 @@ def _command_word_index(tokens):
     i, n = 0, len(tokens)
     while i < n:
         t = tokens[i]
+        # PowerShell native assignment `$var = ...` (two tokens) -> skip both.
+        if i + 1 < n and tokens[i + 1] == "=" and _PS_VAR_RE.match(t):
+            i += 2
+            continue
         if _ASSIGN_RE.match(t) or t in CONTROL:
             i += 1
             continue
         if _REDIR_RE.match(t):
-            # a bare operator (`>`, `2>`) also swallows its target token
-            i += 2 if (t in (">", ">>", "<", "<<") or _REDIR_RE.fullmatch(t)) else 1
+            # a bare operator (`>`, `2>`) also swallows its target token; a
+            # glued one (`>out`, `2>&1`) does not.
+            i += 2 if _REDIR_RE.fullmatch(t) else 1
             continue
         base = t.replace("\\", "/").rsplit("/", 1)[-1]
         if base in WRAPPERS:
             i += 1
-            if base in ARG_WRAPPERS:
-                while i < n and (tokens[i].startswith("-") or tokens[i].isdigit()):
-                    i += 1
+            # any wrapper's own options/values: `sudo -E`, `command -p`,
+            # `env -i`, `timeout 5`, `nice -n 10`.
+            while i < n and (tokens[i].startswith("-") or tokens[i].isdigit()):
+                i += 1
             continue
         return i
     return -1
 
 
+def _issue_create_args(tokens, ci):
+    """If gh at index `ci` invokes `issue create`, return its arg tokens, else None.
+
+    Skips gh's own global flags before the subcommand (`gh --repo X issue create`,
+    `gh -R X issue create`) -- mirroring the position-independence the dedupe
+    probe detector already has.
+    """
+    j = ci + 1
+    n = len(tokens)
+    while j < n and tokens[j].startswith("-"):
+        flag = tokens[j]
+        j += 1
+        if flag in _GH_VALUE_FLAGS and j < n and not tokens[j].startswith("-"):
+            j += 1  # consume the value of `--repo X` / `-R X`
+    if j + 1 < n and tokens[j] == "issue" and tokens[j + 1] == "create":
+        return tokens[j + 2:]
+    return None
+
+
 def _find_create_arg_lists(command):
     """Return the flag-token list for every real `gh issue create` invocation.
 
-    Segments the command first (so operators/newlines/comments are handled),
-    then requires `gh` (or `/path/to/gh`, `gh.exe`, `gh.cmd`) to be the segment's
-    COMMAND WORD followed by `issue create`. Requiring command position (not a
-    scan of every token) means `echo gh issue create ...` is not a filing, and a
-    create only inside a quoted string is not one either (it is a single token).
-    A segment shlex cannot parse is skipped -> fail-open.
+    Segments the command first (so operators/newlines/comments/substitution are
+    handled), then requires `gh` (or `/path/to/gh`, `gh.exe`, `gh.cmd`) to be the
+    segment's COMMAND WORD, optionally followed by gh global flags, then `issue
+    create`. Requiring command position (not a scan of every token) means `echo
+    gh issue create ...` is not a filing, and a create only inside a quoted
+    string is not one either. A segment shlex cannot parse is skipped -> fail-open.
     """
     out = []
     for segment in _split_shell_segments(command):
@@ -289,15 +323,11 @@ def _find_create_arg_lists(command):
         except ValueError:
             continue  # unbalanced quotes etc. -> skip this segment
         ci = _command_word_index(tokens)
-        if ci < 0:
+        if ci < 0 or not _is_gh_token(tokens[ci]):
             continue
-        if (
-            _is_gh_token(tokens[ci])
-            and ci + 2 < len(tokens)
-            and tokens[ci + 1] == "issue"
-            and tokens[ci + 2] == "create"
-        ):
-            out.append(tokens[ci + 3:])
+        args = _issue_create_args(tokens, ci)
+        if args is not None:
+            out.append(args)
     return out
 
 

--- a/scripts/hooks/issue-standard-guard.py
+++ b/scripts/hooks/issue-standard-guard.py
@@ -37,14 +37,25 @@ What it enforces, and why only these three things (ADR-3001 A1, "PR 3"):
 
 Shell parsing is quote- and boundary-aware (see _split_shell_segments): the
 command is sliced into simple commands at UNQUOTED `;`, `&`, `|`, `&&`, `||` and
-newlines BEFORE tokenising each segment, so a second create on the next line
-cannot mask a bad first one and a quoted operator (`--title ";"`) cannot
-truncate the flag list. A heredoc / `--body-file -` body sits on its own lines,
+newlines -- plus the command-substitution / grouping delimiters `(` `)` and
+backtick -- BEFORE tokenising each segment, so a create hidden in the idiomatic
+`URL=$(gh issue create ...)`, a subshell `( gh ... )`, a backtick, or on the
+next line cannot mask a bad one, and a quoted operator (`--title ";"`) cannot
+truncate the flag list. `gh` must be the segment's command word (after
+assignments / wrappers / control keywords / redirections), so `echo gh issue
+create` is not a filing. A heredoc / `--body-file -` body sits on its own lines,
 which become their own (non-create) segments and are ignored -- deliberately
 WITHOUT a naive heredoc pre-strip, which misread a `<<` inside a quoted body
 (`cout << x`, a bit-shift, an Erlang `<<Bin>>`) as a redirect and corrupted the
-command. Line continuations are normalised first. Anything still mis-sliced
-degrades to a segment shlex rejects -> fail-open.
+command. Line continuations are normalised first.
+
+Static parsing is best-effort by design: shell-expansion of a label or the gh
+word itself (`--label $'security'`, `${x}`, `$(echo gh) issue create`) defeats
+resolution, so the security-label ask and the label-contract deny are
+best-effort against a deliberately-obfuscating command. Anything mis-sliced or
+unresolved degrades to allow -> fail-open. This is an enforcement/teaching layer,
+never a security control; the close-on-merge workflow and PR review are the
+backstops.
 
 Design (matches changelog-fragment-guard.py -- the PreToolUse sibling, NOT
 erl-dialyzer-reminder.py's Stop-hook `{"decision":"block"}` shape):
@@ -95,13 +106,25 @@ _PS_LINE_CONT = re.compile(r"`\r?\n")
 # "Mechanical enforcement at creation").
 ACK_ENV = "YUZU_ISSUE_STANDARD_ACK"
 
-# A command word may be preceded by `VAR=val` assignments and these wrappers;
-# `gh` must be the command word itself, so `echo gh issue create ...` (echo is
-# not a wrapper) is NOT treated as a filing.
+# A command word may be preceded by `VAR=val` assignments, control keywords,
+# redirections, and these wrappers (matched by BASENAME so `/usr/bin/env`
+# counts); `gh` must be the command word itself, so `echo gh issue create ...`
+# (echo is not a wrapper) is NOT treated as a filing.
 _ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+# A redirection operator, optionally with a leading fd and/or a glued target:
+# `>`, `>>`, `2>`, `&>`, `>out.txt`, `2>err`.
+_REDIR_RE = re.compile(r"^(?:\d*(?:>>|<<|<|>)|&>)")
 WRAPPERS = frozenset({
     "command", "builtin", "exec", "env", "sudo", "doas",
-    "nice", "time", "xargs", "winpty", "stdbuf",
+    "nice", "time", "xargs", "winpty", "stdbuf", "timeout", "nohup", "ionice",
+})
+# Wrappers that consume a leading option/value token (best-effort): `timeout 5`,
+# `nice -n 10`, `stdbuf -oL`.
+ARG_WRAPPERS = frozenset({"timeout", "nice", "stdbuf", "ionice"})
+# Shell keywords / grouping tokens that precede a command in the same segment.
+CONTROL = frozenset({
+    "if", "then", "elif", "else", "fi", "do", "done", "while", "until",
+    "!", "{", "}", "[[", "]]", ":",
 })
 
 # Label taxonomy -- docs/agents/triage-labels.md. Lower-case; labels are
@@ -141,19 +164,22 @@ def _split_labels(value):
 def _split_shell_segments(command):
     """Slice a command into simple-command segments at UNQUOTED separators.
 
-    Splits on `;`, `&`, `&&`, `|`, `||` and newlines that are outside single
-    quotes, double quotes and backticks. A quoted operator (e.g. inside
-    `--title ";"`) is therefore NOT a boundary, and a create on the next line
-    does not merge into the previous one. A heredoc body sits on its own lines,
-    which become their own segments here and are dropped downstream because they
-    are not a `gh issue create`. An unquoted word-initial `#` starts a comment
-    (Bash and PowerShell both) -- the shell never passes it to gh, so we drop it
-    too, otherwise `--label P1 # --label bug` would count the commented label.
-    Escapes are honoured outside single quotes and inside double quotes/backticks.
+    Splits on `;`, `&`, `&&`, `|`, `||`, newlines, AND the command-substitution
+    / grouping delimiters `(` `)` and backtick -- all outside single/double
+    quotes. So the create inside `URL=$(gh issue create ...)`, `` `gh ...` ``,
+    `( gh ... )` or a `$(...)` capture becomes its own segment and is evaluated,
+    not hidden. A quoted operator (e.g. inside `--title ";"`) is NOT a boundary,
+    and a create on the next line does not merge into the previous one. A heredoc
+    body sits on its own lines, which become their own segments and are dropped
+    downstream because they are not a `gh issue create`. An unquoted word-initial
+    `#` starts a comment (Bash and PowerShell both) -- the shell never passes it
+    to gh, so we drop it too, else `--label P1 # --label bug` would count the
+    commented label. Escapes are honoured outside single quotes and inside double
+    quotes.
     """
     segments = []
     buf = []
-    quote = None  # "'", '"', "`" or None
+    quote = None  # "'" or '"' or None
     i = 0
     n = len(command)
     while i < n:
@@ -180,12 +206,15 @@ def _split_shell_segments(command):
             while i < n and command[i] != "\n":
                 i += 1
             continue
-        if c in ("'", '"', "`"):
+        if c in ("'", '"'):
             quote = c
             buf.append(c)
             i += 1
             continue
-        if c in ("\n", ";"):
+        # command-substitution / grouping delimiters are command boundaries:
+        # the `$` of `$(` stays behind harmlessly, the inner command is its own
+        # segment. Backtick is command substitution in Bash (not a quote here).
+        if c in ("\n", ";", "(", ")", "`"):
             segments.append("".join(buf))
             buf = []
             i += 1
@@ -213,14 +242,31 @@ def _is_gh_token(tok):
 
 
 def _command_word_index(tokens):
-    """Index of the command word: skip leading `VAR=val` assignments and wrappers.
+    """Index of the command word: skip leading assignments, control keywords,
+    redirections and wrappers.
 
-    Returns -1 if the tokens are all assignments/wrappers. This is what makes
-    `gh` have to BE the command (so `echo gh issue create ...` is not a filing)
-    while still allowing `sudo gh ...` / `command gh ...` / `VAR=1 gh ...`.
+    Returns -1 if the tokens are all prefixes. This is what makes `gh` have to
+    BE the command (so `echo gh issue create ...` is not a filing) while still
+    catching `sudo gh ...`, `command gh ...`, `VAR=1 gh ...`, `if ! gh ...`,
+    `timeout 5 gh ...`, `/usr/bin/env gh ...`, and (after the scanner splits on
+    `(`/backtick) `URL=$(gh ...)` and `( gh ... )`.
     """
-    for i, t in enumerate(tokens):
-        if _ASSIGN_RE.match(t) or t in WRAPPERS:
+    i, n = 0, len(tokens)
+    while i < n:
+        t = tokens[i]
+        if _ASSIGN_RE.match(t) or t in CONTROL:
+            i += 1
+            continue
+        if _REDIR_RE.match(t):
+            # a bare operator (`>`, `2>`) also swallows its target token
+            i += 2 if (t in (">", ">>", "<", "<<") or _REDIR_RE.fullmatch(t)) else 1
+            continue
+        base = t.replace("\\", "/").rsplit("/", 1)[-1]
+        if base in WRAPPERS:
+            i += 1
+            if base in ARG_WRAPPERS:
+                while i < n and (tokens[i].startswith("-") or tokens[i].isdigit()):
+                    i += 1
             continue
         return i
     return -1
@@ -441,6 +487,8 @@ def _looks_like_probe(command):
     quoted string/comment (it would be one token) and `-S` inside an unrelated
     value like `Foo-Section` (that is not a standalone token).
     """
+    if len(command) > MAX_COMMAND_LEN:
+        return False  # bound the O(n^2) shlex path, as the main path does
     try:
         toks = shlex.split(command, posix=True)
     except ValueError:

--- a/scripts/hooks/selfcheck-issue-guard.py
+++ b/scripts/hooks/selfcheck-issue-guard.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""selfcheck-issue-guard.py -- prove the issue-guard hook FIRES, via the real wiring.
+
+Run this locally, on Windows especially:
+
+    py -3 scripts/hooks/selfcheck-issue-guard.py
+
+Why it exists (ADR-3001 A1, R3). tests/test_issue_guard.py proves the hook's
+*logic* by spawning it with this interpreter. It cannot prove the *wiring*: on
+Windows `python3` resolves to the Microsoft Store App-Execution-Alias stub,
+which runs, prints "Python was not found", exits nonzero and emits NO stdout --
+so a `python3`-wired hook fails OPEN and is silently dead. CI is Linux-only and
+never sees that trap. This check closes the gap: it reads the ACTUAL command
+string from .claude/settings.json, runs it through Git Bash exactly as Claude
+Code does (POSIX `sh`/Git Bash on Windows, with $CLAUDE_PROJECT_DIR in the
+environment), pipes a synthetic PreToolUse payload, and asserts the hook both
+denies a bad `gh issue create` and stays silent on an allowed call.
+
+If the resolver ever regresses to a dead interpreter, the deny JSON does not
+appear and this check FAILS -- which is the whole point. It passes on Linux/
+macOS too (harmless), so it is safe to run anywhere; it is deliberately NOT
+wired into meson/CI because the trap it guards only exists off-CI.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SETTINGS = ROOT / ".claude" / "settings.json"
+HOOK_BASENAME = "issue-standard-guard.py"
+
+
+def find_wired_command() -> str:
+    """Return the exact PreToolUse command string that wires the issue guard."""
+    cfg = json.loads(SETTINGS.read_text(encoding="utf-8"))
+    for entry in cfg.get("hooks", {}).get("PreToolUse", []):
+        for hook in entry.get("hooks", []):
+            cmd = hook.get("command", "")
+            if HOOK_BASENAME in cmd:
+                return cmd
+    raise SystemExit(
+        f"FAIL: no PreToolUse hook in {SETTINGS} references {HOOK_BASENAME} -- "
+        "the guard is not wired."
+    )
+
+
+def run_via_bash(command: str, payload: dict) -> tuple[int, str, str]:
+    """Run `command` through Git Bash with CLAUDE_PROJECT_DIR set, feeding payload."""
+    bash = shutil.which("bash")
+    if not bash:
+        raise SystemExit(
+            "FAIL: `bash` (Git Bash) not found on PATH. Claude Code runs hooks "
+            "through Git Bash on Windows; this self-check needs it too."
+        )
+    env = dict(os.environ)
+    env["CLAUDE_PROJECT_DIR"] = str(ROOT)
+    proc = subprocess.run(
+        [bash, "-c", command],
+        input=json.dumps(payload).encode("utf-8"),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    return (
+        proc.returncode,
+        proc.stdout.decode("utf-8", "replace").strip(),
+        proc.stderr.decode("utf-8", "replace").strip(),
+    )
+
+
+def decision_of(stdout: str) -> str:
+    if not stdout:
+        return "allow"
+    try:
+        return json.loads(stdout)["hookSpecificOutput"]["permissionDecision"]
+    except Exception:
+        return f"<unparseable: {stdout!r}>"
+
+
+def main() -> int:
+    command = find_wired_command()
+    print(f"wired command: {command}")
+
+    failures = []
+
+    # 1. A bad create MUST deny. If the interpreter is the dead stub, the hook
+    #    emits nothing and this fails -- exactly the R3 regression we guard.
+    bad = {
+        "tool_name": "Bash",
+        "tool_input": {"command": 'gh issue create --title T --label P1,needs-triage'},
+    }
+    rc, out, err = run_via_bash(command, bad)
+    dec = decision_of(out)
+    print(f"  bad create      -> exit={rc} decision={dec}")
+    if rc != 0:
+        failures.append(f"hook exited {rc} (must be 0); stderr={err!r}")
+    if dec != "deny":
+        failures.append(
+            "a bad `gh issue create` did NOT deny through the real wiring -- "
+            "the interpreter likely did not resolve to a real Python (the R3 "
+            f"stub trap). decision={dec!r} stderr={err!r}"
+        )
+
+    # 2. A non-create call MUST stay silent (allow).
+    ok = {"tool_name": "Bash", "tool_input": {"command": "gh pr view 1"}}
+    rc, out, err = run_via_bash(command, ok)
+    dec = decision_of(out)
+    print(f"  non-create call -> exit={rc} decision={dec}")
+    if rc != 0:
+        failures.append(f"hook exited {rc} on allowed call; stderr={err!r}")
+    if dec != "allow":
+        failures.append(f"a non-create call did not allow: decision={dec!r} out={out!r}")
+
+    if failures:
+        print("\nSELF-CHECK FAILED:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("\nself-check OK: the issue-guard hook fires through the real settings.json wiring.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hooks/selfcheck-issue-guard.py
+++ b/scripts/hooks/selfcheck-issue-guard.py
@@ -50,7 +50,7 @@ def find_wired_command() -> str:
     )
 
 
-def run_via_bash(command: str, payload: dict) -> tuple[int, str, str]:
+def run_via_bash(command: str, payload: dict, extra_env: dict | None = None) -> tuple[int, str, str]:
     """Run `command` through Git Bash with CLAUDE_PROJECT_DIR set, feeding payload."""
     bash = shutil.which("bash")
     if not bash:
@@ -60,6 +60,8 @@ def run_via_bash(command: str, payload: dict) -> tuple[int, str, str]:
         )
     env = dict(os.environ)
     env["CLAUDE_PROJECT_DIR"] = str(ROOT)
+    if extra_env:
+        env.update(extra_env)
     proc = subprocess.run(
         [bash, "-c", command],
         input=json.dumps(payload).encode("utf-8"),
@@ -116,6 +118,23 @@ def main() -> int:
         failures.append(f"hook exited {rc} on allowed call; stderr={err!r}")
     if dec != "allow":
         failures.append(f"a non-create call did not allow: decision={dec!r} out={out!r}")
+
+    # 3. The PowerShell matcher must fire too (second matcher in settings.json):
+    #    a backtick-newline continuation must not hide the create.
+    ps = {"tool_name": "PowerShell",
+          "tool_input": {"command": "gh issue `\ncreate --title T --label P1,needs-triage"}}
+    rc, out, err = run_via_bash(command, ps)
+    dec = decision_of(out)
+    print(f"  powershell bad  -> exit={rc} decision={dec}")
+    if dec != "deny":
+        failures.append(f"a bad PowerShell create did not deny: decision={dec!r} stderr={err!r}")
+
+    # 4. The ADR-mandated operator escape hatch must short-circuit to allow.
+    rc, out, err = run_via_bash(command, bad, extra_env={"YUZU_ISSUE_STANDARD_ACK": "1"})
+    dec = decision_of(out)
+    print(f"  ACK=1 bypass    -> exit={rc} decision={dec}")
+    if dec != "allow":
+        failures.append(f"YUZU_ISSUE_STANDARD_ACK=1 did not bypass: decision={dec!r}")
 
     if failures:
         print("\nSELF-CHECK FAILED:")

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -560,3 +560,17 @@ test('flake-retry selftest',
   suite: 'docs',
   timeout: 30,
 )
+
+# Behavioural test for the issue-standard PreToolUse guard (ADR-3001 pillar 4).
+# The first tests scripts/hooks/ has ever had: a convention hook that silently
+# stops enforcing is invisible in normal use, and CI is Linux-only so the
+# Windows interpreter trap never surfaces here -- so the decision logic is
+# pinned on every platform. Spawns the hook with synthetic PreToolUse payloads
+# and asserts allow/ask/deny. (The Windows *wiring* is proved locally by
+# scripts/hooks/selfcheck-issue-guard.py -- CI cannot see that trap.)
+test('issue-guard hook',
+  _python3_test,
+  args: [files('test_issue_guard.py')],
+  suite: 'docs',
+  timeout: 20,
+)

--- a/tests/test_issue_guard.py
+++ b/tests/test_issue_guard.py
@@ -23,6 +23,7 @@ Windows) is proved separately by scripts/hooks/selfcheck-issue-guard.py.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -63,6 +64,7 @@ def run_hook(
     transcript_path: str | None = None,
     tool_name: str = "Bash",
     raw_stdin: bytes | None = None,
+    env_extra: dict | None = None,
 ) -> tuple[str, str]:
     """Invoke the hook and return (decision, reason). No stdout => 'allow'."""
     if raw_stdin is not None:
@@ -74,11 +76,13 @@ def run_hook(
             obj["transcript_path"] = transcript_path
         payload = json.dumps(obj).encode("utf-8")
 
+    run_env = {**os.environ, **env_extra} if env_extra else None
     proc = subprocess.run(
         [sys.executable, str(HOOK)],
         input=payload,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env=run_env,
     )
     # A hook must ALWAYS exit 0 -- the decision is in the JSON, not the code.
     if proc.returncode != 0:
@@ -314,6 +318,39 @@ def build_cases(with_probe: str, no_probe: str):
             f'gh.exe issue create --title T --body "{GOOD_BODY}" --label P1,needs-triage',
             with_probe, "deny", ["no TYPE label"],
         ),
+
+        # --- adversarial-review (Codex) regressions ---
+        (
+            "C1: labels after a shell `#` comment are not counted (smuggle fixed)",
+            'gh issue create --title T --label P1 # --label bug,needs-triage',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "C1b: a prose trailing comment does not break a valid create",
+            f'gh issue create --title T --body "{GOOD_BODY}" '
+            '--label bug,P1,needs-triage # filing the parser bug',
+            with_probe, "allow", [],
+        ),
+        (
+            "C4: `echo gh issue create ...` is not a filing (over-block fixed)",
+            'echo gh issue create --title T --label P1,needs-triage',
+            with_probe, "allow", [],
+        ),
+        (
+            "C4b: `command gh issue create` (wrapper) is still enforced",
+            'command gh issue create --title T --label P1,needs-triage',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "C4c: `sudo gh issue create` (wrapper) is still enforced",
+            'sudo gh issue create --title T --label P1,needs-triage',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "C4d: `VAR=1 gh issue create` (assignment prefix) is still enforced",
+            'GH_HOST=github.com gh issue create --title T --label P1,needs-triage',
+            with_probe, "deny", ["no TYPE label"],
+        ),
     ]
 
 
@@ -398,6 +435,34 @@ def main() -> int:
                 failures.append(f"[R4: oversized command fails open] decision={decision!r} want allow")
         except AssertionError as exc:
             failures.append(f"[R4: oversized command fails open] {exc}")
+
+        # --- C2: PowerShell backtick-newline continuation is normalised ---
+        for label, cmd, want in [
+            ("C2: PS backtick-cont between issue and create",
+             "gh issue `\ncreate --title T --label P1,needs-triage", "deny"),
+            ("C2b: PS backtick-cont between flags",
+             "gh issue create --title T `\n--label P1,needs-triage", "deny"),
+        ]:
+            try:
+                decision, _ = run_hook(cmd, transcript_path=with_probe, tool_name="PowerShell")
+                if decision != want:
+                    failures.append(f"[{label}] decision={decision!r} want={want!r}")
+            except AssertionError as exc:
+                failures.append(f"[{label}] {exc}")
+
+        # --- C3: the ADR-mandated YUZU_ISSUE_STANDARD_ACK=1 operator bypass ---
+        bad = "gh issue create --title T --label P1,needs-triage"  # no type -> would deny
+        try:
+            decision, _ = run_hook(bad, transcript_path=with_probe,
+                                   env_extra={"YUZU_ISSUE_STANDARD_ACK": "1"})
+            if decision != "allow":
+                failures.append(f"[C3: ACK=1 bypass] decision={decision!r} want allow")
+            decision, _ = run_hook(bad, transcript_path=with_probe,
+                                   env_extra={"YUZU_ISSUE_STANDARD_ACK": "0"})
+            if decision != "deny":
+                failures.append(f"[C3: ACK=0 does not bypass] decision={decision!r} want deny")
+        except AssertionError as exc:
+            failures.append(f"[C3: ACK bypass] {exc}")
 
         # --- non-shell tool is ignored ---
         try:

--- a/tests/test_issue_guard.py
+++ b/tests/test_issue_guard.py
@@ -425,6 +425,63 @@ def build_cases(with_probe: str, no_probe: str):
             'gh issue create --title T --label bug,P1,needs-triage --body=just-a-one-liner',
             with_probe, "ask", ["missing required section"],
         ),
+
+        # --- two-reviewer adversarial (Kimi+Codex): global flags & wrappers ---
+        (
+            "IG-1: gh --repo before subcommand is enforced",
+            'gh --repo Tr3kkR/Yuzu issue create --title T --label P1,needs-triage',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "IG-1: gh -R before subcommand is enforced (do-not-close)",
+            'gh -R Tr3kkR/Yuzu issue create --title T --label bug,P1,needs-triage,do-not-close',
+            with_probe, "deny", ["automation-owned"],
+        ),
+        (
+            "IG-1: gh --repo=X glued global flag is enforced",
+            'gh --repo=Tr3kkR/Yuzu issue create --title T --label P1,needs-triage',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "IG-1-neg: a VALID gh --repo create is allowed",
+            f'gh --repo Tr3kkR/Yuzu issue create --title T --body "{GOOD_BODY}" --label bug,P1,needs-triage',
+            with_probe, "allow", [],
+        ),
+        (
+            "IG-2: `sudo -E gh` (option-wrapper) is enforced",
+            'sudo -E gh issue create --title T --label bug,P1,needs-triage,do-not-close',
+            with_probe, "deny", ["automation-owned"],
+        ),
+        (
+            "IG-2: `command -p gh` is enforced",
+            'command -p gh issue create --title T --label P1,needs-triage',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "IG-2: `env -i gh` is enforced",
+            'env -i gh issue create --title T --label P1,needs-triage',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "IG-2: `time -p gh` is enforced",
+            'time -p gh issue create --title T --label P1,needs-triage',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "IG-3: `2>&1 gh` fd-redirect prefix is enforced (& not a boundary)",
+            '2>&1 gh issue create --title T --label P1,needs-triage',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "IG-3: `>&2 gh` redirect prefix is enforced",
+            '>&2 gh issue create --title T --label P1,needs-triage',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "background `&` after a create is still a create",
+            'gh issue create --title T --label P1,needs-triage &',
+            with_probe, "deny", ["no TYPE label"],
+        ),
     ]
 
 
@@ -516,6 +573,10 @@ def main() -> int:
              "gh issue `\ncreate --title T --label P1,needs-triage", "deny"),
             ("C2b: PS backtick-cont between flags",
              "gh issue create --title T `\n--label P1,needs-triage", "deny"),
+            ("IG-C-P1-2: PS `$url = gh issue create` native assignment is enforced",
+             "$url = gh issue create --title T --label P1,needs-triage", "deny"),
+            ("IG-C-P1-2b: PS `$u = $(gh ...)` subexpression is enforced",
+             "$u = $(gh issue create --title T --label P1,needs-triage)", "deny"),
         ]:
             try:
                 decision, _ = run_hook(cmd, transcript_path=with_probe, tool_name="PowerShell")

--- a/tests/test_issue_guard.py
+++ b/tests/test_issue_guard.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Behavioural tests for scripts/hooks/issue-standard-guard.py.
+
+The first tests scripts/hooks/ has ever had. A convention hook that silently
+stops enforcing -- because the interpreter wiring broke, a refactor regressed
+the decision logic, or a fail-open path swallowed a real violation -- is
+indistinguishable from a conformant session: the failure is invisible in normal
+use and CI runs on Linux where the Windows interpreter trap never bites. So the
+logic is pinned here, on every platform, by feeding the hook synthetic
+PreToolUse payloads on stdin (exactly as Claude Code does) and asserting the
+decision it emits.
+
+The two meta-invariants at the end are the point: a known-bad create MUST deny
+and a known-good create MUST allow. If someone neuters the hook to always-allow,
+the deny cases fail; to always-deny, the allow cases fail.
+
+Run directly (`python3 tests/test_issue_guard.py`) or via meson (suite: docs).
+The hook is spawned with THIS interpreter (sys.executable), so the test proves
+the hook's *logic*; the *wiring* (that settings.json resolves a real Python on
+Windows) is proved separately by scripts/hooks/selfcheck-issue-guard.py.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+HOOK = ROOT / "scripts" / "hooks" / "issue-standard-guard.py"
+
+# A body that satisfies all four mandatory sections (real newlines).
+GOOD_BODY = (
+    "## Context\nwhy this matters\n"
+    "## Evidence\nfoo.cpp:42 is wrong\n"
+    "## Acceptance criteria\nit stops being wrong\n"
+    "## Origin\ngovernance run; probes ran, nothing found"
+)
+
+
+def make_transcript(tmpdir: Path, commands: list[str], name: str) -> str:
+    """Write a JSONL transcript whose entries are Bash tool_use blocks."""
+    path = tmpdir / f"{name}.jsonl"
+    lines = []
+    for cmd in commands:
+        lines.append(json.dumps({
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "name": "Bash", "input": {"command": cmd}}
+                ],
+            },
+        }))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(path)
+
+
+def run_hook(
+    command: str | None,
+    transcript_path: str | None = None,
+    tool_name: str = "Bash",
+    raw_stdin: bytes | None = None,
+) -> tuple[str, str]:
+    """Invoke the hook and return (decision, reason). No stdout => 'allow'."""
+    if raw_stdin is not None:
+        payload = raw_stdin
+    else:
+        tool_input = {} if command is None else {"command": command}
+        obj: dict = {"tool_name": tool_name, "tool_input": tool_input}
+        if transcript_path is not None:
+            obj["transcript_path"] = transcript_path
+        payload = json.dumps(obj).encode("utf-8")
+
+    proc = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=payload,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    # A hook must ALWAYS exit 0 -- the decision is in the JSON, not the code.
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"hook exited {proc.returncode} (must always be 0); "
+            f"stderr={proc.stderr.decode('utf-8', 'replace')}"
+        )
+    out = proc.stdout.decode("utf-8", "replace").strip()
+    if not out:
+        return ("allow", "")
+    obj = json.loads(out)
+    hso = obj["hookSpecificOutput"]
+    assert hso["hookEventName"] == "PreToolUse", hso
+    return (hso["permissionDecision"], hso.get("permissionDecisionReason", ""))
+
+
+# Each case: (name, command, expected_decision, [substrings the reason must have])
+# All label-bearing commands include a full valid body so the body check never
+# fires unless a case is specifically about the body.
+def build_cases(with_probe: str, no_probe: str):
+    valid = f'gh issue create --title "T" --body "{GOOD_BODY}" --label bug,P1,needs-triage'
+    return [
+        # --- allow: fully conformant ---
+        ("valid non-roadmap create", valid, with_probe, "allow", []),
+        (
+            "valid roadmap create (no priority, no state)",
+            f'gh issue create --title "T" --body "{GOOD_BODY}" --label enhancement,roadmap',
+            with_probe, "allow", [],
+        ),
+        (
+            "labels as repeated flags",
+            f'gh issue create --title T --body "{GOOD_BODY}" -l bug -l P0 -l ready-for-agent',
+            with_probe, "allow", [],
+        ),
+        (
+            "facet label alongside the mandatory axes is fine",
+            f'gh issue create --title T --body "{GOOD_BODY}" --label bug,P2,ready-for-agent,performance',
+            with_probe, "allow", [],
+        ),
+        (
+            "body via --body-file is not inspected (allow)",
+            "gh issue create --title T --body-file body.md --label bug,P1,needs-triage",
+            with_probe, "allow", [],
+        ),
+        (
+            "body via $VAR is unresolvable (allow, no body ask)",
+            'gh issue create --title T --body "$BODY" --label bug,P1,needs-triage',
+            with_probe, "allow", [],
+        ),
+        (
+            "--web defers to the browser form (allow)",
+            "gh issue create --web --label whatever",
+            with_probe, "allow", [],
+        ),
+        (
+            "not a gh issue create at all (allow, no output)",
+            "gh pr list --repo Tr3kkR/Yuzu",
+            with_probe, "allow", [],
+        ),
+        (
+            "gh issue create only inside a quoted string is not a real create",
+            'echo "gh issue create --label bug"',
+            with_probe, "allow", [],
+        ),
+
+        # --- deny: label-contract violations ---
+        (
+            "no type label",
+            f'gh issue create --title T --body "{GOOD_BODY}" --label P1,needs-triage',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "two type labels",
+            f'gh issue create --title T --body "{GOOD_BODY}" --label bug,task,P1,needs-triage',
+            with_probe, "deny", ["multiple TYPE labels"],
+        ),
+        (
+            "no priority on the gh path",
+            f'gh issue create --title T --body "{GOOD_BODY}" --label bug,needs-triage',
+            with_probe, "deny", ["no PRIORITY"],
+        ),
+        (
+            "no triage state",
+            f'gh issue create --title T --body "{GOOD_BODY}" --label bug,P1',
+            with_probe, "deny", ["no TRIAGE STATE"],
+        ),
+        (
+            "two priorities",
+            f'gh issue create --title T --body "{GOOD_BODY}" --label bug,P0,P1,needs-triage',
+            with_probe, "deny", ["multiple PRIORITY"],
+        ),
+        (
+            "roadmap must not carry a priority",
+            f'gh issue create --title T --body "{GOOD_BODY}" --label enhancement,roadmap,P1',
+            with_probe, "deny", ["roadmap` carries no priority"],
+        ),
+        (
+            "roadmap must not carry a triage state",
+            f'gh issue create --title T --body "{GOOD_BODY}" --label enhancement,roadmap,needs-triage',
+            with_probe, "deny", ["roadmap` carries no triage state"],
+        ),
+        (
+            "no labels at all",
+            'gh issue create --title T --body "some text"',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "automation-owned label at filing (do-not-close)",
+            f'gh issue create --title T --body "{GOOD_BODY}" --label bug,P0,needs-triage,do-not-close',
+            with_probe, "deny", ["automation-owned"],
+        ),
+
+        # --- ask: human-judgement cases ---
+        (
+            "security label -> ask",
+            f'gh issue create --title T --body "{GOOD_BODY}" --label bug,P1,needs-triage,security',
+            with_probe, "ask", ["security", "advisories"],
+        ),
+        (
+            "missing dedupe probe -> ask",
+            valid, no_probe, "ask", ["duplicate-search probe"],
+        ),
+        (
+            "resolvable body missing sections -> ask",
+            'gh issue create --title T --body "just a one liner" --label bug,P1,needs-triage',
+            with_probe, "ask", ["missing required section"],
+        ),
+
+        # --- precedence: a label deny outranks a body/security ask ---
+        (
+            "deny outranks ask when both apply",
+            'gh issue create --title T --body "one liner" --label P1,needs-triage,security',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+
+        # --- red-team regressions (confirmed defects, now fixed) ---
+        (
+            "R1: extra whitespace between tokens does not bypass the gate",
+            f'gh   issue   create --title T --body "{GOOD_BODY}" --label do-not-close',
+            with_probe, "deny", ["automation-owned"],
+        ),
+        (
+            "R2: newline-joined typeless first create is still caught",
+            f'gh issue create --title T --label P1,needs-triage\n'
+            f'gh issue create --title T2 --body "{GOOD_BODY}" --label bug,P1,needs-triage',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "R2b: newline-joined typeless SECOND create is caught",
+            f'gh issue create --title T1 --body "{GOOD_BODY}" --label bug,P1,needs-triage\n'
+            f'gh issue create --title T2 --label P1,needs-triage',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "R8: a quoted operator in the title does not truncate the flag list",
+            f'gh issue create --title "&" --body "{GOOD_BODY}" --label bug,P1,needs-triage',
+            with_probe, "allow", [],
+        ),
+        (
+            "R9: a quoted semicolon does not hide a later automation-owned label",
+            f'gh issue create --title ";" --body "{GOOD_BODY}" --label bug,P1,needs-triage --label do-not-close',
+            with_probe, "deny", ["automation-owned"],
+        ),
+        (
+            "R10: a pipe glued to the label value does not over-block a valid create",
+            f'gh issue create --title T --body "{GOOD_BODY}" --label bug,P1,needs-triage|grep foo',
+            with_probe, "allow", [],
+        ),
+        (
+            "R3: mis-cased SECURITY label still asks",
+            f'gh issue create --title T --body "{GOOD_BODY}" --label bug,P1,needs-triage,SECURITY',
+            with_probe, "ask", ["security"],
+        ),
+        (
+            "R3b: mis-cased DO-NOT-CLOSE still denies",
+            f'gh issue create --title T --body "{GOOD_BODY}" --label bug,P1,needs-triage,DO-NOT-CLOSE',
+            with_probe, "deny", ["automation-owned"],
+        ),
+        (
+            "R3c: all-caps valid labels are accepted (GitHub is case-insensitive)",
+            f'gh issue create --title T --body "{GOOD_BODY}" --label BUG,P1,NEEDS-TRIAGE',
+            with_probe, "allow", [],
+        ),
+        (
+            "path-prefixed gh is still matched",
+            f'/usr/bin/gh issue create --title T --body "{GOOD_BODY}" --label P1,needs-triage',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "redirection after the flags does not break parsing",
+            f'gh issue create --title T --body "{GOOD_BODY}" --label bug,P1,needs-triage > out.txt',
+            with_probe, "allow", [],
+        ),
+        (
+            "R7: heredoc body prose is not parsed as flags",
+            'gh issue create --title T --label bug,P1,needs-triage --body-file - <<EOF\n'
+            'Context: this mentions --label do-not-close in prose\nEOF',
+            with_probe, "allow", [],
+        ),
+
+        # --- red-team pass 2 regressions (rewrite defects, now fixed) ---
+        (
+            "RT2-1: `<<` in a quoted body does not corrupt parsing (bypass fixed)",
+            'gh issue create --title T --label bug,P1,needs-triage,do-not-close '
+            '--body "## Evidence\nsee foo.cpp:42 cout << data << endl\nmore text"',
+            with_probe, "deny", ["automation-owned"],
+        ),
+        (
+            "RT2-1b: Erlang `<<Bin>>` in a quoted body is not a heredoc",
+            'gh issue create --title T --label bug,P1,needs-triage,do-not-close '
+            '--body "uses <<Payload>> binaries"',
+            with_probe, "deny", ["automation-owned"],
+        ),
+        (
+            "RT2-2: `<<` in a quoted body does not strip a section (over-block fixed)",
+            'gh issue create --title T --label bug,P1,needs-triage --body '
+            '"## Context\nc\n## Evidence\nqueue << STOP marker\n'
+            '## Acceptance criteria\nac\nSTOP\n## Origin\nprobes ran"',
+            with_probe, "allow", [],
+        ),
+        (
+            "RT2-3: a `<<<` here-string does not swallow the create",
+            'gh issue create --title T --label bug,P1,needs-triage,do-not-close <<< "input"',
+            with_probe, "deny", ["automation-owned"],
+        ),
+        (
+            "RT2-4: a line continuation inside the create phrase is caught",
+            'gh issue \\\ncreate --title T --label bug,P1,needs-triage,do-not-close',
+            with_probe, "deny", ["automation-owned"],
+        ),
+        (
+            "RT2-7: gh.exe is matched (Windows)",
+            f'gh.exe issue create --title T --body "{GOOD_BODY}" --label P1,needs-triage',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+    ]
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    if not HOOK.is_file():
+        print(f"hook not found: {HOOK}", file=sys.stderr)
+        return 2
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        with_probe = make_transcript(tmp, [
+            "gh issue list --repo Tr3kkR/Yuzu --state open --search foo.cpp",
+            "cat foo.cpp",
+        ], "with_probe")
+        no_probe = make_transcript(tmp, ["cat foo.cpp", "ls -la"], "no_probe")
+
+        for name, cmd, transcript, want, subs in build_cases(with_probe, no_probe):
+            try:
+                decision, reason = run_hook(cmd, transcript_path=transcript)
+            except AssertionError as exc:
+                failures.append(f"[{name}] {exc}")
+                continue
+            if decision != want:
+                failures.append(
+                    f"[{name}] decision={decision!r} want={want!r} reason={reason!r}"
+                )
+                continue
+            for sub in subs:
+                if sub not in reason:
+                    failures.append(f"[{name}] reason missing {sub!r}: {reason!r}")
+
+        # --- fail-open on malformed input (must never wedge a session) ---
+        for label, raw in [
+            ("empty stdin", b""),
+            ("non-JSON stdin", b"not json at all"),
+            ("unbalanced quotes in command",
+             json.dumps({"tool_name": "Bash",
+                         "tool_input": {"command": 'gh issue create --title "oops'}}).encode()),
+            ("missing transcript_path is not fatal",
+             json.dumps({"tool_name": "Bash",
+                         "tool_input": {"command": "gh pr view 1"}}).encode()),
+        ]:
+            try:
+                decision, _ = run_hook(None, raw_stdin=raw)
+                if decision != "allow":
+                    failures.append(f"[fail-open: {label}] decision={decision!r} want allow")
+            except AssertionError as exc:
+                failures.append(f"[fail-open: {label}] {exc}")
+
+        # --- dedupe probe detection is tokenised, not substring (R5/R6) ---
+        valid_create = f'gh issue create --title T --body "{GOOD_BODY}" --label bug,P1,needs-triage'
+        echo_fake = make_transcript(tmp, ['echo "gh search issues foo"', "ls"], "echo_fake")
+        s_in_value = make_transcript(
+            tmp, ["gh issue list --repo Tr3kkR/Yuzu-Server --state open"], "s_in_value")
+        real_short = make_transcript(tmp, ["gh issue list -S foo.cpp"], "real_short")
+        global_flag = make_transcript(
+            tmp, ["gh --repo Tr3kkR/Yuzu issue list --search foo"], "global_flag")
+        glued_s = make_transcript(tmp, ["gh issue list -Sfoo"], "glued_s")
+        gh_exe = make_transcript(tmp, ["gh.exe issue list --search bar"], "gh_exe")
+        for label, transcript, want in [
+            ("R5: echo of probe text is not a real probe", echo_fake, "ask"),
+            ("R6: -S inside a value is not a probe", s_in_value, "ask"),
+            ("real -S short-flag probe is recognised", real_short, "allow"),
+            ("RT2-5: global flag before subcommand still a probe", global_flag, "allow"),
+            ("RT2-6: glued -Sfoo short-flag is a probe", glued_s, "allow"),
+            ("RT2-7b: gh.exe probe is recognised", gh_exe, "allow"),
+        ]:
+            try:
+                decision, _ = run_hook(valid_create, transcript_path=transcript)
+                if decision != want:
+                    failures.append(f"[{label}] decision={decision!r} want={want!r}")
+            except AssertionError as exc:
+                failures.append(f"[{label}] {exc}")
+
+        # --- R4: an oversized command fails open (no O(n^2) shlex stall) ---
+        huge = "gh issue create --title T --label do-not-close --body " + ("A" * 40000)
+        try:
+            decision, _ = run_hook(huge, transcript_path=with_probe)
+            if decision != "allow":
+                failures.append(f"[R4: oversized command fails open] decision={decision!r} want allow")
+        except AssertionError as exc:
+            failures.append(f"[R4: oversized command fails open] {exc}")
+
+        # --- non-shell tool is ignored ---
+        try:
+            decision, _ = run_hook("gh issue create --label bug", transcript_path=no_probe,
+                                   tool_name="Edit")
+            if decision != "allow":
+                failures.append(f"[non-shell tool ignored] decision={decision!r} want allow")
+        except AssertionError as exc:
+            failures.append(f"[non-shell tool ignored] {exc}")
+
+        # --- META: the hook is provably live (not a silent no-op) ---
+        deny_dec, _ = run_hook(
+            'gh issue create --title T --label P1,needs-triage', transcript_path=with_probe)
+        if deny_dec != "deny":
+            failures.append(
+                "META: a known-bad create did not deny -- the guard is disabled/no-op")
+        allow_dec, _ = run_hook(
+            f'gh issue create --title T --body "{GOOD_BODY}" --label bug,P1,needs-triage',
+            transcript_path=with_probe)
+        if allow_dec != "allow":
+            failures.append(
+                "META: a known-good create did not allow -- the guard over-blocks")
+
+    if failures:
+        print(f"issue-guard hook checks FAILED ({len(failures)}):")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+
+    print("issue-guard hook checks OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_issue_guard.py
+++ b/tests/test_issue_guard.py
@@ -351,6 +351,80 @@ def build_cases(with_probe: str, no_probe: str):
             'GH_HOST=github.com gh issue create --title T --label P1,needs-triage',
             with_probe, "deny", ["no TYPE label"],
         ),
+
+        # --- governance (unhappy-path HIGH): command-substitution / grouping smuggle ---
+        (
+            "G-HIGH: URL=$(gh issue create ...) capture idiom is enforced",
+            'URL=$(gh issue create --title T --label bug,P1,needs-triage,do-not-close)',
+            with_probe, "deny", ["automation-owned"],
+        ),
+        (
+            "G-HIGH: bare $(gh issue create ...) capture is enforced",
+            'N=$(gh issue create --title T --label P1,needs-triage)',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "G-HIGH: backtick capture is enforced",
+            'URL=`gh issue create --title T --label P1,needs-triage`',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "G-HIGH: ( subshell ) is enforced",
+            '( gh issue create --title T --label P1,needs-triage )',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "G-HIGH: `if ! gh issue create` is enforced",
+            'if ! gh issue create --title T --label P1,needs-triage; then echo x; fi',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "G-HIGH: `{ ...; }` grouping is enforced",
+            '{ gh issue create --title T --label P1,needs-triage; }',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "G-HIGH: leading redirection prefix is enforced",
+            '> out.txt gh issue create --title T --label P1,needs-triage',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "G-HIGH: /usr/bin/env wrapper (basename) is enforced",
+            '/usr/bin/env gh issue create --title T --label P1,needs-triage',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "G-HIGH: `timeout 5 gh` (arg-wrapper) is enforced",
+            'timeout 5 gh issue create --title T --label P1,needs-triage',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "G-HIGH-neg: a VALID create captured in $() is allowed",
+            f'URL=$(gh issue create --title T --body "{GOOD_BODY}" --label bug,P1,needs-triage)',
+            with_probe, "allow", [],
+        ),
+
+        # --- governance (quality-engineer M2): equals / glued parse forms ---
+        (
+            "M2: `--label=` equals form parses",
+            f'gh issue create --title T --body "{GOOD_BODY}" --label=bug,P1,needs-triage',
+            with_probe, "allow", [],
+        ),
+        (
+            "M2: glued `-lX` short cluster parses",
+            f'gh issue create --title T --body "{GOOD_BODY}" -lbug -lP1 -lneeds-triage',
+            with_probe, "allow", [],
+        ),
+        (
+            "M2: typeless glued `-lX` is denied (no silent pass)",
+            f'gh issue create --title T --body "{GOOD_BODY}" -lP1 -lneeds-triage',
+            with_probe, "deny", ["no TYPE label"],
+        ),
+        (
+            "M2: `--body=` equals form is inspected (missing sections -> ask)",
+            'gh issue create --title T --label bug,P1,needs-triage --body=just-a-one-liner',
+            with_probe, "ask", ["missing required section"],
+        ),
     ]
 
 


### PR DESCRIPTION
## Merge order: #2168 (PR1) → #2170 (PR2) → #2172 (PR4) → #2174 (PR3)

## Description

- **Summary** — Implements ADR-3001 pillar 4: a `PreToolUse` hook that holds `gh issue create` in
  Claude sessions to the issue-lifecycle standard (`docs/agents/issue-standard.md`), and fixes the
  Claude Code hook wiring so hooks fire on Windows. Ships the first automated tests `scripts/hooks/`
  has ever had, plus a local Windows wiring self-check.
- **Rationale & drivers** —
  - The issue standard is enforced today only by prose and PR review. Pillar 4 adds mechanical
    enforcement on the one path where labels are statically visible — the agent-side `gh` CLI —
    catching contract violations at filing rather than in review.
  - **Amendment A1 / R3:** every hook was wired as `python3 "$CLAUDE_PROJECT_DIR/…"`. On Windows
    `python3` resolves to the Microsoft Store App-Execution-Alias stub, which exits non-zero and
    emits no output, so the hook failed **open** and was silently dead. Both the pre-existing
    changelog-fragment guard and the dialyzer reminder were dead on Windows; a new hook wired the
    same way would be born dead on the maintainer's own machine. CI is Linux-only and cannot see it.
- **Technical overview** —
  - `scripts/hooks/issue-standard-guard.py` (matcher `Bash|PowerShell`). On a `gh issue create`:
    **deny** on a label-contract violation (exactly one type; `roadmap` XOR a priority + triage
    state; no automation-owned labels at filing); **ask** on a `security` label (public issues are
    hardening-only; exploitable vulnerabilities go through private advisory reporting) or when no
    duplicate-search probe was seen earlier in the session transcript; best-effort body-section
    check only when the body is statically resolvable. It respects the ADR-mandated
    `YUZU_ISSUE_STANDARD_ACK=1` operator escape hatch, **fails open** on any ambiguity, and always
    exits 0 — so it can never wedge a session; the close-on-merge workflow and PR review remain the
    server-side backstops. It is an enforcement/teaching layer, never a security control.
  - Shell parsing is quote/operator/command-word aware: it descends into command substitution
    (`URL=$(gh …)`), subshells, backticks, control keywords and redirections, recognises gh global
    flags (`gh --repo X issue create`) and PowerShell native capture (`$url = gh …`), and requires
    `gh` to be the command word so `echo gh issue create …` is not a filing — while staying fully
    fail-open on anything it cannot resolve.
  - `.claude/settings.json`: all three hook commands rewired with an inline POSIX interpreter
    resolver (`command -v py && py -3 … || python3 …`) — a real Python on Windows (the `py`
    launcher) and on Linux/macOS (`python3`). This also revives the changelog and dialyzer hooks.
  - `scripts/hooks/selfcheck-issue-guard.py`: runs the **actual** settings.json command through Git
    Bash and asserts the hook fires (Bash + PowerShell + the `ACK` bypass) — the local Windows check
    for the class of failure CI cannot see.

## Impact

- **Capabilities** — new: mechanical issue-standard enforcement on the `gh issue create` path in
  Claude sessions; Claude Code hooks now fire on Windows (previously all silently dead).
- **Security:** routes `security`-labelled filings to a human check citing SECURITY.md; weakens no
  control. Reviving the changelog guard restores an approvals-integrity control on Windows.
- **Reliability:** the guard fails open on every ambiguity and always exits 0 — it cannot wedge a
  session; the close-on-merge workflow (pillar 2) and PR review remain the backstops.

## Testing & verification

- `tests/test_issue_guard.py` (suite `docs`) — ~75 behavioural cases (allow/ask/deny, fail-open, a
  "hook is provably live" meta-check, and regression cases for every review finding below). Green.
- `scripts/hooks/selfcheck-issue-guard.py` — green on Windows: the deny JSON appears through the
  real wiring via `py -3`, for Bash and PowerShell, and the `ACK` bypass short-circuits to allow.
- **Four independent review rounds, every finding fixed and pinned by a regression test:** two
  in-house adversarial red-team passes (17 defects); `/adversarial-review` with Codex (4 — shell
  comment smuggle, PowerShell backtick continuation, missing `ACK` bypass, echo over-block);
  `/governance` across twelve specialist agents (1 HIGH command-substitution smuggle + 3 MEDIUM +
  LOW); and a two-reviewer `/adversarial-review` with **Kimi and Codex** on the final code (both
  independently flagged the gh-global-flag bypass; plus PowerShell native-assignment, option-taking
  wrappers, and fd-redirection prefixes).
- `scripts/assemble-changelog.py --check` — OK. Local gates: the `py -3` suite, the Windows wiring
  self-check, and the fragment lint are all green; the CI matrix (Windows MSVC / Linux / macOS) is
  the enforcement point for the meson `docs` suite and the wider build (this change is Python + JSON
  + one docs-suite test entry; no C/C++).

## Related items

- ADR-3001 (`docs/adr/3001-issue-lifecycle-guardrails.md`), Amendment A1 — pillar 4 and R3.
- **Stacked on #2172** (`feat/tracker-report`); base retargets to `dev` when that predecessor merges.
- Depends on the issue-lifecycle standard (`docs/agents/issue-standard.md`) reaching `dev`, which
  the hook's messages and changelog fragment reference; that lands with its own PR earlier in the
  ADR-3001 sequence.

## Deliverables / artefacts

| Artefact | Type | Location |
|---|---|---|
| Issue-standard guard | Hook | `scripts/hooks/issue-standard-guard.py` |
| Interpreter-robust hook wiring (all 3 hooks) | Config | `.claude/settings.json` |
| Windows wiring self-check | Script | `scripts/hooks/selfcheck-issue-guard.py` |
| Hook behavioural tests (first ever for scripts/hooks) | Test | `tests/test_issue_guard.py` (suite `docs`) |
| Changelog fragments | Changelog | `changelog.d/adr3001-*.{added,fixed}.md` |
