### PR TITLE
fix(ci): pin macOS cmake to 4.3.4 via pipx instead of floating brew

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -887,7 +887,46 @@ jobs:
           # autoconf/automake/libtool: vcpkg's libpq port (Postgres substrate,
           # ADR-0006) runs autoreconf during its build and the hosted macOS
           # image doesn't ship autotools.
-          brew install cmake ninja ccache pipx autoconf automake libtool
+          #
+          # cmake deliberately excluded from this brew line, pinned via pipx
+          # below instead. 2026-07-16: brew's floating `cmake` drifted to
+          # 4.4.0 underneath us with no code change on our side, and that
+          # release crashes resolving httplib's CMake package: FindThreads'
+          # try_compile() trips CMake's own internal "This should not have
+          # happened" guard in Internal/CheckSourceCompiles.cmake, which
+          # poisons every subsequent cmake-method dependency lookup in the
+          # same configure. Broke macOS CI fleet-wide across unrelated PRs
+          # simultaneously (e.g. #2224). Pin like meson below so a future
+          # brew bump can't repeat this.
+          brew install ninja ccache pipx autoconf automake libtool
+          # Belt-and-suspenders: the macos-15 image pre-bakes its own cmake
+          # (that's what the log line "cmake 4.4.0 is already installed and
+          # up-to-date" was reporting) independent of this workflow's brew
+          # line, so dropping cmake above doesn't remove it. Unlink it so it
+          # can never win a PATH race against the pinned pipx cmake below.
+          # `|| true`: fine if a future image doesn't pre-bake cmake at all;
+          # stderr is left visible (not redirected) so a genuine unlink
+          # failure still shows up in the step log for a future debugger.
+          brew unlink cmake || true
+          # 4.3.4 is the latest 4.x release before the 4.4.0 regression
+          # above. Bump deliberately once a fixed release is confirmed clean
+          # here. Query pipx's own shim dir and prepend it to GITHUB_PATH
+          # (mirrors the pip3 --user pattern the Linux legs use, above) so
+          # it's guaranteed to win on PATH rather than assumed to. Captured
+          # into a variable first (not inlined into the `echo` argument):
+          # under `set -e`, a failing/empty command substitution inlined
+          # into `echo "$(...)"` would NOT abort the step (echo's own exit
+          # status is what -e checks), silently writing a blank PATH entry.
+          pipx install cmake==4.3.4
+          pipx_bin_dir="$(pipx environment --value PIPX_BIN_DIR)"
+          test -n "$pipx_bin_dir"
+          echo "$pipx_bin_dir" >> "$GITHUB_PATH"
+          # GITHUB_PATH only takes effect from the next step onward, not
+          # within this script, so verify via the resolved dir directly
+          # rather than a bare `cmake` (which may still hit an empty PATH
+          # slot right here). Self-documents the fix in every future log:
+          # today's incident was exactly this kind of silent version drift.
+          "$pipx_bin_dir/cmake" --version
           # awk strips the trailing ` \` that pip-compile adds when the
           # requirement is continued by `--hash=...` lines.
           pipx install "$(awk '/^meson==/ {print $1}' requirements-ci.txt)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -825,7 +825,43 @@ jobs:
           # autoconf/automake/libtool: vcpkg's libpq port (Postgres substrate,
           # ADR-0006) runs autoreconf during its build and the hosted macOS
           # image doesn't ship autotools.
-          brew install cmake ninja ccache pipx autoconf automake libtool
+          #
+          # cmake deliberately excluded from this brew line, pinned via pipx
+          # below instead. 2026-07-16: brew's floating `cmake` drifted to
+          # 4.4.0 underneath us with no code change on our side, and that
+          # release crashes resolving httplib's CMake package: FindThreads'
+          # try_compile() trips CMake's own internal "This should not have
+          # happened" guard in Internal/CheckSourceCompiles.cmake, which
+          # poisons every subsequent cmake-method dependency lookup in the
+          # same configure. Broke macOS CI fleet-wide the same way (ci.yml,
+          # #2224) before it could hit a release build here. Pin like meson
+          # below so a future brew bump can't repeat this.
+          brew install ninja ccache pipx autoconf automake libtool
+          # Belt-and-suspenders: the macos-15 image pre-bakes its own cmake
+          # independent of this workflow's brew line, so dropping cmake
+          # above doesn't remove it. Unlink it so it can never win a PATH
+          # race against the pinned pipx cmake below. `|| true`: fine if a
+          # future image doesn't pre-bake cmake at all; stderr is left
+          # visible so a genuine unlink failure still shows in the log.
+          brew unlink cmake || true
+          # 4.3.4 is the latest 4.x release before the 4.4.0 regression
+          # above. Bump deliberately once a fixed release is confirmed clean
+          # here. Query pipx's own shim dir and prepend it to GITHUB_PATH so
+          # it's guaranteed to win on PATH rather than assumed to. Captured
+          # into a variable first (not inlined into the `echo` argument):
+          # under `set -e`, a failing/empty command substitution inlined
+          # into `echo "$(...)"` would NOT abort the step (echo's own exit
+          # status is what -e checks), silently writing a blank PATH entry.
+          pipx install cmake==4.3.4
+          pipx_bin_dir="$(pipx environment --value PIPX_BIN_DIR)"
+          test -n "$pipx_bin_dir"
+          echo "$pipx_bin_dir" >> "$GITHUB_PATH"
+          # GITHUB_PATH only takes effect from the next step onward, not
+          # within this script, so verify via the resolved dir directly
+          # rather than a bare `cmake` (which may still hit an empty PATH
+          # slot right here). Self-documents the fix in every future log:
+          # today's incident was exactly this kind of silent version drift.
+          "$pipx_bin_dir/cmake" --version
           # awk strips the trailing ` \` that pip-compile adds when the
           # requirement is continued by `--hash=...` lines.
           pipx install "$(awk '/^meson==/ {print $1}' requirements-ci.txt)"


### PR DESCRIPTION
## Summary

macOS CI broke fleet-wide today across every open PR simultaneously (e.g. #2224) with no code change on any of them. Root cause, confirmed from the actual failing job log: the macOS `Install dependencies` step ran `brew install cmake ninja ccache pipx autoconf automake libtool` with `cmake` unpinned. Homebrew's floating cmake drifted to 4.4.0 on the `macos-15` hosted runner, and that release crashes meson's cmake-method resolution of the `httplib` vcpkg dependency: `httplibConfig.cmake`'s `find_dependency(Threads)` → `FindThreads.cmake` → `try_compile()` trips CMake's own internal `"This should not have happened"` guard in `Internal/CheckSourceCompiles.cmake`, which poisons the subsequent `cpp-httplib` fallback lookup too and hard-fails `meson setup`.

- Pins `cmake` via `pipx install cmake==4.3.4` (the latest 4.x release before the 4.4.0 regression) in both `ci.yml`'s PR-fast-path macOS job and `release.yml`'s tag-triggered macOS release-build job — `release.yml` carried the identical unpinned line and would have hit the same crash on the next release cut (a sibling-gap finding caught in review).
- `brew unlink cmake || true` as belt-and-suspenders: the runner image pre-bakes its own cmake independent of this workflow's `brew install` line, so just dropping `cmake` from that line doesn't remove the pre-existing binary.
- Explicit `GITHUB_PATH` prepend via `pipx environment --value PIPX_BIN_DIR`, captured into a variable rather than inlined into `echo` (a failing/empty command substitution inlined into `echo "$(...)"` would silently pass under `set -e`, since only `echo`'s own exit status is checked).
- Verifies the pinned binary directly (`"$pipx_bin_dir/cmake" --version`) rather than a bare `cmake` call, since `GITHUB_PATH` only takes effect starting the next step — makes the fix self-documenting in future logs.

## Governance

Full `/governance` run on this commit, all gates clean, no CRITICAL/HIGH/BLOCKING findings:
- Gate 2 (security-guardian + docs-writer): closed one real MEDIUM (the `release.yml` sibling gap) and one LOW (stderr-swallowing on the unlink) in a hardening round; re-reviewed clean.
- Gate 3 (build-ci): approved, then empirically re-verified the `set -e`/command-substitution fix after Gate 4 found it.
- Gate 4 (happy-path/unhappy-path/consistency-auditor): folded in one real SHOULD-level bash correctness bug (see above) and a self-verifying diagnostic; otherwise clean.
- Gate 5 (chaos-injector): skipped — no compound-failure scenario applicable to a CI workflow YAML change.
- Gate 6 (compliance-officer/sre/enterprise-readiness): all PASS. Non-blocking follow-ups noted (fleet-wide pipx hash-pinning, a future reminder to revisit this pin once cmake 4.4.x is confirmed fixed) — tracked separately, not gating this PR.

## Test plan

- [x] YAML validated (`yaml.safe_load`) on both files
- [x] Shell logic empirically verified under GH Actions' actual `bash --noprofile --norc -eo pipefail {0}` semantics (assignment-context command-substitution failure propagation, empty-string detection, quoting with a space-containing path)
- [x] `cmake==4.3.4` confirmed to exist on PyPI with a `macosx_10_10_universal2` wheel (covers `arm64-osx`)
- [ ] macOS CI leg goes green on this PR (the actual end-to-end proof — watching after push)