### PR TITLE
fix(test): release parked drain worker on every exit path (#1648 exit-42 on Windows)

### DIFF
--- a/tests/unit/test_guardian_engine_spark_reconcile.cpp
+++ b/tests/unit/test_guardian_engine_spark_reconcile.cpp
@@ -836,6 +836,31 @@ TEST_CASE("prefer_spark=true: pending records are durable BEFORE stop() joins th
                                  return SendResult::Sent;
                              });
 
+    // RAII safety net (mirrors OrphanExitGuard in agents/core/src/hard_exit.hpp):
+    // the send callback above parks the drain worker on `release`. If a REQUIRE
+    // below fires while the worker is en route to (or already parked in) that
+    // callback, Catch2 unwinds this scope; without releasing the worker first,
+    // ~GuardianEngine's stop()-join blocks on a `release` that never flips and
+    // the still-live worker races the destruction of these stack-local sync
+    // primitives - the #1648 non-Catch2 process exit (42) that defeats
+    // flake-retry classification and hard-blocks the whole agent suite. Declared
+    // AFTER `engine` so reverse-declaration-order destruction runs this FIRST:
+    // the worker is released (then joined by ~GuardianEngine) while send_mu/
+    // send_cv/release are still alive, so any assertion failure exits as an
+    // ordinary, classifiable Catch2 failure instead of a crash.
+    struct ReleaseParkedWorker {
+        std::mutex& mu;
+        std::condition_variable& cv;
+        bool& release_flag;
+        ~ReleaseParkedWorker() {
+            {
+                std::lock_guard<std::mutex> lk{mu};
+                release_flag = true;
+            }
+            cv.notify_all();
+        }
+    } release_parked_worker{send_mu, send_cv, release};
+
     // One injected write failure leaves the armed rule's record PENDING rather than durable,
     // so what reaches disk later is attributable to a stop()-path persist and nothing else.
     engine.lifecycle_journal_for_test()->inject_write_failures_for_test(1);
@@ -846,8 +871,16 @@ TEST_CASE("prefer_spark=true: pending records are durable BEFORE stop() joins th
     REQUIRE(kv.list_entries(yuzu::agent::kJournalNamespace, yuzu::agent::kBatchKeyPrefix)->empty());
 
     {   // Park the worker inside a send, so the join below cannot complete.
+        // Generous deadline: on a saturated Windows CI runner the drain worker can
+        // be starved well past its ~5 s periodic backstop before it reaches the
+        // send callback (box-contention flake, not a logic bug - see the WeeTam
+        // agent-suite timeouts). The deadline is NOT shrunk by pinning the
+        // backstop cadence: a short backstop would let the worker persist the
+        // pending record on its own timer BEFORE the stop()-path persist, which
+        // would defeat this test's whole attribution. If the worker still misses
+        // this window, ReleaseParkedWorker above makes the failure exit cleanly.
         std::unique_lock<std::mutex> lk{send_mu};
-        REQUIRE(send_cv.wait_for(lk, std::chrono::seconds(10), [&] { return in_send; }));
+        REQUIRE(send_cv.wait_for(lk, std::chrono::seconds(30), [&] { return in_send; }));
     }
 
     std::atomic<bool> stop_returned{false};


### PR DESCRIPTION
## What

Fixes the `#1648` non-Catch2 **exit-42** that hard-blocked the **Windows** agent test suite on `dev` (WeeTam `agent unit tests` FAIL ~70s, *"not a classifiable Catch2 run — crash/non-Catch2"*, observed on every Windows run after the 2026-07-23 morning merges).

## Root cause

The failing assertion is `tests/unit/test_guardian_engine_spark_reconcile.cpp:850` in *"prefer_spark=true: pending records are durable BEFORE stop() joins the drain worker"* (added by `97da3f12`, #2298 — **unrelated to the macОС parity work that merged the same morning**).

The test wires a send callback that **parks the drain worker** on a `release` flag captured **by reference from the test stack**. On a saturated WeeTam runner the worker is starved past the 10s deadline that waits for it to enter `send`; when that `REQUIRE` throws, Catch2 unwinds the scope while the worker is still racing toward that callback. Without releasing it first, `~GuardianEngine`'s stop()-join blocks on a `release` that never flips and the live worker touches the stack-local sync primitives during their destruction → the process exits **42**. Catch2 prints a clean `1 failed` but the OS reports 42, which `scripts/ci/flake-retry.py` can't reconcile with Catch2's convention (exit == failure count) → it classifies the whole suite as an unrecoverable crash and blocks the job.

## Fix (test-only, +34/−1)

1. **`ReleaseParkedWorker` RAII guard** declared *after* `engine` so reverse-declaration-order destruction releases the worker (and lets `~GuardianEngine` join it) while the captured primitives are still alive — on **every** exit path, incl. a thrown `REQUIRE`. Mirrors the `OrphanExitGuard` idiom in `agents/core/src/hard_exit.hpp`. Any assertion failure now exits as an **ordinary, classifiable Catch2 failure** (recoverable by flake-retry) instead of a crash.
2. **Deadline 10s → 30s** for scheduling slack under box contention. Deliberately **not** via pinning the backstop cadence — a short backstop would persist the pending record on its own timer before the stop()-path persist and defeat this test's whole attribution.

## Validation

- Green on macOS (Apple Clang): fixed case exits 0 with a clean summary (`Session::run() returned 0`); full `[reconcile]` tag 189 assertions / 22 cases.
- This PR runs the WeeTam Windows MSVC job for in-environment validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)