### PR TITLE
fix(test): keep Guardian protobuf maps inside the agent DLL

### DIFF
--- a/tests/unit/test_guardian_engine_spark_reconcile.cpp
+++ b/tests/unit/test_guardian_engine_spark_reconcile.cpp
@@ -836,18 +836,9 @@ TEST_CASE("prefer_spark=true: pending records are durable BEFORE stop() joins th
                                  return SendResult::Sent;
                              });
 
-    // RAII safety net (mirrors OrphanExitGuard in agents/core/src/hard_exit.hpp):
-    // the send callback above parks the drain worker on `release`. If a REQUIRE
-    // below fires while the worker is en route to (or already parked in) that
-    // callback, Catch2 unwinds this scope; without releasing the worker first,
-    // ~GuardianEngine's stop()-join blocks on a `release` that never flips and
-    // the still-live worker races the destruction of these stack-local sync
-    // primitives - the #1648 non-Catch2 process exit (42) that defeats
-    // flake-retry classification and hard-blocks the whole agent suite. Declared
-    // AFTER `engine` so reverse-declaration-order destruction runs this FIRST:
-    // the worker is released (then joined by ~GuardianEngine) while send_mu/
-    // send_cv/release are still alive, so any assertion failure exits as an
-    // ordinary, classifiable Catch2 failure instead of a crash.
+    // A fatal assertion at the wait boundary can unwind while the worker is racing into
+    // the parked callback. Declared after engine so this releases the worker before
+    // ~GuardianEngine joins it, while send_mu/send_cv/release are still alive.
     struct ReleaseParkedWorker {
         std::mutex& mu;
         std::condition_variable& cv;
@@ -867,7 +858,10 @@ TEST_CASE("prefer_spark=true: pending records are durable BEFORE stop() joins th
     gpb::GuaranteedStatePush push;
     push.set_full_sync(true);
     *push.add_rules() = make_service_rule("r1");
-    engine.apply_rules(push);
+    // Serialize-then-dispatch because the rule carries a protobuf Map; see the fixture's
+    // apply() helper above for the Windows EXE/DLL abseil hash-seed boundary.
+    REQUIRE(yuzu::agent::guardian_dispatch_push_bytes_for_test(engine, push.SerializeAsString())
+                .exit_code == 0);
     REQUIRE(kv.list_entries(yuzu::agent::kJournalNamespace, yuzu::agent::kBatchKeyPrefix)->empty());
 
     {   // Park the worker inside a send, so the join below cannot complete.


### PR DESCRIPTION
## Summary

- Route this Guardian test's protobuf payload through the existing serialize-and-dispatch helper.
- Keep protobuf `Map` construction and lookup on the agent-DLL side of the Windows module boundary.
- Retain the worker-release guard added by #2393, while correcting its explanation of the observed failure.

## Root cause

The failing case in run `29998367194` was:

`prefer_spark=true: pending records are durable BEFORE stop() joins the drain worker`

It failed at the wait for `in_send`, after logging that rule `r1` could not derive a Spark spec for `service-status-change`. The test built a `GuaranteedStatePush` in the test EXE and passed it directly to `GuardianEngine::apply_rules()` in `yuzu_agent_core.dll`.

On Windows, the test EXE and agent DLL each statically link protobuf/Abseil. The rule's protobuf `Map` was populated with the EXE's address-derived Abseil hash seed, then searched by code in the DLL with the DLL's seed. Depending on the seeds, `find("service_name")` searched a different bucket and returned no value. The rule was therefore not armed, the send callback was never reached, and the wait assertion failed. This is intermittent because the per-module seeds vary.

This is a test-boundary bug, not a product bug: production receives serialized gRPC bytes and parses the message inside the DLL. The existing `guardian_dispatch_push_bytes_for_test()` helper models that boundary and is already used by the fixture for this exact reason.

The process exit code was not evidence of a teardown crash. Catch2 v3 uses the fixed `TestFailureExitCode` value `42`; the artifact contains a normal Catch2 summary with one failed assertion. Flake retry then launched the test binary without the Meson-provided agent-core DLL path, so Windows returned `0xC0000135` before Catch2 could write its retry JUnit file. That empty result was labeled `crash/non-Catch2`, and the test was not listed as known-flaky, so the job blocked. The retry environment is a separate CI follow-up.

## History

The test entered `dev` in `97da3f12fb7d` via #2345 on 2026-07-23. Its first merge run happened to pass; the first Windows debug failure followed in run `29995544379`, and run `29998367194` reproduced it in both debug and release. Matching Linux revisions did not hard-fail this case. No product change from the other merges that morning is required to explain the onset.

#2393 added a useful assertion-unwind guard and lengthened the wait, but its teardown/starvation explanation does not account for the logged Spark-spec rejection preceding the assertion. This patch is based on the merged #2393 change, retains the guard, and fixes the protobuf module-boundary hazard.

## Verification

- `meson compile -C build-macos yuzu_agent_tests`
- Exact failing case: 1 case / 7 assertions passed, exit 0
- `yuzu_agent_tests "[spark][guardian][reconcile]"`: 22 cases / 190 assertions passed
- `yuzu_agent_tests "~[tsan-heavy]"`: 1,386 passed, 4 skipped / 106,650 assertions passed, exit 0
- `git diff --check origin/dev...HEAD`

Windows CI validation is still required because the defect depends on the MSVC EXE/DLL boundary. The macOS runs verify compilation, behavior, and the happy path, but cannot exercise that Windows-specific ABI/module layout.
