### PR TITLE
test(pg): tag PG-fixture route tests [pg] — restore the ~[pg] shard's PG-free contract (#2354)

### DIFF
--- a/tests/unit/server/test_auth_jit_elevation.cpp
+++ b/tests/unit/server/test_auth_jit_elevation.cpp
@@ -254,7 +254,7 @@ TEST_CASE("AuthManager::reap_expired_elevation is exactly-once under concurrent 
 
 // ── AuthDB eligibility column ────────────────────────────────────────────────
 
-TEST_CASE("AuthDB::set/is_elevation_eligible round-trips, fail-closed", "[jit][authdb]") {
+TEST_CASE("AuthDB::set/is_elevation_eligible round-trips, fail-closed", "[jit][authdb][pg]") {
     auto dir = yuzu::test::TempDir{};
     fs::create_directories(dir.path);
     AuthDB db(dir.path, /*cleanup_interval_secs=*/0);
@@ -439,7 +439,7 @@ struct JitHarness {
 };
 } // namespace
 
-TEST_CASE("POST /api/v1/elevate: eligible operator is elevated to admin", "[jit][routes]") {
+TEST_CASE("POST /api/v1/elevate: eligible operator is elevated to admin", "[jit][routes][pg]") {
     JitHarness h;
     auto token = h.session_for("alice");
 
@@ -490,7 +490,7 @@ TEST_CASE("POST /api/v1/elevate: eligible operator is elevated to admin", "[jit]
 // is already expired), passes post-fix (ceil'd remaining).
 TEST_CASE("POST /api/v1/elevate: duration_secs:1 is a live window, not "
           "truncated to 0",
-          "[jit][routes]") {
+          "[jit][routes][pg]") {
     JitHarness h;
     auto token = h.session_for("alice"); // normal, full-lifetime session
 
@@ -529,7 +529,7 @@ TEST_CASE("POST /api/v1/elevate: duration_secs:1 is a live window, not "
 // no other test forces a clamp at the REST layer.
 TEST_CASE("POST /api/v1/elevate: a session-lifetime clamp keeps the audit "
           "duration_secs in sync with the response expires_in",
-          "[jit][routes]") {
+          "[jit][routes][pg]") {
     JitHarness h;
     auto token = h.session_for("alice");
 
@@ -567,7 +567,7 @@ TEST_CASE("POST /api/v1/elevate: a session-lifetime clamp keeps the audit "
     CHECK(audit_duration == expires_in);
 }
 
-TEST_CASE("an elevated operator can perform an admin-gated action", "[jit][routes]") {
+TEST_CASE("an elevated operator can perform an admin-gated action", "[jit][routes][pg]") {
     JitHarness h;
     auto token = h.session_for("alice");
     // Before elevation: the admin-gated eligibility endpoint is forbidden.
@@ -585,7 +585,7 @@ TEST_CASE("an elevated operator can perform an admin-gated action", "[jit][route
     CHECK(h.auth_db.is_elevation_eligible("bob").value() == false);
 }
 
-TEST_CASE("an elevated admin action is audited as principal_role=admin (H1)", "[jit][routes]") {
+TEST_CASE("an elevated admin action is audited as principal_role=admin (H1)", "[jit][routes][pg]") {
     JitHarness h;
     auto token = h.session_for("alice"); // base role: user
     REQUIRE(h.post("/api/v1/elevate", token, R"({"justification":"x"})")->status == 200);
@@ -598,7 +598,7 @@ TEST_CASE("an elevated admin action is audited as principal_role=admin (H1)", "[
     CHECK(h.audit_role("role.elevation.granted", "alice") == "admin");
 }
 
-TEST_CASE("POST /api/v1/elevate: MFA enrollment is mandatory to elevate", "[jit][routes]") {
+TEST_CASE("POST /api/v1/elevate: MFA enrollment is mandatory to elevate", "[jit][routes][pg]") {
     JitHarness h;
     // bob is eligible but has NO second factor enrolled — elevation is the
     // privilege-crossing boundary, so it is refused regardless of mfa_enforcement
@@ -629,7 +629,7 @@ TEST_CASE("POST /api/v1/elevate: MFA enrollment is mandatory to elevate", "[jit]
 // asserting a successful OIDC-amr grant were removed here and belong with #1852.
 TEST_CASE("POST /api/v1/elevate: an OIDC session cannot elevate — denied at the "
           "eligibility gate (#1837/#1857 severance; restoration tracked in #1852)",
-          "[jit][routes][oidc]") {
+          "[jit][routes][oidc][pg]") {
     JitHarness h;
     // bob has a local users row (eligible), but his OIDC session's principal is
     // the namespaced oidc:<iss>#<sub>, NOT "bob" — it can never match bob's (or
@@ -656,7 +656,7 @@ TEST_CASE("POST /api/v1/elevate: an OIDC session cannot elevate — denied at th
 
 TEST_CASE("POST /api/v1/elevate: a federated-only OIDC identity (no local users row) "
           "is likewise denied (#1837/#1857 severance)",
-          "[jit][routes][oidc]") {
+          "[jit][routes][oidc][pg]") {
     JitHarness h;
     // "dave" was never seeded into auth.db — a genuinely federated-only
     // identity. Same outcome as an OIDC session whose sub coincides with a
@@ -677,7 +677,7 @@ TEST_CASE("POST /api/v1/elevate: a federated-only OIDC identity (no local users 
 // admin's local session with a fresh local step-up proof — the OIDC branch
 // must never engage for auth_source=="local".
 TEST_CASE("POST /api/v1/elevate: a local session is unaffected by the OIDC-amr path",
-          "[jit][routes][oidc]") {
+          "[jit][routes][oidc][pg]") {
     JitHarness h;
     auto token = h.session_for("alice"); // local session, alice IS enrolled
     auto res = h.post("/api/v1/elevate", token, R"({"justification":"x"})");
@@ -689,7 +689,7 @@ TEST_CASE("POST /api/v1/elevate: a local session is unaffected by the OIDC-amr p
 
 TEST_CASE("POST /api/v1/elevate: audit detail places mfa= before justification= "
           "(anti-forgery, consistency S-3)",
-          "[jit][routes]") {
+          "[jit][routes][pg]") {
     JitHarness h;
     auto token = h.session_for("alice");
     // A crafted justification embeds a forged "mfa=oidc_amr" token. Free-text
@@ -709,7 +709,7 @@ TEST_CASE("POST /api/v1/elevate: audit detail places mfa= before justification= 
     CHECK(detail.substr(mfa_pos, std::string("mfa=local_totp").size()) == "mfa=local_totp");
 }
 
-TEST_CASE("POST /api/v1/elevate: a stale MFA proof is challenged, not granted", "[jit][routes]") {
+TEST_CASE("POST /api/v1/elevate: a stale MFA proof is challenged, not granted", "[jit][routes][pg]") {
     JitHarness h;
     // alice IS enrolled but the session has no fresh proof (mfa_verified_at at the
     // epoch sentinel) → the step-up gate challenges; elevation is NOT granted.
@@ -721,7 +721,7 @@ TEST_CASE("POST /api/v1/elevate: a stale MFA proof is challenged, not granted", 
     CHECK_FALSE(auth::is_elevated(*h.auth_mgr.validate_session(token)));
 }
 
-TEST_CASE("POST /api/v1/elevate: an ineligible operator is denied", "[jit][routes]") {
+TEST_CASE("POST /api/v1/elevate: an ineligible operator is denied", "[jit][routes][pg]") {
     JitHarness h;
     REQUIRE(h.auth_db.set_elevation_eligible("alice", false).has_value()); // revoke eligibility
     auto token = h.session_for("alice");
@@ -732,7 +732,7 @@ TEST_CASE("POST /api/v1/elevate: an ineligible operator is denied", "[jit][route
     CHECK_FALSE(auth::is_elevated(*h.auth_mgr.validate_session(token)));
 }
 
-TEST_CASE("POST /api/v1/elevate: justification is mandatory", "[jit][routes]") {
+TEST_CASE("POST /api/v1/elevate: justification is mandatory", "[jit][routes][pg]") {
     JitHarness h;
     auto token = h.session_for("alice");
     auto res = h.post("/api/v1/elevate", token, R"({"justification":"   "})"); // whitespace only
@@ -741,7 +741,7 @@ TEST_CASE("POST /api/v1/elevate: justification is mandatory", "[jit][routes]") {
     CHECK_FALSE(auth::is_elevated(*h.auth_mgr.validate_session(token)));
 }
 
-TEST_CASE("POST /api/v1/elevate: wrong-typed fields are a 400, not a 500", "[jit][routes]") {
+TEST_CASE("POST /api/v1/elevate: wrong-typed fields are a 400, not a 500", "[jit][routes][pg]") {
     JitHarness h;
     auto token = h.session_for("alice");
     // A present-but-wrong-type field must be a clean client error (review UP-2).
@@ -765,7 +765,7 @@ TEST_CASE("POST /api/v1/elevate: wrong-typed fields are a 400, not a 500", "[jit
     CHECK(huge_expires_in == h.cfg.jit_max_elevation_secs);
 }
 
-TEST_CASE("POST /api/v1/elevate: duration is clamped to the cap", "[jit][routes]") {
+TEST_CASE("POST /api/v1/elevate: duration is clamped to the cap", "[jit][routes][pg]") {
     JitHarness h;
     auto token = h.session_for("alice");
     auto res = h.post("/api/v1/elevate", token,
@@ -778,7 +778,7 @@ TEST_CASE("POST /api/v1/elevate: duration is clamped to the cap", "[jit][routes]
     CHECK(expires_in == h.cfg.jit_max_elevation_secs);
 }
 
-TEST_CASE("POST /api/v1/elevate/revoke reverts the elevation", "[jit][routes]") {
+TEST_CASE("POST /api/v1/elevate/revoke reverts the elevation", "[jit][routes][pg]") {
     JitHarness h;
     auto token = h.session_for("alice");
     REQUIRE(h.post("/api/v1/elevate", token, R"({"justification":"x"})")->status == 200);
@@ -791,7 +791,7 @@ TEST_CASE("POST /api/v1/elevate/revoke reverts the elevation", "[jit][routes]") 
     CHECK_FALSE(auth::is_elevated(*h.auth_mgr.validate_session(token)));
 }
 
-TEST_CASE("revoking eligibility terminates an active elevation", "[jit][routes]") {
+TEST_CASE("revoking eligibility terminates an active elevation", "[jit][routes][pg]") {
     JitHarness h;
     // alice elevates, then an admin revokes her eligibility — her in-flight
     // elevation must drop immediately (review UP-1), not linger for the window.
@@ -806,7 +806,7 @@ TEST_CASE("revoking eligibility terminates an active elevation", "[jit][routes]"
     CHECK_FALSE(auth::is_elevated(*h.auth_mgr.validate_session(alice))); // elevation cleared
 }
 
-TEST_CASE("an operator cannot set their own elevation eligibility", "[jit][routes]") {
+TEST_CASE("an operator cannot set their own elevation eligibility", "[jit][routes][pg]") {
     JitHarness h;
     // Self-grant is blocked (review UP-6) so a temporary admin window cannot
     // manufacture a durable self-elevation right.
@@ -816,7 +816,7 @@ TEST_CASE("an operator cannot set their own elevation eligibility", "[jit][route
     CHECK(res->status == 403);
 }
 
-TEST_CASE("POST /api/v1/elevate: a tokenless (no-cookie) request is rejected", "[jit][routes]") {
+TEST_CASE("POST /api/v1/elevate: a tokenless (no-cookie) request is rejected", "[jit][routes][pg]") {
     JitHarness h;
     // No Cookie header → not an interactive session → 401 (API/MCP tokens, which
     // resolve without a cookie, can never elevate).
@@ -829,7 +829,7 @@ TEST_CASE("POST /api/v1/elevate: a tokenless (no-cookie) request is rejected", "
 
 TEST_CASE("role.elevation.expired is audited lazily on the next authenticated "
          "request after a passive lapse",
-         "[jit][routes]") {
+         "[jit][routes][pg]") {
     JitHarness h;
     auto token = h.session_for("alice");
     // Force a lapsed elevation directly via AuthManager (bypassing the REST
@@ -858,7 +858,7 @@ TEST_CASE("role.elevation.expired is audited lazily on the next authenticated "
 }
 
 TEST_CASE("a manually revoked elevation does not ALSO emit role.elevation.expired",
-         "[jit][routes]") {
+         "[jit][routes][pg]") {
     JitHarness h;
     auto token = h.session_for("alice");
     REQUIRE(h.post("/api/v1/elevate", token, R"({"justification":"x"})")->status == 200);
@@ -875,7 +875,7 @@ TEST_CASE("a manually revoked elevation does not ALSO emit role.elevation.expire
 
 TEST_CASE("a reap that fires within a request leaves THAT request's session "
          "resolving as base role (UP-9)",
-         "[jit][routes]") {
+         "[jit][routes][pg]") {
     JitHarness h;
     auto token = h.session_for("alice");
     REQUIRE(h.auth_mgr.elevate_session(token, std::chrono::seconds(1)).has_value());
@@ -899,7 +899,7 @@ TEST_CASE("a reap that fires within a request leaves THAT request's session "
 
 TEST_CASE("a lazy role.elevation.expired reap survives an unwritable audit store "
          "(best-effort, UP-3)",
-         "[jit][routes]") {
+         "[jit][routes][pg]") {
     JitHarness h(/*audit_store_broken=*/true);
     auto token = h.session_for("alice");
     REQUIRE(h.auth_mgr.elevate_session(token, std::chrono::seconds(1)).has_value());

--- a/tests/unit/server/test_auth_routes.cpp
+++ b/tests/unit/server/test_auth_routes.cpp
@@ -106,7 +106,7 @@ httplib::Request request_with_header(const std::string& name, const std::string&
 }  // namespace
 
 TEST_CASE("AuthRoutes::resolve_session — Bearer token populates principal",
-          "[auth_routes]") {
+          "[auth_routes][pg]") {
     AuthRoutesFixture fix;
     auto raw = fix.mint_token();
     auto req = request_with_header("Authorization", "Bearer " + raw);
@@ -118,7 +118,7 @@ TEST_CASE("AuthRoutes::resolve_session — Bearer token populates principal",
 }
 
 TEST_CASE("AuthRoutes::resolve_session — X-Yuzu-Token populates principal",
-          "[auth_routes]") {
+          "[auth_routes][pg]") {
     AuthRoutesFixture fix;
     auto raw = fix.mint_token();
     auto req = request_with_header("X-Yuzu-Token", raw);
@@ -129,7 +129,7 @@ TEST_CASE("AuthRoutes::resolve_session — X-Yuzu-Token populates principal",
 }
 
 TEST_CASE("AuthRoutes::resolve_session — session cookie populates principal",
-          "[auth_routes]") {
+          "[auth_routes][pg]") {
     AuthRoutesFixture fix;
     auto cookie = fix.auth_mgr.authenticate("test_user", "test_password");
     REQUIRE(cookie.has_value());
@@ -141,7 +141,7 @@ TEST_CASE("AuthRoutes::resolve_session — session cookie populates principal",
 }
 
 TEST_CASE("AuthRoutes::resolve_session — no auth returns nullopt",
-          "[auth_routes]") {
+          "[auth_routes][pg]") {
     AuthRoutesFixture fix;
     httplib::Request req;
     auto session = fix.ar->resolve_session(req);
@@ -150,7 +150,7 @@ TEST_CASE("AuthRoutes::resolve_session — no auth returns nullopt",
 
 TEST_CASE("AuthRoutes::make_audit_event — populates principal from Bearer token "
           "(regression: mcp.* audit rows had empty principal)",
-          "[auth_routes][audit]") {
+          "[auth_routes][audit][pg]") {
     AuthRoutesFixture fix;
     auto raw = fix.mint_token();
     auto req = request_with_header("Authorization", "Bearer " + raw);
@@ -164,7 +164,7 @@ TEST_CASE("AuthRoutes::make_audit_event — populates principal from Bearer toke
 }
 
 TEST_CASE("AuthRoutes::make_audit_event — populates principal from X-Yuzu-Token",
-          "[auth_routes][audit]") {
+          "[auth_routes][audit][pg]") {
     AuthRoutesFixture fix;
     auto raw = fix.mint_token();
     auto req = request_with_header("X-Yuzu-Token", raw);
@@ -176,7 +176,7 @@ TEST_CASE("AuthRoutes::make_audit_event — populates principal from X-Yuzu-Toke
 }
 
 TEST_CASE("AuthRoutes::make_audit_event — populates principal from session cookie",
-          "[auth_routes][audit]") {
+          "[auth_routes][audit][pg]") {
     AuthRoutesFixture fix;
     auto cookie = fix.auth_mgr.authenticate("test_user", "test_password");
     REQUIRE(cookie.has_value());
@@ -190,7 +190,7 @@ TEST_CASE("AuthRoutes::make_audit_event — populates principal from session coo
 }
 
 TEST_CASE("AuthRoutes::make_audit_event — empty principal when no auth present",
-          "[auth_routes][audit]") {
+          "[auth_routes][audit][pg]") {
     AuthRoutesFixture fix;
     httplib::Request req;
     auto event = fix.ar->make_audit_event(req, "anonymous", "success");
@@ -201,7 +201,7 @@ TEST_CASE("AuthRoutes::make_audit_event — empty principal when no auth present
 
 TEST_CASE("AuthRoutes::emit_event — analytics event records principal from "
           "Bearer token (regression: same shape as audit_event bug)",
-          "[auth_routes][analytics]") {
+          "[auth_routes][analytics][pg]") {
     AuthRoutesFixture fix;
     auto raw = fix.mint_token();
     auto req = request_with_header("Authorization", "Bearer " + raw);
@@ -228,7 +228,7 @@ TEST_CASE("AuthRoutes::emit_event — analytics event records principal from "
 // ---------------------------------------------------------------------------
 
 TEST_CASE("AuthRoutes::require_admin — service-scoped token from admin is rejected",
-          "[auth_routes][scope][mcp]") {
+          "[auth_routes][scope][mcp][pg]") {
     AuthRoutesFixture fix;
     // Mint a token scoped to "finance-svc"; creator is an admin.
     auto now = std::chrono::duration_cast<std::chrono::seconds>(
@@ -258,7 +258,7 @@ TEST_CASE("AuthRoutes::require_admin — service-scoped token from admin is reje
 }
 
 TEST_CASE("AuthRoutes::require_admin — MCP token from admin is rejected",
-          "[auth_routes][scope][mcp]") {
+          "[auth_routes][scope][mcp][pg]") {
     AuthRoutesFixture fix;
     auto now = std::chrono::duration_cast<std::chrono::seconds>(
                    std::chrono::system_clock::now().time_since_epoch()).count();
@@ -275,7 +275,7 @@ TEST_CASE("AuthRoutes::require_admin — MCP token from admin is rejected",
 }
 
 TEST_CASE("AuthRoutes::require_admin — unscoped admin token is accepted (regression guard)",
-          "[auth_routes][scope][mcp]") {
+          "[auth_routes][scope][mcp][pg]") {
     AuthRoutesFixture fix;
     auto raw = fix.api_tokens->create_token("plain", "test_user");
     REQUIRE(raw.has_value());
@@ -294,7 +294,7 @@ TEST_CASE("AuthRoutes::require_admin — unscoped admin token is accepted (regre
 // ---------------------------------------------------------------------------
 
 TEST_CASE("AuthRoutes::require_permission — readonly MCP tier blocks Execute regardless of RBAC",
-          "[auth_routes][scope][mcp]") {
+          "[auth_routes][scope][mcp][pg]") {
     AuthRoutesFixture fix;
     // Fixture has rbac_store=nullptr (RBAC disabled). test_user is admin.
     // Tier enforcement must fire regardless of RBAC state.
@@ -324,7 +324,7 @@ TEST_CASE("AuthRoutes::require_permission — readonly MCP tier blocks Execute r
 }
 
 TEST_CASE("AuthRoutes::require_permission — readonly MCP tier allows Read without RBAC",
-          "[auth_routes][scope][mcp]") {
+          "[auth_routes][scope][mcp][pg]") {
     AuthRoutesFixture fix;
     // readonly tier permits Read; creator is admin; RBAC disabled → should pass.
     auto now = std::chrono::duration_cast<std::chrono::seconds>(
@@ -344,7 +344,7 @@ TEST_CASE("AuthRoutes::require_permission — readonly MCP tier allows Read with
 // ---------------------------------------------------------------------------
 
 TEST_CASE("AuthRoutes::require_scoped_permission — operator MCP tier allows Execute without RBAC",
-          "[auth_routes][scope][mcp]") {
+          "[auth_routes][scope][mcp][pg]") {
     AuthRoutesFixture fix;
     // operator tier permits Execution:Execute; creator is admin; RBAC disabled → pass.
     auto now = std::chrono::duration_cast<std::chrono::seconds>(
@@ -360,7 +360,7 @@ TEST_CASE("AuthRoutes::require_scoped_permission — operator MCP tier allows Ex
 }
 
 TEST_CASE("AuthRoutes::require_scoped_permission — readonly MCP tier blocks Execute",
-          "[auth_routes][scope][mcp]") {
+          "[auth_routes][scope][mcp][pg]") {
     AuthRoutesFixture fix;
     auto now = std::chrono::duration_cast<std::chrono::seconds>(
                    std::chrono::system_clock::now().time_since_epoch()).count();
@@ -398,7 +398,7 @@ TEST_CASE("AuthRoutes::require_scoped_permission — readonly MCP tier blocks Ex
 // ---------------------------------------------------------------------------
 
 TEST_CASE("AuthRoutes::require_permission — supervised MCP token blocked from approval-gated Execute",
-          "[auth_routes][scope][mcp]") {
+          "[auth_routes][scope][mcp][pg]") {
     AuthRoutesFixture fix;
     auto now = std::chrono::duration_cast<std::chrono::seconds>(
                    std::chrono::system_clock::now().time_since_epoch()).count();
@@ -425,7 +425,7 @@ TEST_CASE("AuthRoutes::require_permission — supervised MCP token blocked from 
 // recall consumes the ticket then dies at the auth layer. This is the exact
 // integration bug the UAT smoke caught (the MCP unit harness mocks perm_fn).
 TEST_CASE("AuthRoutes::require_permission — approval gate is skipped on the MCP transport",
-          "[auth_routes][scope][mcp]") {
+          "[auth_routes][scope][mcp][pg]") {
     AuthRoutesFixture fix;
     auto now = std::chrono::duration_cast<std::chrono::seconds>(
                    std::chrono::system_clock::now().time_since_epoch()).count();
@@ -453,7 +453,7 @@ TEST_CASE("AuthRoutes::require_permission — approval gate is skipped on the MC
 // Execute, so requires_approval() was false for the REST pair and a supervised
 // MCP token could quarantine (and release) via REST with NO approval (#520).
 TEST_CASE("AuthRoutes::require_permission — supervised token mirror-denied on REST quarantine POST",
-          "[auth_routes][scope][mcp][quarantine]") {
+          "[auth_routes][scope][mcp][quarantine][pg]") {
     AuthRoutesFixture fix;
     auto now = std::chrono::duration_cast<std::chrono::seconds>(
                    std::chrono::system_clock::now().time_since_epoch()).count();
@@ -475,7 +475,7 @@ TEST_CASE("AuthRoutes::require_permission — supervised token mirror-denied on 
 }
 
 TEST_CASE("AuthRoutes::require_permission — supervised token mirror-denied on REST quarantine DELETE",
-          "[auth_routes][scope][mcp][quarantine]") {
+          "[auth_routes][scope][mcp][quarantine][pg]") {
     AuthRoutesFixture fix;
     auto now = std::chrono::duration_cast<std::chrono::seconds>(
                    std::chrono::system_clock::now().time_since_epoch()).count();
@@ -494,7 +494,7 @@ TEST_CASE("AuthRoutes::require_permission — supervised token mirror-denied on 
 }
 
 TEST_CASE("AuthRoutes::require_scoped_permission — supervised MCP token blocked from approval-gated Delete",
-          "[auth_routes][scope][mcp]") {
+          "[auth_routes][scope][mcp][pg]") {
     AuthRoutesFixture fix;
     auto now = std::chrono::duration_cast<std::chrono::seconds>(
                    std::chrono::system_clock::now().time_since_epoch()).count();
@@ -511,7 +511,7 @@ TEST_CASE("AuthRoutes::require_scoped_permission — supervised MCP token blocke
 }
 
 TEST_CASE("AuthRoutes::require_permission — supervised MCP token allows Read (not approval-gated)",
-          "[auth_routes][scope][mcp]") {
+          "[auth_routes][scope][mcp][pg]") {
     AuthRoutesFixture fix;
     auto now = std::chrono::duration_cast<std::chrono::seconds>(
                    std::chrono::system_clock::now().time_since_epoch()).count();
@@ -530,7 +530,7 @@ TEST_CASE("AuthRoutes::require_permission — supervised MCP token allows Read (
 // ---------------------------------------------------------------------------
 
 TEST_CASE("AuthRoutes::require_auth — oversized Bearer token is rejected (DoS protection #630)",
-          "[auth_routes][dos]") {
+          "[auth_routes][dos][pg]") {
     AuthRoutesFixture fix;
     std::string big_token(1000, 'a');
     auto req = request_with_header("Authorization", "Bearer " + big_token);
@@ -542,7 +542,7 @@ TEST_CASE("AuthRoutes::require_auth — oversized Bearer token is rejected (DoS 
 }
 
 TEST_CASE("AuthRoutes::require_auth — oversized X-Yuzu-Token is rejected (DoS protection #630)",
-          "[auth_routes][dos]") {
+          "[auth_routes][dos][pg]") {
     AuthRoutesFixture fix;
     std::string big_token(1000, 'b');
     auto req = request_with_header("X-Yuzu-Token", big_token);
@@ -615,7 +615,7 @@ TEST_CASE("AuthRoutes::url_decode — mixed valid and malformed sequences (H-A)"
 // every stream on the fleet at the same instant (chaos CH-4).
 
 TEST_CASE("revalidate_stream: a live token for the stream's principal is valid",
-          "[auth][stream][ch4]") {
+          "[auth][stream][ch4][pg]") {
     AuthRoutesFixture f;
     const auto token = f.mint_token();
     auto req = request_with_header("Authorization", "Bearer " + token);
@@ -623,7 +623,7 @@ TEST_CASE("revalidate_stream: a live token for the stream's principal is valid",
 }
 
 TEST_CASE("revalidate_stream: a revoked token DEFINITIVELY ends the stream",
-          "[auth][stream][ch4]") {
+          "[auth][stream][ch4][pg]") {
     AuthRoutesFixture f;
     const auto token = f.mint_token();
     auto live = f.api_tokens->validate_token(token);
@@ -637,7 +637,7 @@ TEST_CASE("revalidate_stream: a revoked token DEFINITIVELY ends the stream",
 }
 
 TEST_CASE("revalidate_stream: a valid token for ANOTHER principal is not authority",
-          "[auth][stream][ch4]") {
+          "[auth][stream][ch4][pg]") {
     AuthRoutesFixture f;
     const auto token = f.mint_token(); // belongs to test_user
     auto req = request_with_header("Authorization", "Bearer " + token);
@@ -646,14 +646,14 @@ TEST_CASE("revalidate_stream: a valid token for ANOTHER principal is not authori
     CHECK(f.ar->revalidate_stream(req, "someone_else") == auth::CredentialCheck::kRevoked);
 }
 
-TEST_CASE("revalidate_stream: no credential at all is a definitive no", "[auth][stream][ch4]") {
+TEST_CASE("revalidate_stream: no credential at all is a definitive no", "[auth][stream][ch4][pg]") {
     AuthRoutesFixture f;
     httplib::Request bare;
     CHECK(f.ar->revalidate_stream(bare, "test_user") == auth::CredentialCheck::kRevoked);
 }
 
 TEST_CASE("revalidate_stream: a dead cookie FALLS THROUGH to a live token",
-          "[auth][stream][ch4]") {
+          "[auth][stream][ch4][pg]") {
     // The invariant: a stream lives iff a fresh request with these headers would still
     // authenticate as this principal — so this must mirror resolve_session's
     // fall-through exactly. An earlier version returned kRevoked as soon as the cookie
@@ -669,7 +669,7 @@ TEST_CASE("revalidate_stream: a dead cookie FALLS THROUGH to a live token",
 }
 
 TEST_CASE("revalidate_stream: X-Yuzu-Token is honoured alongside a dead Bearer",
-          "[auth][stream][ch4]") {
+          "[auth][stream][ch4][pg]") {
     AuthRoutesFixture f;
     const auto token = f.mint_token();
     httplib::Request req;
@@ -679,7 +679,7 @@ TEST_CASE("revalidate_stream: X-Yuzu-Token is honoured alongside a dead Bearer",
 }
 
 TEST_CASE("revalidate_stream: an unreachable token store is INDETERMINATE, not revoked",
-          "[auth][stream][ch4]") {
+          "[auth][stream][ch4][pg]") {
     // CH-4's second half. If the store cannot answer, we do not KNOW the credential is
     // gone — and treating "cannot tell" as "revoked" would cut every stream on the
     // fleet the moment the auth store hiccupped. The pump rides out a bounded grace

--- a/tests/unit/server/test_auth_routes_hardened.cpp
+++ b/tests/unit/server/test_auth_routes_hardened.cpp
@@ -175,7 +175,7 @@ constexpr const char* kFormCt = "application/x-www-form-urlencoded";
 } // namespace
 
 TEST_CASE("standard mode: local login still works (regression guard)",
-          "[auth][hardened][routes]") {
+          "[auth][hardened][routes][pg]") {
     HardenedHarness h("standard", "");
     auto res = h.sink.Post("/login", form({{"username", "alice"}, {"password", "alicepassword1"}}),
                            kFormCt);
@@ -186,7 +186,7 @@ TEST_CASE("standard mode: local login still works (regression guard)",
 }
 
 TEST_CASE("sso-only: non-break-glass local login is rejected with a generic 401",
-          "[auth][hardened][routes]") {
+          "[auth][hardened][routes][pg]") {
     HardenedHarness h("sso-only", "");
     auto res = h.sink.Post("/login", form({{"username", "alice"}, {"password", "alicepassword1"}}),
                            kFormCt);
@@ -205,7 +205,7 @@ TEST_CASE("sso-only: non-break-glass local login is rejected with a generic 401"
 }
 
 TEST_CASE("sso-only: a valid password is still rejected when local login is disabled",
-          "[auth][hardened][routes]") {
+          "[auth][hardened][routes][pg]") {
     // Even the correct credential must not mint a session in sso-only mode for a
     // non-exempt user — the disable is unconditional, not a password check.
     HardenedHarness h("sso-only", "");
@@ -220,7 +220,7 @@ TEST_CASE("sso-only: a valid password is still rejected when local login is disa
 }
 
 TEST_CASE("sso-only: break-glass user is still rejected when NOT armed",
-          "[auth][hardened][routes]") {
+          "[auth][hardened][routes][pg]") {
     HardenedHarness h("sso-only", "admin");
     // admin is the configured break-glass user but has not been armed.
     auto res = h.sink.Post("/login", form({{"username", "admin"}, {"password", "adminpassword1"}}),
@@ -235,7 +235,7 @@ TEST_CASE("sso-only: break-glass user is still rejected when NOT armed",
 }
 
 TEST_CASE("sso-only: armed break-glass user with MFA proceeds to the MFA challenge",
-          "[auth][hardened][routes]") {
+          "[auth][hardened][routes][pg]") {
     HardenedHarness h("sso-only", "admin");
     h.enroll_mfa("admin");
     h.arm("admin");
@@ -255,7 +255,7 @@ TEST_CASE("sso-only: armed break-glass user with MFA proceeds to the MFA challen
 }
 
 TEST_CASE("sso-only: a non-break-glass user is rejected even while another is armed",
-          "[auth][hardened][routes]") {
+          "[auth][hardened][routes][pg]") {
     HardenedHarness h("sso-only", "admin");
     h.enroll_mfa("admin");
     h.arm("admin");
@@ -269,7 +269,7 @@ TEST_CASE("sso-only: a non-break-glass user is rejected even while another is ar
 }
 
 TEST_CASE("sso-only: armed break-glass user WITHOUT MFA is HARD-DENIED, not offered enrollment",
-          "[auth][hardened][routes]") {
+          "[auth][hardened][routes][pg]") {
     // Governance UP-1 (BLOCKING fix). The boot guard normally refuses to start
     // with an MFA-less break-glass user; if one slips through (MFA cleared
     // out-of-band after boot), the login handler must HARD-DENY — never offer
@@ -290,7 +290,7 @@ TEST_CASE("sso-only: armed break-glass user WITHOUT MFA is HARD-DENIED, not offe
 }
 
 TEST_CASE("sso-only: the break-glass account is exempt from failed-login lockout",
-          "[auth][hardened][routes]") {
+          "[auth][hardened][routes][pg]") {
     // Governance Hermes-F / UP-13: without the exemption an attacker who learns
     // the break-glass username could spray wrong passwords to keep it locked and
     // render the escape hatch unreachable during the very IdP outage it exists
@@ -321,7 +321,7 @@ TEST_CASE("sso-only: the break-glass account is exempt from failed-login lockout
 }
 
 TEST_CASE("sso-only: wrong password against an armed break-glass user is a normal login failure",
-          "[auth][hardened][routes]") {
+          "[auth][hardened][routes][pg]") {
     // The break-glass success row (auth.breakglass.login) must fire only AFTER
     // verify_password succeeds — a wrong password takes the standard
     // auth.login_failed path and never produces a spurious "ok" break-glass row.

--- a/tests/unit/server/test_auth_routes_mfa.cpp
+++ b/tests/unit/server/test_auth_routes_mfa.cpp
@@ -201,7 +201,7 @@ std::string form(std::initializer_list<std::pair<std::string, std::string>> kv) 
 } // namespace
 
 TEST_CASE("POST /login no-MFA success returns 200 + session cookie + auth.login audit",
-          "[mfa][routes][auth_routes]") {
+          "[mfa][routes][auth_routes][pg]") {
     AuthRoutesHarness h;
     auto res = h.sink.Post("/login", form({{"username", "admin"}, {"password", "adminpassword1"}}),
                            "application/x-www-form-urlencoded");
@@ -216,7 +216,7 @@ TEST_CASE("POST /login no-MFA success returns 200 + session cookie + auth.login 
 }
 
 TEST_CASE("POST /login bad password returns 401 + auth.login_failed audit",
-          "[mfa][routes][auth_routes]") {
+          "[mfa][routes][auth_routes][pg]") {
     AuthRoutesHarness h;
     auto res = h.sink.Post("/login", form({{"username", "admin"}, {"password", "wrong"}}),
                            "application/x-www-form-urlencoded");
@@ -228,7 +228,7 @@ TEST_CASE("POST /login bad password returns 401 + auth.login_failed audit",
 }
 
 TEST_CASE("POST /login MFA-enrolled returns 202 + mfa_pending_token, no cookie",
-          "[mfa][routes][auth_routes]") {
+          "[mfa][routes][auth_routes][pg]") {
     AuthRoutesHarness h;
     h.enroll_mfa("admin");
     auto res = h.sink.Post("/login", form({{"username", "admin"}, {"password", "adminpassword1"}}),
@@ -248,7 +248,7 @@ TEST_CASE("POST /login MFA-enrolled returns 202 + mfa_pending_token, no cookie",
 
 TEST_CASE("POST /login/mfa with valid TOTP mints session and emits dual audit (mfa.login.verified "
           "+ auth.login)",
-          "[mfa][routes][auth_routes]") {
+          "[mfa][routes][auth_routes][pg]") {
     AuthRoutesHarness h;
     auto secret_b32 = h.enroll_mfa("admin");
     // First leg: /login → 202 + pending token
@@ -274,7 +274,7 @@ TEST_CASE("POST /login/mfa with valid TOTP mints session and emits dual audit (m
 }
 
 TEST_CASE("POST /login/mfa with valid recovery code emits mfa.recovery_code.used + auth.login",
-          "[mfa][routes][auth_routes]") {
+          "[mfa][routes][auth_routes][pg]") {
     AuthRoutesHarness h;
     h.enroll_mfa("admin");
     // Pull a freshly minted recovery code by regenerating (init's reveal
@@ -309,7 +309,7 @@ TEST_CASE("POST /login/mfa with valid recovery code emits mfa.recovery_code.used
 }
 
 TEST_CASE("POST /login/mfa with invalid pending token returns 401 + audit",
-          "[mfa][routes][auth_routes]") {
+          "[mfa][routes][auth_routes][pg]") {
     AuthRoutesHarness h;
     auto res = h.sink.Post(
         "/login/mfa",
@@ -322,7 +322,7 @@ TEST_CASE("POST /login/mfa with invalid pending token returns 401 + audit",
 }
 
 TEST_CASE("POST /login/mfa attempts cap erases pending after 5 failures",
-          "[mfa][routes][auth_routes]") {
+          "[mfa][routes][auth_routes][pg]") {
     AuthRoutesHarness h;
     h.enroll_mfa("admin");
     auto step1 = h.sink.Post("/login",
@@ -365,7 +365,7 @@ TEST_CASE("POST /login/mfa attempts cap erases pending after 5 failures",
 }
 
 TEST_CASE("POST /login/mfa strict shape gate routes non-6-digit to recovery path",
-          "[mfa][routes][auth_routes]") {
+          "[mfa][routes][auth_routes][pg]") {
     AuthRoutesHarness h;
     h.enroll_mfa("admin");
     auto codes = h.auth_db.mfa_regenerate_recovery_codes("admin");
@@ -400,7 +400,7 @@ TEST_CASE("POST /login/mfa strict shape gate routes non-6-digit to recovery path
     CHECK(saw_recovery);
 }
 
-TEST_CASE("POST /login/mfa pending token expires after TTL", "[mfa][routes][auth_routes]") {
+TEST_CASE("POST /login/mfa pending token expires after TTL", "[mfa][routes][auth_routes][pg]") {
     AuthRoutesHarness h;
     h.enroll_mfa("admin");
     auto step1 = h.sink.Post("/login",
@@ -476,7 +476,7 @@ std::string login_with_mfa(AuthRoutesHarness& h, const std::string& username,
 
 TEST_CASE(
     "POST /login/mfa/stepup with valid fresh TOTP succeeds and emits mfa.step_up.passed",
-    "[mfa][stepup][routes]") {
+    "[mfa][stepup][routes][pg]") {
     AuthRoutesHarness h;
     auto secret = h.enroll_mfa("admin");
     auto cookie = login_with_mfa(h, "admin", "adminpassword1", secret);
@@ -505,7 +505,7 @@ TEST_CASE(
 
 TEST_CASE(
     "POST /login/mfa/stepup with a recovery code succeeds and emits mfa.step_up.passed",
-    "[mfa][stepup][routes]") {
+    "[mfa][stepup][routes][pg]") {
     AuthRoutesHarness h;
     auto secret = h.enroll_mfa("admin");
     auto codes = h.auth_db.mfa_regenerate_recovery_codes("admin");
@@ -533,7 +533,7 @@ TEST_CASE(
 }
 
 TEST_CASE("POST /login/mfa/stepup without a session returns 401 (require_auth gate)",
-          "[mfa][stepup][routes]") {
+          "[mfa][stepup][routes][pg]") {
     AuthRoutesHarness h;
     h.enroll_mfa("admin");
     auto res = h.sink.Post("/login/mfa/stepup", form({{"code", "123456"}}),
@@ -546,7 +546,7 @@ TEST_CASE("POST /login/mfa/stepup without a session returns 401 (require_auth ga
 }
 
 TEST_CASE("POST /login/mfa/stepup with empty code body returns 400 + audit",
-          "[mfa][stepup][routes]") {
+          "[mfa][stepup][routes][pg]") {
     AuthRoutesHarness h;
     auto secret = h.enroll_mfa("admin");
     auto cookie = login_with_mfa(h, "admin", "adminpassword1", secret);
@@ -560,7 +560,7 @@ TEST_CASE("POST /login/mfa/stepup with empty code body returns 400 + audit",
 }
 
 TEST_CASE("POST /login/mfa/stepup with wrong TOTP returns 401 + mfa.step_up.failed",
-          "[mfa][stepup][routes]") {
+          "[mfa][stepup][routes][pg]") {
     AuthRoutesHarness h;
     auto secret = h.enroll_mfa("admin");
     auto cookie = login_with_mfa(h, "admin", "adminpassword1", secret);
@@ -591,7 +591,7 @@ TEST_CASE("POST /login/mfa/stepup with wrong TOTP returns 401 + mfa.step_up.fail
 // ── /login/mfa/enroll + enforcement bootstrap tests (PR3) ─────────────────
 
 TEST_CASE("POST /login load-sheds with 503 when the pending-token map is at capacity (H-2)",
-          "[mfa][routes][auth_routes]") {
+          "[mfa][routes][auth_routes][pg]") {
     // Hermes H-2 / governance qe-B: the pending-map cap is exercised via the
     // test-only seam (the production 50k is impractical to fill). The login
     // challenge and enrollment issuance sites share byte-identical cap logic
@@ -615,7 +615,7 @@ TEST_CASE("POST /login load-sheds with 503 when the pending-token map is at capa
 
 TEST_CASE("POST /login under mfa_enforcement=required: un-enrolled user gets 202 enrollment "
           "challenge, no cookie",
-          "[mfa][enroll][routes][auth_routes]") {
+          "[mfa][enroll][routes][auth_routes][pg]") {
     AuthRoutesHarness h;
     h.cfg.mfa_enforcement = "required"; // cfg_ is held by reference
     auto res = h.sink.Post("/login", form({{"username", "alice"}, {"password", "alicepassword1"}}),
@@ -634,7 +634,7 @@ TEST_CASE("POST /login under mfa_enforcement=required: un-enrolled user gets 202
 }
 
 TEST_CASE("POST /login/mfa/enroll completes enforced enrollment: 200 + cookie + recovery codes",
-          "[mfa][enroll][routes][auth_routes]") {
+          "[mfa][enroll][routes][auth_routes][pg]") {
     AuthRoutesHarness h;
     h.cfg.mfa_enforcement = "required";
     auto step1 =
@@ -667,7 +667,7 @@ TEST_CASE("POST /login/mfa/enroll completes enforced enrollment: 200 + cookie + 
 
 TEST_CASE("POST /login under mfa_enforcement=admin-only: admin enrolls, regular user logs in "
           "normally",
-          "[mfa][enroll][routes][auth_routes]") {
+          "[mfa][enroll][routes][auth_routes][pg]") {
     AuthRoutesHarness h;
     h.cfg.mfa_enforcement = "admin-only";
 
@@ -690,7 +690,7 @@ TEST_CASE("POST /login under mfa_enforcement=admin-only: admin enrolls, regular 
 
 TEST_CASE("POST /login under enforcement: already-enrolled user gets the login challenge, not "
           "enrollment",
-          "[mfa][enroll][routes][auth_routes]") {
+          "[mfa][enroll][routes][auth_routes][pg]") {
     AuthRoutesHarness h;
     h.cfg.mfa_enforcement = "required";
     h.enroll_mfa("alice");
@@ -703,7 +703,7 @@ TEST_CASE("POST /login under enforcement: already-enrolled user gets the login c
 }
 
 TEST_CASE("enrollment token replayed at /login/mfa is rejected",
-          "[mfa][enroll][routes][auth_routes]") {
+          "[mfa][enroll][routes][auth_routes][pg]") {
     AuthRoutesHarness h;
     h.cfg.mfa_enforcement = "required";
     auto e1 = h.sink.Post("/login", form({{"username", "alice"}, {"password", "alicepassword1"}}),
@@ -734,7 +734,7 @@ TEST_CASE("enrollment token replayed at /login/mfa is rejected",
 }
 
 TEST_CASE("login-challenge token replayed at /login/mfa/enroll is rejected",
-          "[mfa][enroll][routes][auth_routes]") {
+          "[mfa][enroll][routes][auth_routes][pg]") {
     AuthRoutesHarness h;
     auto secret = h.enroll_mfa("admin");
     auto step1 = h.sink.Post("/login",
@@ -765,7 +765,7 @@ TEST_CASE("login-challenge token replayed at /login/mfa/enroll is rejected",
 }
 
 TEST_CASE("POST /login enforced + auth_db unavailable fails CLOSED with 503",
-          "[mfa][enroll][routes][auth_routes]") {
+          "[mfa][enroll][routes][auth_routes][pg]") {
     // GOVERNANCE qe-B1 / SOC 2 CC6.6 fail-closed. Under enforcement, if the
     // store that holds TOTP secrets is unavailable, /login must refuse to
     // mint a session (503) rather than silently mint an unprotected one.
@@ -781,7 +781,7 @@ TEST_CASE("POST /login enforced + auth_db unavailable fails CLOSED with 503",
 }
 
 TEST_CASE("POST /login/mfa/enroll + auth_db unavailable fails closed with uniform 401",
-          "[mfa][enroll][routes][auth_routes]") {
+          "[mfa][enroll][routes][auth_routes][pg]") {
     // qe-B1 + Hermes L-1: the enroll db-null branch fails closed with the
     // uniform 401 body (matching /login/mfa), not a distinct 503 that would
     // leak pending-token validity during a store outage. No session minted.
@@ -805,7 +805,7 @@ TEST_CASE("POST /login/mfa/enroll + auth_db unavailable fails closed with unifor
 }
 
 TEST_CASE("POST /login/mfa/enroll attempts cap erases pending after 5 failures",
-          "[mfa][enroll][routes][auth_routes]") {
+          "[mfa][enroll][routes][auth_routes][pg]") {
     // qe-B2: enrollment-bootstrap brute-force cap parity with /login/mfa.
     AuthRoutesHarness h;
     h.cfg.mfa_enforcement = "required";
@@ -845,7 +845,7 @@ TEST_CASE("POST /login/mfa/enroll attempts cap erases pending after 5 failures",
 }
 
 TEST_CASE("POST /login/mfa/enroll non-6-digit code is rejected as malformed, token survives",
-          "[mfa][enroll][routes][auth_routes]") {
+          "[mfa][enroll][routes][auth_routes][pg]") {
     // qe-S1: shape gate. Recovery codes don't exist at enroll time, so a
     // non-6-digit code is "malformed", not routed to recovery.
     AuthRoutesHarness h;
@@ -881,7 +881,7 @@ TEST_CASE("POST /login/mfa/enroll non-6-digit code is rejected as malformed, tok
 }
 
 TEST_CASE("POST /login/mfa/enroll concurrent submit with same token: exactly one wins",
-          "[mfa][enroll][routes][auth_routes]") {
+          "[mfa][enroll][routes][auth_routes][pg]") {
     // qe-S2: the enroll endpoint's atomic move-out-on-lookup must mint
     // exactly one session under a same-token race, like /login/mfa.
     AuthRoutesHarness h;
@@ -914,7 +914,7 @@ TEST_CASE("POST /login/mfa/enroll concurrent submit with same token: exactly one
 }
 
 TEST_CASE("POST /login/mfa concurrent submit with same token: exactly one wins",
-          "[mfa][routes][auth_routes]") {
+          "[mfa][routes][auth_routes][pg]") {
     AuthRoutesHarness h;
     auto secret_b32 = h.enroll_mfa("admin");
     auto step1 = h.sink.Post("/login",
@@ -958,7 +958,7 @@ TEST_CASE("POST /login/mfa concurrent submit with same token: exactly one wins",
 // invariant, and the success-clears-the-counter path.
 
 TEST_CASE("POST /login: N bad passwords locks the account, applied audit fires once",
-          "[mfa][routes][auth_routes][lockout]") {
+          "[mfa][routes][auth_routes][lockout][pg]") {
     AuthRoutesHarness h;
     h.cfg.auth_lockout_threshold = 3;
     h.cfg.auth_lockout_window_secs = 900;
@@ -987,7 +987,7 @@ TEST_CASE("POST /login: N bad passwords locks the account, applied audit fires o
 }
 
 TEST_CASE("POST /login: locked-account 401 body is byte-identical to a bad-password 401 (no oracle)",
-          "[mfa][routes][auth_routes][lockout]") {
+          "[mfa][routes][auth_routes][lockout][pg]") {
     AuthRoutesHarness h;
     h.cfg.auth_lockout_threshold = 2;
 
@@ -1014,7 +1014,7 @@ TEST_CASE("POST /login: locked-account 401 body is byte-identical to a bad-passw
 }
 
 TEST_CASE("POST /login: a successful login clears a non-zero failure counter",
-          "[mfa][routes][auth_routes][lockout]") {
+          "[mfa][routes][auth_routes][lockout][pg]") {
     AuthRoutesHarness h;
     h.cfg.auth_lockout_threshold = 3;
 
@@ -1042,7 +1042,7 @@ TEST_CASE("POST /login: a successful login clears a non-zero failure counter",
 }
 
 TEST_CASE("POST /login: lockout disabled (threshold=0) never locks",
-          "[mfa][routes][auth_routes][lockout]") {
+          "[mfa][routes][auth_routes][lockout][pg]") {
     AuthRoutesHarness h;
     h.cfg.auth_lockout_threshold = 0; // disabled
 
@@ -1061,7 +1061,7 @@ TEST_CASE("POST /login: lockout disabled (threshold=0) never locks",
 }
 
 TEST_CASE("POST /login: concurrent burst for one user cannot exceed the threshold (C1 race close)",
-          "[mfa][routes][auth_routes][lockout][concurrency]") {
+          "[mfa][routes][auth_routes][lockout][concurrency][pg]") {
     // Adversarial C1: without per-username serialization, a synchronized burst
     // of attempts for ONE username could all pass the stale lockout pre-check
     // and each verify a password before any failure was recorded, so the

--- a/tests/unit/server/test_auth_sso_identity.cpp
+++ b/tests/unit/server/test_auth_sso_identity.cpp
@@ -286,7 +286,7 @@ bool column_exists(sqlite3* db, const char* table, const char* column) {
 } // namespace
 
 TEST_CASE("AuthDB migration v6: identity columns added, existing v5 rows survive",
-          "[sso][authdb][migration]") {
+          "[sso][authdb][migration][pg]") {
     auto dir = yuzu::test::TempDir{};
     fs::create_directories(dir.path);
     auto db_path = dir.path / "auth.db";
@@ -435,7 +435,7 @@ struct SsoJitHarness {
 } // namespace
 
 TEST_CASE("POST /api/v1/elevate: a provisioned, eligible OIDC session elevates",
-          "[sso][jit][routes]") {
+          "[sso][jit][routes][pg]") {
     SsoJitHarness h;
     auto [token, principal] = h.oidc_session("sub-alice");
 
@@ -459,7 +459,7 @@ TEST_CASE("POST /api/v1/elevate: a provisioned, eligible OIDC session elevates",
 }
 
 TEST_CASE("POST /api/v1/elevate: an OIDC session with no durable row is denied fail-closed",
-          "[sso][jit][routes]") {
+          "[sso][jit][routes][pg]") {
     SsoJitHarness h;
     // No upsert_sso_identity call — simulates a provisioning miss (or simply
     // no admin having granted eligibility, since a never-provisioned
@@ -477,7 +477,7 @@ TEST_CASE("POST /api/v1/elevate: an OIDC session with no durable row is denied f
 
 TEST_CASE("POST /api/v1/elevate: an OIDC session with no amr-attested MFA is denied "
           "unconditionally (even under the default --mfa-enforcement=optional)",
-          "[sso][jit][routes]") {
+          "[sso][jit][routes][pg]") {
     SsoJitHarness h;
     // Provisioned + eligible, but the IdP never attested MFA (amr_mfa=false)
     // — mfa_verified_at is unset (epoch sentinel).
@@ -513,7 +513,7 @@ TEST_CASE("POST /api/v1/elevate: an OIDC session with no amr-attested MFA is den
 
 TEST_CASE("POST /api/v1/elevate: an OIDC session cannot borrow a legacy identity_source='local' "
           "row's eligibility grant even when the principal strings collide",
-          "[sso][jit][routes]") {
+          "[sso][jit][routes][pg]") {
     SsoJitHarness h;
     // Simulate the exact landmine cons-N2 describes: a row named exactly
     // like a durable OIDC principal, but whose identity_source is 'local'
@@ -546,7 +546,7 @@ TEST_CASE("POST /api/v1/elevate: an OIDC session cannot borrow a legacy identity
 
 TEST_CASE("POST /api/v1/elevate: a SAML session whose NameID collides with a provisioned OIDC "
           "principal is denied (identity-source mismatch, not just the no-amr gate)",
-          "[sso][jit][routes][saml]") {
+          "[sso][jit][routes][saml][pg]") {
     SsoJitHarness h;
     // The other half of cons-N2: a crafted SAML NameID equal to a real,
     // eligible OIDC principal string. SAML sessions already fail closed at
@@ -649,7 +649,7 @@ TEST_CASE("AuthDB::invalidate_all_sessions accepts a durable SSO principal", "[s
 
 TEST_CASE("POST /api/v1/users/elevation-eligibility?username=: the query form reaches "
           "a durable SSO principal that the path form can never carry",
-          "[sso][routes]") {
+          "[sso][routes][pg]") {
     SsoJitHarness h;
     // A realistic OIDC principal — contains '/' (in the issuer URL) and '#'
     // (the iss/sub separator). httplib percent-decodes the path (%2F -> '/',

--- a/tests/unit/server/test_oidc_routes.cpp
+++ b/tests/unit/server/test_oidc_routes.cpp
@@ -116,7 +116,7 @@ oidc::OidcConfig make_minimal_oidc_config() {
 // ---------------------------------------------------------------------------
 
 TEST_CASE("OIDC callback — IdP error response increments yuzu_auth_oidc_login_total{result=error}",
-          "[oidc][auth_routes]") {
+          "[oidc][auth_routes][pg]") {
     OidcRoutesFixture fix;
     fix.oidc_provider = std::make_unique<oidc::OidcProvider>(make_minimal_oidc_config());
     REQUIRE(fix.oidc_provider->is_enabled());
@@ -139,7 +139,7 @@ TEST_CASE("OIDC callback — IdP error response increments yuzu_auth_oidc_login_
 
 TEST_CASE("OIDC callback — missing code/state increments "
           "yuzu_auth_oidc_login_total{result=error}",
-          "[oidc][auth_routes]") {
+          "[oidc][auth_routes][pg]") {
     OidcRoutesFixture fix;
     fix.oidc_provider = std::make_unique<oidc::OidcProvider>(make_minimal_oidc_config());
     REQUIRE(fix.oidc_provider->is_enabled());
@@ -162,7 +162,7 @@ TEST_CASE("OIDC callback — missing code/state increments "
 
 TEST_CASE("OIDC callback — unknown PKCE state increments "
           "yuzu_auth_oidc_login_total{result=error} (no network touched)",
-          "[oidc][auth_routes]") {
+          "[oidc][auth_routes][pg]") {
     OidcRoutesFixture fix;
     fix.oidc_provider = std::make_unique<oidc::OidcProvider>(make_minimal_oidc_config());
     REQUIRE(fix.oidc_provider->is_enabled());
@@ -186,7 +186,7 @@ TEST_CASE("OIDC callback — unknown PKCE state increments "
 }
 
 TEST_CASE("OIDC callback — 404 when provider not configured emits no login counter",
-          "[oidc][auth_routes]") {
+          "[oidc][auth_routes][pg]") {
     OidcRoutesFixture fix; // oidc_provider left null
     auto res = fix.sink.dispatch("GET", "/auth/callback?code=x&state=y");
     REQUIRE(res != nullptr);

--- a/tests/unit/server/test_rest_access_review.cpp
+++ b/tests/unit/server/test_rest_access_review.cpp
@@ -355,7 +355,7 @@ struct AccessReviewHarness {
 
 TEST_CASE("access-reviews: read routes require AccessReview:Read, write routes require "
           "AccessReview:Attest — denied without the right permission",
-          "[access_review][rest][gate]") {
+          "[access_review][rest][gate][pg]") {
     AccessReviewHarness h;
 
     SECTION("export denied without AccessReview:Read") {
@@ -407,7 +407,7 @@ TEST_CASE("access-reviews: read routes require AccessReview:Read, write routes r
 }
 
 TEST_CASE("access-reviews: a session with only AccessReview:Read can export but not attest",
-          "[access_review][rest][gate]") {
+          "[access_review][rest][gate][pg]") {
     AccessReviewHarness h;
     h.perm_override = [](const std::string& t, const std::string& op) {
         return t == "AccessReview" && op == "Read"; // ONLY Read is granted
@@ -435,7 +435,7 @@ TEST_CASE("access-reviews: a session with only AccessReview:Read can export but 
 TEST_CASE("access-reviews: an AuditLog:Read-only principal is denied all six ops — the "
           "over-disclosure #2225 round 2 closes (Operator/PlatformEngineer no longer pull "
           "the grant graph via their unrelated AuditLog:Read grant)",
-          "[access_review][rest][gate]") {
+          "[access_review][rest][gate][pg]") {
     AccessReviewHarness h;
     h.perm_override = [](const std::string& t, const std::string& op) {
         return t == "AuditLog" && op == "Read"; // AuditLog:Read only — NOT AccessReview
@@ -470,7 +470,7 @@ TEST_CASE("access-reviews: an AuditLog:Read-only principal is denied all six ops
 
 TEST_CASE("MCP: an AuditLog:Read-only principal is denied all six access-review tools — the "
           "over-disclosure #2225 round 2 closes, MCP twin",
-          "[access_review][mcp][gate]") {
+          "[access_review][mcp][gate][pg]") {
     AccessReviewHarness h;
     h.perm_override = [](const std::string& t, const std::string& op) {
         return t == "AuditLog" && op == "Read"; // AuditLog:Read only — NOT AccessReview
@@ -507,7 +507,7 @@ TEST_CASE("MCP: an AuditLog:Read-only principal is denied all six access-review 
 
 TEST_CASE("access-reviews: a Reviewer-equivalent grant (AccessReview:Read + "
           "AccessReview:Attest) can perform all six ops — the seeded Reviewer role's shape",
-          "[access_review][rest][gate]") {
+          "[access_review][rest][gate][pg]") {
     AccessReviewHarness h;
     h.perm_override = [](const std::string& t, const std::string& op) {
         return t == "AccessReview" && (op == "Read" || op == "Attest");
@@ -552,7 +552,7 @@ TEST_CASE("access-reviews: a Reviewer-equivalent grant (AccessReview:Read + "
 
 TEST_CASE("MCP: a Reviewer-equivalent grant (AccessReview:Read + AccessReview:Attest) can "
           "perform all six access-review tools",
-          "[access_review][mcp][gate]") {
+          "[access_review][mcp][gate][pg]") {
     AccessReviewHarness h;
     h.perm_override = [](const std::string& t, const std::string& op) {
         return t == "AccessReview" && (op == "Read" || op == "Attest");
@@ -602,7 +602,7 @@ TEST_CASE("MCP: a Reviewer-equivalent grant (AccessReview:Read + AccessReview:At
 // ── Engine-classed session structural deny belt ─────────────────────────────
 
 TEST_CASE("access-reviews: an engine-classed session is denied on every route",
-          "[access_review][rest][engine_deny]") {
+          "[access_review][rest][engine_deny][pg]") {
     AccessReviewHarness h;
     h.session_principal_kind = "engine"; // perm_fn stays permissive (nullptr override)
 
@@ -633,7 +633,7 @@ TEST_CASE("access-reviews: an engine-classed session is denied on every route",
 
 TEST_CASE("export: fails loud with 503 when a source store is unavailable, never a silent "
           "200-empty",
-          "[access_review][rest][503]") {
+          "[access_review][rest][503][pg]") {
     AccessReviewHarness h{/*auth_db_available=*/false};
     auto res = h.sink.Get("/api/v1/access-reviews/export");
     REQUIRE(res);
@@ -646,7 +646,7 @@ TEST_CASE("export: fails loud with 503 when a source store is unavailable, never
 // ── decision enum ────────────────────────────────────────────────────────────
 
 TEST_CASE("attestations: decision outside {attested,flagged_revoke} -> 400",
-          "[access_review][rest][decision]") {
+          "[access_review][rest][decision][pg]") {
     AccessReviewHarness h;
     auto res = h.sink.Post("/api/v1/access-reviews/whatever/attestations",
                            R"({"principal_type":"user","principal_id":"a","role_name":"R",)"
@@ -661,7 +661,7 @@ TEST_CASE("attestations: decision outside {attested,flagged_revoke} -> 400",
 // type_error, so these hit the ordinary "required field missing" 400 path.
 
 TEST_CASE("open campaign: wrong-typed title degrades to 400, never 500",
-          "[access_review][rest][badtype]") {
+          "[access_review][rest][badtype][pg]") {
     AccessReviewHarness h;
     for (const std::string body : {R"({"title":123})", R"({"title":[]})", R"({"title":null})"}) {
         INFO("body=" << body);
@@ -672,7 +672,7 @@ TEST_CASE("open campaign: wrong-typed title degrades to 400, never 500",
 }
 
 TEST_CASE("attestations: wrong-typed decision/principal_type degrades to 400, never 500",
-          "[access_review][rest][badtype]") {
+          "[access_review][rest][badtype][pg]") {
     AccessReviewHarness h;
 
     SECTION("decision not a string") {
@@ -704,7 +704,7 @@ TEST_CASE("attestations: wrong-typed decision/principal_type degrades to 400, ne
 
 TEST_CASE("access-reviews: an audit-persist failure on open/attest/close still commits the "
           "mutation and surfaces Sec-Audit-Failed",
-          "[access_review][rest][audit][secauditfailed]") {
+          "[access_review][rest][audit][secauditfailed][pg]") {
     SECTION("open") {
         AccessReviewHarness h;
         h.audit_fail_action = "access_review.campaign_opened";
@@ -772,7 +772,7 @@ TEST_CASE("access-reviews: an audit-persist failure on open/attest/close still c
 // ── format enum (REST-only — MCP export has no format concept) #2291 ───────
 
 TEST_CASE("export: format classifier — json|csv 200, anything else 400",
-          "[access_review][rest][format][2291]") {
+          "[access_review][rest][format][2291][pg]") {
     AccessReviewHarness h;
 
     auto json_res = h.sink.Get("/api/v1/access-reviews/export?format=json");
@@ -797,7 +797,7 @@ TEST_CASE("export: format classifier — json|csv 200, anything else 400",
 // ── decision enum parity across REST and MCP twins #2291 ───────────────────
 
 TEST_CASE("record_attestation decision validity is consistent across REST and the MCP twin",
-          "[access_review][rest][mcp][decision][2291]") {
+          "[access_review][rest][mcp][decision][2291][pg]") {
     AccessReviewHarness h;
 
     SECTION("valid decisions -> not a 400/invalid-params rejection on either transport") {
@@ -859,7 +859,7 @@ TEST_CASE("record_attestation decision validity is consistent across REST and th
 
 TEST_CASE("attestations: decision=flagged_revoke records evidence only — the underlying grant "
           "is never mutated",
-          "[access_review][rest][flag]") {
+          "[access_review][rest][flag][pg]") {
     AccessReviewHarness h;
     REQUIRE(h.rbac.create_role({.name = "SomeRole", .description = "d"}).has_value());
     REQUIRE(h.auth_db.upsert_user("alice", "hash", "salt", auth::Role::user).has_value());
@@ -895,7 +895,7 @@ TEST_CASE("attestations: decision=flagged_revoke records evidence only — the u
 // ── not_found -> 404, never 503 ─────────────────────────────────────────────
 
 TEST_CASE("attest/get/close on an unknown campaign_id -> 404, not 503",
-          "[access_review][rest][not_found]") {
+          "[access_review][rest][not_found][pg]") {
     AccessReviewHarness h;
 
     auto get_res = h.sink.Get("/api/v1/access-reviews/no-such-campaign");
@@ -920,7 +920,7 @@ TEST_CASE("attest/get/close on an unknown campaign_id -> 404, not 503",
 // ── Self-audit ───────────────────────────────────────────────────────────────
 
 TEST_CASE("access-reviews: export/attest/flag emit their own self-audit rows",
-          "[access_review][rest][audit]") {
+          "[access_review][rest][audit][pg]") {
     AccessReviewHarness h;
     REQUIRE(h.rbac.create_role({.name = "AuditRole", .description = "d"}).has_value());
     REQUIRE(h.auth_db.upsert_user("bob", "hash", "salt", auth::Role::user).has_value());
@@ -975,7 +975,7 @@ TEST_CASE("access-reviews: export/attest/flag emit their own self-audit rows",
 
 // ── GET /api/v1/access-reviews (list campaigns, H-2) ────────────────────────
 
-TEST_CASE("GET /access-reviews: happy path returns opened campaigns", "[access_review][rest][list]") {
+TEST_CASE("GET /access-reviews: happy path returns opened campaigns", "[access_review][rest][list][pg]") {
     AccessReviewHarness h;
     const auto cid = h.open_campaign_rest("List me");
 
@@ -986,7 +986,7 @@ TEST_CASE("GET /access-reviews: happy path returns opened campaigns", "[access_r
     CHECK(res->body.find("\"List me\"") != std::string::npos);
 }
 
-TEST_CASE("GET /access-reviews: 403 without AccessReview:Read", "[access_review][rest][list]") {
+TEST_CASE("GET /access-reviews: 403 without AccessReview:Read", "[access_review][rest][list][pg]") {
     AccessReviewHarness h;
     h.perm_override = [](const std::string& t, const std::string& op) {
         return !(t == "AccessReview" && op == "Read");
@@ -997,7 +997,7 @@ TEST_CASE("GET /access-reviews: 403 without AccessReview:Read", "[access_review]
 }
 
 TEST_CASE("GET /access-reviews: an engine-classed session is denied",
-          "[access_review][rest][list][engine_deny]") {
+          "[access_review][rest][list][engine_deny][pg]") {
     AccessReviewHarness h;
     h.session_principal_kind = "engine";
     auto res = h.sink.Get("/api/v1/access-reviews");
@@ -1007,7 +1007,7 @@ TEST_CASE("GET /access-reviews: an engine-classed session is denied",
 
 TEST_CASE("GET /access-reviews: 503 when the access review store is unavailable, never a "
           "silent 200-empty",
-          "[access_review][rest][list][503]") {
+          "[access_review][rest][list][503][pg]") {
     AccessReviewHarness h{/*auth_db_available=*/true, /*store_available=*/false};
     auto res = h.sink.Get("/api/v1/access-reviews");
     REQUIRE(res);
@@ -1018,7 +1018,7 @@ TEST_CASE("GET /access-reviews: 503 when the access review store is unavailable,
 
 TEST_CASE("MCP: export_access_review / open_access_review / get_access_review / "
           "list_access_reviews / close_access_review happy paths, end to end",
-          "[access_review][mcp][happy]") {
+          "[access_review][mcp][happy][pg]") {
     AccessReviewHarness h;
     REQUIRE(h.rbac.create_role({.name = "McpRole", .description = "d"}).has_value());
     REQUIRE(h.auth_db.upsert_user("mcpuser", "hash", "salt", auth::Role::user).has_value());
@@ -1102,7 +1102,7 @@ TEST_CASE("MCP: export_access_review / open_access_review / get_access_review / 
 
 TEST_CASE("MCP: close_access_review — not_found maps to kInvalidParams, store-down maps to "
           "kInternalError",
-          "[access_review][mcp][close]") {
+          "[access_review][mcp][close][pg]") {
     SECTION("not_found -> kInvalidParams (mirrors the REST twin's 404, never 503-shaped)") {
         AccessReviewHarness h;
         auto res = h.mcp_call_tool("close_access_review", {{"campaign_id", "no-such-campaign"}});
@@ -1128,7 +1128,7 @@ TEST_CASE("MCP: close_access_review — not_found maps to kInvalidParams, store-
 
 TEST_CASE("MCP: a session with only AccessReview:Read can export/get/list but not "
           "open/attest/close",
-          "[access_review][mcp][gate]") {
+          "[access_review][mcp][gate][pg]") {
     AccessReviewHarness h;
     h.perm_override = [](const std::string& t, const std::string& op) {
         return t == "AccessReview" && op == "Read"; // ONLY Read granted
@@ -1172,7 +1172,7 @@ TEST_CASE("MCP: a session with only AccessReview:Read can export/get/list but no
 }
 
 TEST_CASE("MCP: an engine-classed session is denied (kTierDenied) on every access-review tool",
-          "[access_review][mcp][engine_deny]") {
+          "[access_review][mcp][engine_deny][pg]") {
     AccessReviewHarness h;
     h.session_principal_kind = "engine"; // perm_fn stays permissive (nullptr override)
 
@@ -1205,7 +1205,7 @@ TEST_CASE("MCP: an engine-classed session is denied (kTierDenied) on every acces
 TEST_CASE("access-reviews: the 4 new metrics are wired with the documented names/labels and "
           "increment on their respective operation (REST-only — server.cpp's own wiring "
           "comment says the MCP twins are deliberately not double-counted)",
-          "[access_review][rest][metrics]") {
+          "[access_review][rest][metrics][pg]") {
     AccessReviewHarness h;
     // Pre-seed exactly as server.cpp does at startup (the "Periodic Access
     // Reviews (SOC 2 CC6.2) feature metrics" block) — rest_api_v1.cpp's

--- a/tests/unit/server/test_rest_api_tokens.cpp
+++ b/tests/unit/server/test_rest_api_tokens.cpp
@@ -203,7 +203,7 @@ struct RestTokensHarness {
 
 } // namespace
 
-TEST_CASE("REST DELETE /api/v1/tokens: owner can revoke own token", "[rest][token][owner]") {
+TEST_CASE("REST DELETE /api/v1/tokens: owner can revoke own token", "[rest][token][owner][pg]") {
     RestTokensHarness h;
     auto token_id = h.create_token_for("alice", "alice-key");
 
@@ -227,7 +227,7 @@ TEST_CASE("REST DELETE /api/v1/tokens: owner can revoke own token", "[rest][toke
 }
 
 TEST_CASE("REST DELETE /api/v1/tokens: non-owner non-admin gets 404 (no oracle)",
-          "[rest][token][owner][idor]") {
+          "[rest][token][owner][idor][pg]") {
     RestTokensHarness h;
     auto token_id = h.create_token_for("alice", "alice-key");
 
@@ -259,7 +259,7 @@ TEST_CASE("REST DELETE /api/v1/tokens: non-owner non-admin gets 404 (no oracle)"
 
 TEST_CASE("REST DELETE /api/v1/tokens: response body is identical for "
           "unknown id and not-owner (enumeration oracle closed)",
-          "[rest][token][owner][idor]") {
+          "[rest][token][owner][idor][pg]") {
     RestTokensHarness h;
     auto token_id = h.create_token_for("alice", "alice-key");
 
@@ -278,7 +278,7 @@ TEST_CASE("REST DELETE /api/v1/tokens: response body is identical for "
 }
 
 TEST_CASE("REST DELETE /api/v1/tokens: admin bypass revokes any token",
-          "[rest][token][owner][admin]") {
+          "[rest][token][owner][admin][pg]") {
     RestTokensHarness h;
     auto token_id = h.create_token_for("alice", "alice-key");
 
@@ -302,7 +302,7 @@ TEST_CASE("REST DELETE /api/v1/tokens: admin bypass revokes any token",
 }
 
 TEST_CASE("REST DELETE /api/v1/tokens: unknown token id returns 404 with no audit",
-          "[rest][token]") {
+          "[rest][token][pg]") {
     RestTokensHarness h;
     h.session_user = "alice";
     h.session_role = auth::Role::user;
@@ -326,7 +326,7 @@ TEST_CASE("REST DELETE /api/v1/tokens: unknown token id returns 404 with no audi
 // ──────────────────────────────────────────────────────────────────────────
 
 TEST_CASE("REST POST /api/v1/tokens: CSPRNG failure emits failure audit (F-002)",
-          "[rest][token][csprng][audit]") {
+          "[rest][token][csprng][audit][pg]") {
     RestTokensHarness h;
     h.session_user = "alice";
     h.session_role = auth::Role::user;
@@ -370,7 +370,7 @@ TEST_CASE("REST POST /api/v1/tokens: CSPRNG failure emits failure audit (F-002)"
 }
 
 TEST_CASE("REST POST /api/v1/device-tokens: CSPRNG failure emits failure audit (F-002)",
-          "[rest][token][csprng][audit]") {
+          "[rest][token][csprng][audit][pg]") {
     RestTokensHarness h;
     h.session_user = "alice";
     h.session_role = auth::Role::user;
@@ -474,7 +474,7 @@ TEST_CASE("HTMX POST /api/settings/api-tokens: CSPRNG failure persists failure "
 }
 
 TEST_CASE("REST POST /api/v1/tokens: success path is unchanged (regression guard)",
-          "[rest][token][csprng][audit]") {
+          "[rest][token][csprng][audit][pg]") {
     // Defensive: confirm the new failure-path branch did not perturb the
     // success-path audit emission. A successful create must still emit a
     // single `success` row, with the F-002 marker absent.
@@ -523,7 +523,7 @@ TEST_CASE("REST POST /api/v1/tokens: success path is unchanged (regression guard
 
 TEST_CASE("REST POST /api/v1/tokens: silent audit-drop on CSPRNG failure surfaces "
           "Sec-Audit-Failed header + audit_emitted=false body (UP-H1)",
-          "[rest][token][csprng][audit][uph1]") {
+          "[rest][token][csprng][audit][uph1][pg]") {
     RestTokensHarness h;
     h.session_user = "alice";
     h.session_role = auth::Role::user;
@@ -554,7 +554,7 @@ TEST_CASE("REST POST /api/v1/tokens: silent audit-drop on CSPRNG failure surface
 
 TEST_CASE("REST POST /api/v1/tokens: audit-pipeline exception is caught and surfaced "
           "via Sec-Audit-Failed (UP-H1)",
-          "[rest][token][csprng][audit][uph1]") {
+          "[rest][token][csprng][audit][uph1][pg]") {
     RestTokensHarness h;
     h.session_user = "alice";
     h.session_role = auth::Role::user;
@@ -574,7 +574,7 @@ TEST_CASE("REST POST /api/v1/tokens: audit-pipeline exception is caught and surf
 
 TEST_CASE("REST POST /api/v1/device-tokens: silent audit-drop surfaces Sec-Audit-Failed "
           "header + audit_emitted=false body (UP-H1)",
-          "[rest][token][csprng][audit][uph1]") {
+          "[rest][token][csprng][audit][uph1][pg]") {
     RestTokensHarness h;
     h.session_user = "alice";
     h.session_role = auth::Role::user;
@@ -598,7 +598,7 @@ TEST_CASE("REST POST /api/v1/device-tokens: silent audit-drop surfaces Sec-Audit
 
 TEST_CASE("REST POST /api/v1/tokens: oversized name (>256 chars) rejected with 400 "
           "invalid_input_length and NO audit row (UP-H2)",
-          "[rest][token][csprng][audit][uph2]") {
+          "[rest][token][csprng][audit][uph2][pg]") {
     RestTokensHarness h;
     h.session_user = "alice";
     h.session_role = auth::Role::user;
@@ -621,7 +621,7 @@ TEST_CASE("REST POST /api/v1/tokens: oversized name (>256 chars) rejected with 4
 
 TEST_CASE("REST POST /api/v1/device-tokens: oversized device_id (>256 chars) rejected with "
           "400 invalid_input_length (UP-H2)",
-          "[rest][token][csprng][audit][uph2]") {
+          "[rest][token][csprng][audit][uph2][pg]") {
     RestTokensHarness h;
     h.session_user = "alice";
     h.session_role = auth::Role::user;
@@ -640,7 +640,7 @@ TEST_CASE("REST POST /api/v1/device-tokens: oversized device_id (>256 chars) rej
 
 TEST_CASE("REST POST /api/v1/tokens: CSPRNG failure increments "
           "yuzu_secure_random_failure_total{site=api_token} (sre-1)",
-          "[rest][token][csprng][metrics][sre1]") {
+          "[rest][token][csprng][metrics][sre1][pg]") {
     RestTokensHarness h;
     h.session_user = "alice";
     h.session_role = auth::Role::user;
@@ -669,7 +669,7 @@ TEST_CASE("REST POST /api/v1/tokens: CSPRNG failure increments "
 
 TEST_CASE("REST POST /api/v1/device-tokens: CSPRNG failure increments "
           "yuzu_secure_random_failure_total{site=device_token} (sre-1)",
-          "[rest][token][csprng][metrics][sre1]") {
+          "[rest][token][csprng][metrics][sre1][pg]") {
     RestTokensHarness h;
     h.session_user = "alice";
     h.session_role = auth::Role::user;
@@ -689,7 +689,7 @@ TEST_CASE("REST POST /api/v1/device-tokens: CSPRNG failure increments "
 
 TEST_CASE("REST POST /api/v1/tokens: validation 400 (oversized) does NOT increment "
           "secure_random metric (sre-1 negative)",
-          "[rest][token][csprng][metrics][sre1]") {
+          "[rest][token][csprng][metrics][sre1][pg]") {
     // Negative case: confirm UP-H2's pre-CSPRNG rejection path doesn't
     // touch the CSPRNG metric. Same input as the UP-H2 oversized-name
     // test, but asserts on the metric.
@@ -711,7 +711,7 @@ TEST_CASE("REST POST /api/v1/tokens: validation 400 (oversized) does NOT increme
 }
 
 TEST_CASE("REST POST /api/v1/tokens: CSPRNG failure returns 503 + Retry-After: 5 (sre-2)",
-          "[rest][token][csprng][sre2]") {
+          "[rest][token][csprng][sre2][pg]") {
     RestTokensHarness h;
     h.session_user = "alice";
     h.session_role = auth::Role::user;

--- a/tests/unit/server/test_saml_routes.cpp
+++ b/tests/unit/server/test_saml_routes.cpp
@@ -683,7 +683,7 @@ TEST_CASE("extract_form_value — key absent returns empty", "[saml][auth_routes
 // GET /auth/saml/start — provider not configured (null pointer)
 // ---------------------------------------------------------------------------
 
-TEST_CASE("SAML start — returns 404 when provider is null", "[saml][auth_routes]") {
+TEST_CASE("SAML start — returns 404 when provider is null", "[saml][auth_routes][pg]") {
     SamlRoutesFixture fix; // saml_provider defaults to nullptr
     auto res = fix.sink.Get("/auth/saml/start");
     REQUIRE(res != nullptr);
@@ -710,7 +710,7 @@ TEST_CASE("SAML start — returns 404 when provider is null", "[saml][auth_route
 // POST /saml/acs — provider not configured
 // ---------------------------------------------------------------------------
 
-TEST_CASE("SAML ACS — returns 404 when provider is null", "[saml][auth_routes]") {
+TEST_CASE("SAML ACS — returns 404 when provider is null", "[saml][auth_routes][pg]") {
     SamlRoutesFixture fix;
     auto res = fix.sink.Post("/saml/acs",
                              "SAMLResponse=garbage&RelayState=%2Fdashboard",
@@ -742,7 +742,7 @@ TEST_CASE("SAML ACS — returns 404 when provider is null", "[saml][auth_routes]
 // Platform-independent: the empty-field check runs before validate_response.
 // ---------------------------------------------------------------------------
 
-TEST_CASE("SAML ACS — missing SAMLResponse redirects to login error", "[saml][auth_routes]") {
+TEST_CASE("SAML ACS — missing SAMLResponse redirects to login error", "[saml][auth_routes][pg]") {
 #if defined(_WIN32)
     // On Windows the provider stub makes is_enabled()=false, so the route 404s
     // before the field-check. Skip the redirect assertion on Windows.
@@ -783,7 +783,7 @@ TEST_CASE("SAML ACS — missing SAMLResponse redirects to login error", "[saml][
 // POST /saml/acs — malformed SAMLResponse (validate_response returns error)
 // ---------------------------------------------------------------------------
 
-TEST_CASE("SAML ACS — malformed SAMLResponse redirects to login error", "[saml][auth_routes]") {
+TEST_CASE("SAML ACS — malformed SAMLResponse redirects to login error", "[saml][auth_routes][pg]") {
 #if defined(_WIN32)
     SKIP("SamlProvider always disabled on Windows (N4)");
 #else
@@ -820,7 +820,7 @@ TEST_CASE("SAML ACS — malformed SAMLResponse redirects to login error", "[saml
 // GET /auth/saml/start — provider enabled → redirects to IdP
 // ---------------------------------------------------------------------------
 
-TEST_CASE("SAML start — redirects when provider is enabled", "[saml][auth_routes]") {
+TEST_CASE("SAML start — redirects when provider is enabled", "[saml][auth_routes][pg]") {
 #if defined(_WIN32)
     SKIP("SamlProvider always disabled on Windows (N4)");
 #else
@@ -851,7 +851,7 @@ TEST_CASE("SAML start — redirects when provider is enabled", "[saml][auth_rout
 // ---------------------------------------------------------------------------
 
 TEST_CASE("SAML ACS — RelayState open-redirect: absolute URL falls back to /",
-          "[saml][auth_routes]") {
+          "[saml][auth_routes][pg]") {
 #if defined(_WIN32)
     SKIP("SamlProvider always disabled on Windows (N4)");
 #else
@@ -909,7 +909,7 @@ TEST_CASE("SAML ACS — RelayState open-redirect: absolute URL falls back to /",
 // ---------------------------------------------------------------------------
 
 TEST_CASE("SAML ACS — valid signed SAMLResponse creates session with auth_source=saml",
-          "[saml][auth_routes]") {
+          "[saml][auth_routes][pg]") {
 #if defined(_WIN32)
     SKIP("SamlProvider always disabled on Windows (N4)");
 #else
@@ -1059,7 +1059,7 @@ TEST_CASE("SAML ACS — valid signed SAMLResponse creates session with auth_sour
 }
 
 TEST_CASE("SAML ACS — assertion groups containing --saml-admin-group mint an admin session",
-          "[saml][auth_routes]") {
+          "[saml][auth_routes][pg]") {
 #if defined(_WIN32)
     SKIP("SamlProvider always disabled on Windows (N4)");
 #else
@@ -1153,7 +1153,7 @@ TEST_CASE("SAML ACS — assertion groups containing --saml-admin-group mint an a
 }
 
 TEST_CASE("SAML ACS — assertion groups not containing --saml-admin-group mint a user session",
-          "[saml][auth_routes]") {
+          "[saml][auth_routes][pg]") {
 #if defined(_WIN32)
     SKIP("SamlProvider always disabled on Windows (N4)");
 #else
@@ -1241,7 +1241,7 @@ TEST_CASE("SAML ACS — assertion groups not containing --saml-admin-group mint 
 }
 
 TEST_CASE("SAML ACS — a near-miss group value does not mint admin (qa-S1)",
-          "[saml][auth_routes]") {
+          "[saml][auth_routes][pg]") {
 #if defined(_WIN32)
     SKIP("SamlProvider always disabled on Windows (N4)");
 #else
@@ -1266,7 +1266,7 @@ TEST_CASE("SAML ACS — a near-miss group value does not mint admin (qa-S1)",
 }
 
 TEST_CASE("SAML ACS — a case-differing group value does not mint admin (qa-S1)",
-          "[saml][auth_routes]") {
+          "[saml][auth_routes][pg]") {
 #if defined(_WIN32)
     SKIP("SamlProvider always disabled on Windows (N4)");
 #else
@@ -1291,7 +1291,7 @@ TEST_CASE("SAML ACS — a case-differing group value does not mint admin (qa-S1)
 }
 
 TEST_CASE("SAML ACS — an admin-group match beyond the 64-value cap does not mint admin (qa-S2)",
-          "[saml][auth_routes]") {
+          "[saml][auth_routes][pg]") {
 #if defined(_WIN32)
     SKIP("SamlProvider always disabled on Windows (N4)");
 #else
@@ -1328,7 +1328,7 @@ TEST_CASE("SAML ACS — an admin-group match beyond the 64-value cap does not mi
 
 TEST_CASE("SAML ACS — exactly kMaxGroupValues values does not trip the cap-truncation counter "
           "(#1828.3 boundary)",
-          "[saml][auth_routes]") {
+          "[saml][auth_routes][pg]") {
 #if defined(_WIN32)
     SKIP("SamlProvider always disabled on Windows (N4)");
 #else
@@ -1356,7 +1356,7 @@ TEST_CASE("SAML ACS — exactly kMaxGroupValues values does not trip the cap-tru
 }
 
 TEST_CASE("SAML ACS — a trailing space in --saml-admin-group still matches after trim (UP-4)",
-          "[saml][auth_routes]") {
+          "[saml][auth_routes][pg]") {
 #if defined(_WIN32)
     SKIP("SamlProvider always disabled on Windows (N4)");
 #else
@@ -1397,7 +1397,7 @@ TEST_CASE("trim_ascii_whitespace — trims leading/trailing space/tab/CR/LF, "
 
 TEST_CASE("SAML ACS — assertion with no AttributeStatement mints a user session even when "
           "--saml-admin-group is configured",
-          "[saml][auth_routes]") {
+          "[saml][auth_routes][pg]") {
 #if defined(_WIN32)
     SKIP("SamlProvider always disabled on Windows (N4)");
 #else
@@ -1490,7 +1490,7 @@ TEST_CASE("SAML ACS — assertion with no AttributeStatement mints a user sessio
 // ---------------------------------------------------------------------------
 
 TEST_CASE("SAML ACS — unsafe RelayState values fall back to /",
-          "[saml][auth_routes]") {
+          "[saml][auth_routes][pg]") {
 #if defined(_WIN32)
     SKIP("SamlProvider always disabled on Windows (N4)");
 #else
@@ -1565,7 +1565,7 @@ TEST_CASE("SAML ACS — unsafe RelayState values fall back to /",
 // Browser-binding CSRF tests
 // ---------------------------------------------------------------------------
 
-TEST_CASE("SAML ACS — missing binding cookie is rejected", "[saml][auth_routes]") {
+TEST_CASE("SAML ACS — missing binding cookie is rejected", "[saml][auth_routes][pg]") {
 #if defined(_WIN32)
     SKIP("SamlProvider always disabled on Windows (N4)");
 #else
@@ -1619,7 +1619,7 @@ TEST_CASE("SAML ACS — missing binding cookie is rejected", "[saml][auth_routes
 #endif
 }
 
-TEST_CASE("SAML ACS — wrong binding cookie value is rejected", "[saml][auth_routes]") {
+TEST_CASE("SAML ACS — wrong binding cookie value is rejected", "[saml][auth_routes][pg]") {
 #if defined(_WIN32)
     SKIP("SamlProvider always disabled on Windows (N4)");
 #else
@@ -1686,7 +1686,7 @@ TEST_CASE("SAML ACS — wrong binding cookie value is rejected", "[saml][auth_ro
 // ---------------------------------------------------------------------------
 
 TEST_CASE("SAML ACS — shadow-prefix cookie does not shadow real binding cookie (H-B)",
-          "[saml][auth_routes]") {
+          "[saml][auth_routes][pg]") {
 #if defined(_WIN32)
     SKIP("SamlProvider always disabled on Windows (N4)");
 #else
@@ -1753,7 +1753,7 @@ TEST_CASE("SAML ACS — shadow-prefix cookie does not shadow real binding cookie
 // ---------------------------------------------------------------------------
 
 TEST_CASE("SAML ACS — RelayState with path traversal (..) falls back to / (H-D)",
-          "[saml][auth_routes]") {
+          "[saml][auth_routes][pg]") {
 #if defined(_WIN32)
     SKIP("SamlProvider always disabled on Windows (N4)");
 #else
@@ -1813,7 +1813,7 @@ TEST_CASE("SAML ACS — RelayState with path traversal (..) falls back to / (H-D
 }
 
 TEST_CASE("SAML ACS — valid RelayState /dashboard is accepted (H-D)",
-          "[saml][auth_routes]") {
+          "[saml][auth_routes][pg]") {
 #if defined(_WIN32)
     SKIP("SamlProvider always disabled on Windows (N4)");
 #else

--- a/tests/unit/server/test_schedule_routes.cpp
+++ b/tests/unit/server/test_schedule_routes.cpp
@@ -127,7 +127,7 @@ struct ScheduleRouteHarness {
 } // namespace
 
 TEST_CASE("POST /api/schedules: Schedule:Write alone is rejected without Execution:Execute (H-01)",
-          "[server][schedule][h01][rest]") {
+          "[server][schedule][h01][rest][pg]") {
     ScheduleRouteHarness h;
     auto req = h.session_request_for("sched-writer", "ScheduleOnly", {{"Schedule", "Write"}});
     req.body = R"({"name":"nightly-scan","definition_id":"def-1","frequency_type":"daily"})";
@@ -140,7 +140,7 @@ TEST_CASE("POST /api/schedules: Schedule:Write alone is rejected without Executi
 }
 
 TEST_CASE("POST /api/schedules: Execution:Execute alone is rejected without Schedule:Write",
-          "[server][schedule][h01][rest]") {
+          "[server][schedule][h01][rest][pg]") {
     ScheduleRouteHarness h;
     auto req = h.session_request_for("exec-only", "ExecuteOnly", {{"Execution", "Execute"}});
     req.body = R"({"name":"nightly-scan","definition_id":"def-1","frequency_type":"daily"})";
@@ -153,7 +153,7 @@ TEST_CASE("POST /api/schedules: Execution:Execute alone is rejected without Sche
 }
 
 TEST_CASE("POST /api/schedules: Schedule:Write + Execution:Execute together create the schedule",
-          "[server][schedule][h01][rest]") {
+          "[server][schedule][h01][rest][pg]") {
     ScheduleRouteHarness h;
     auto req = h.session_request_for("sched-op", "ScheduleAndExecute",
                                      {{"Schedule", "Write"}, {"Execution", "Execute"}});


### PR DESCRIPTION
## What

Adds `[pg]` to the tag string of **174 TEST_CASEs across 10 route-fixture files** that construct a PG-backed fixture (`ApiTokenStorePg` / `AccessReviewHarness` / per-file template clones) but carried no `[pg]` tag — so they ran in the `~[pg]` shard, whose 600s budget assumes it is PG-free. Tag-only: no logic, no fixture changes.

Files: `test_auth_routes` (31), `test_auth_routes_mfa` (32), `test_auth_routes_hardened` (9), `test_auth_sso_identity` (7), `test_auth_jit_elevation` (24), `test_saml_routes` (21), `test_oidc_routes` (4), `test_schedule_routes` (3), `test_rest_api_tokens` (17), `test_rest_access_review` (26). Cases that never touch PG keep their tags — pure-SQLite harness cases, the `test_rest_api_tokens` broken-pool arm (`:745`, garbage-DSN own pool), and `test_engine_principal_integration` (audited: already consistent, zero changes).

## Why

The `~[pg]` shard's 602.52s at-cap TIMEOUT (PR #2483's Windows leg) traced to exactly this: each of these cases pays a `CREATE DATABASE … TEMPLATE` clone + `DROP` — on Windows (`EXEC_BACKEND`) a `postgres.exe` spawn storm that scales with box contention (#2354). 121s of quiet-box case time sat in the shard whose budget was sized for none of it.

## Measured (Shulgi, quiet box, PG 18.4, CI-parity durability-off, this head vs dev)

| shard | before | after | budget |
|---|---:|---:|---:|
| `~[pg]` | 335.2s / 4269 cases | **213.7s / 4124** | 600s |
| `[pg]` | 217.5s / 574 | **340.1s / 762** | 900s |

Both shards fully green, 0 failures. The moved time (121.5s out / 122.6s in) matches the pre-change prediction within 1.5%. At Wee Tam's measured ~1.8× contention multiplier the `~[pg]` shard projects to ~385s — the timeout class is gone with ~35% headroom, and the multiplier itself should flatten since the clone churn (the contention-scaling component) left the shard.

## Sequencing

Slice 1 of the #2354 plan: tag-first for the immediate CI de-flake; the shared-DB + TRUNCATE conversions of these same fixtures (extending #2362's pattern) follow once #2362 clears re-review, and will shrink what this PR moved.

Test-only change — no changelog fragment per `changelog.d/README.md` rule 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)