### PR TITLE
docs(architecture): correct a false claim about inline route registration in server.cpp

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -291,9 +291,25 @@ Operator                     Server                                  Agent
 
 ## Route Registration
 
-Every HTTP surface the server exposes — REST, dashboard fragments, MCP — is registered by a
+Most HTTP surfaces the server exposes — REST, dashboard fragments, MCP — are registered by a
 **route owner**: a class with a `register_routes(...)` method that the server calls once at
-startup. `server.cpp` itself registers no routes directly; it only wires owners.
+startup. `server.cpp` wires those owners, *and* registers a further **~105 routes inline** on
+`web_server_->{Get,Post,Put,Delete}` — the health and readiness probes, the static-asset surface,
+much of the `/api/*` dashboard JSON, and `POST /api/command`
+(`server/core/src/server.cpp:7951`). It constructs no `HttplibRouteSink` of its own, so none of
+those inline routes is reachable from the in-process test harness.
+
+Counting the surface therefore needs a receiver-agnostic pattern, not a search for one variable
+name:
+
+```bash
+grep -rnE '\b[A-Za-z_][A-Za-z0-9_]*(\.|->)(Get|Post|Put|Delete|Patch|Options)\(' server/core/src/*.cpp
+```
+
+Route owners name their receiver `svr` or `sink`; `server.cpp` names its `web_server_`. Grepping
+only for `svr\.` returns nothing from `server.cpp` and reads as "no inline routes" — a false
+negative that was published in this document and in #2542 before it was caught. `/api/command`'s
+untestability is tracked by #2557; the owner-side migration by #2542.
 
 **The registration seam.** A route owner's real `register_routes` takes `HttpRouteSink&`
 (`server/core/src/http_route_sink.hpp`), and its `httplib::Server&` overload is a thin wrapper
@@ -315,8 +331,9 @@ fragments shipped a destructive operation with no route-handler coverage until #
 
 **Invariant.** New route owners register through `HttpRouteSink&`; new routes on an existing owner
 register through the sink that owner already uses. Do not add a handler that only the
-`httplib::Server&` overload can reach. Owners still registering directly on `httplib::Server` are
-pre-existing debt, not a precedent to copy.
+`httplib::Server&` overload — or an inline `web_server_->` call in `server.cpp` — can reach.
+Registrations outside the sink are pre-existing debt, not a precedent to copy: eight route owners
+(55 registrations) plus `server.cpp`'s ~105 inline ones, roughly 160 in total.
 
 ## Storage Architecture
 


### PR DESCRIPTION
Docs-only. Corrects a factual error I introduced in #2534 and then repeated.

## The error

#2534 added a Route Registration section to `docs/architecture.md` stating:

> `server.cpp` itself registers no routes directly; it only wires owners.

**False.** `server.cpp` registers **105 routes inline** on `web_server_->{Get,Post,Put,Delete}`,
constructs no `HttplibRouteSink`, and the set includes `POST /api/command`
(`server/core/src/server.cpp:7951`), the health and readiness probes, the static-asset surface, and
much of the `/api/*` dashboard JSON. None of it is reachable from the in-process test harness.

That matters because the sentence reads as an invariant. Anyone sizing the route-testability debt
from this document would have concluded the remaining work was 55 registrations across 8 route
owners. It is roughly 160.

## How it happened

A governance reviewer on #2534 reported the claim. I "verified" it by re-running that reviewer's own
`grep` for `svr\.` — the receiver name used *inside route owners* — against a file whose receiver is
`web_server_`. The pattern could not have matched. I recorded the null result as verification, and
it propagated into the doc, into #2542, and into #2534's own description.

## What this changes

The section now states the real position, and carries a **receiver-agnostic** recipe rather than
leaving the next person to invent one:

```bash
grep -rnE '\b[A-Za-z_][A-Za-z0-9_]*(\.|->)(Get|Post|Put|Delete|Patch|Options)\(' server/core/src/*.cpp
```

Verified before documenting: it returns exactly 105 against `server.cpp`, and `server.cpp:7951` is
`web_server_->Post("/api/command", ...)`.

The invariant is widened to cover inline `web_server_->` calls, not just the `httplib::Server&`
overload, and the debt is sized at ~160 registrations.

## Related

- **#2557** tracks `/api/command`'s untestability specifically, including the security properties
  that now depend on that handler. It also records that several `#1786` citations elsewhere named
  the wrong issue — #1786 was always the TAR retention-paused dashboard fragments, closed by #2534,
  never the generic dispatch route.
- **#2542** carried the same false claim and is corrected in place, with its scope restated.
- **#2534**'s description is corrected and carries a comment of record; its commit message
  `4c6fbd8e` retains the original wording and cannot be amended post-merge.

No code change, no behaviour change, no changelog fragment (`changelog.d/README.md` rule 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
