### PR TITLE
test: make TAR execution deterministic

### DIFF
--- a/scripts/ci/flake-retry.py
+++ b/scripts/ci/flake-retry.py
@@ -676,7 +676,6 @@ def _selftest():
           "non-pg shard maps to itself")
     check(match_suite("server - yuzu:server pg unit tests", shards)["cmd"] == ["s", "[pg]"],
           "pg shard maps to itself")
-
     # tag-spec surgery for isolated retries (#2092): strip positional tag
     # filters, keep argv[0] and option args, never invent args.
     check(_cmd_without_test_specs(["x", "~[pg]"]) == ["x"], "strips ~[pg]")
@@ -692,6 +691,9 @@ def _selftest():
           "strips mid-spec-negation shard filter (#2394)")
     check(_cmd_without_test_specs(["x", "[pg][routes],[pg][store],[pg][token]"]) == ["x"],
           "strips comma-OR shard filter (#2394)")
+    check(_cmd_without_test_specs(["x", "--order", "lex", "--rng-seed", "1"])
+          == ["x", "--order", "lex", "--rng-seed", "1"],
+          "TAR retry keeps deterministic options")
     check(_cmd_without_test_specs(["x", "a normal, prose case name"])
           == ["x", "a normal, prose case name"],
           "prose case name with a comma is NOT a spec (kept)")

--- a/scripts/ci/test_flake_retry.py
+++ b/scripts/ci/test_flake_retry.py
@@ -52,6 +52,7 @@ if a and a[0] == "introspect":
         cmd = [os.environ["FAKE_CATCH2_BIN"]]
         if os.environ.get("FAKE_SHARD_SPEC"):   # sharded entry (#2092): tag filter in cmd
             cmd.append(os.environ["FAKE_SHARD_SPEC"])
+        cmd += json.loads(os.environ.get("FAKE_CATCH2_OPTIONS", "[]"))
     print(json.dumps([{"name": "fake unit tests", "cmd": cmd, "env": {}, "workdir": None,
                        "suite": ["yuzu:fake"]}]))
     sys.exit(0)
@@ -77,7 +78,10 @@ import os, re, sys
 a = sys.argv[1:]
 fail = [c for c in os.environ.get("FAKE_FAIL_CASES", "").split(";") if c]
 always = [c for c in os.environ.get("FAKE_ALWAYS_FAIL", "").split(";") if c]
+expected_options = __import__("json").loads(os.environ.get("FAKE_CATCH2_OPTIONS", "[]"))
 TAG_SPEC = re.compile(r"^~?(\[[^\[\]]+\])+$")
+if any(option not in a for option in expected_options):
+    sys.exit(1)
 if "--reporter" in a:                       # enumeration run -> emit Catch2 junit
     # A sharded entry's tag filter must SURVIVE into the enumeration run
     # (#2092: only the isolated retry strips it) — a missing spec means the
@@ -95,7 +99,7 @@ if "--reporter" in a:                       # enumeration run -> emit Catch2 jun
 # re-run the whole shard) -> hard fail so the recovery scenario can't pass.
 if any(TAG_SPEC.match(x) for x in a):
     sys.exit(1)
-case = a[0] if a else ""
+case = next((candidate for candidate in fail + always if candidate in a), "")
 sys.exit(1 if case in always else 0)
 """
 
@@ -411,6 +415,17 @@ def main():
                      {"FAKE_FAIL_CASES": "FlakeA", "FAKE_NONCATCH2": "1"}, listed, False),
         run_scenario("sharded suite (#2092): retry replaces tag filter",
                      {"FAKE_FAIL_CASES": "FlakeA", "FAKE_SHARD_SPEC": "~[pg]"}, listed, True),
+        run_scenario(
+            "aggregate TAR retry keeps deterministic Catch2 options",
+            {
+                "FAKE_FAIL_CASES": "FlakeA",
+                "FAKE_CATCH2_OPTIONS": json.dumps(
+                    ["--order", "lex", "--rng-seed", "1"]
+                ),
+            },
+            listed,
+            True,
+        ),
         # Suite red under meson, but the solo enumeration re-run reproduces
         # ZERO failing cases (order/contention-dependent failure, or a stale
         # junit from a crashed run). Nothing is attributable to a listed

--- a/scripts/ci/tsan-gdb-capture.py
+++ b/scripts/ci/tsan-gdb-capture.py
@@ -180,6 +180,51 @@ def targets_for_cancelled(fr, tests, sections):
 
 
 # ── gdb ───────────────────────────────────────────────────────────────────────
+def replay_command(cmd, seed):
+    """Return one valid Catch2 replay command with faithful order policy.
+
+    Meson entries may already pin ``--order`` and ``--rng-seed``. Catch2 rejects
+    duplicate occurrences, so preserve the first explicit value and only supply
+    a recovered seed or randomized order when the entry omitted that option.
+    Other options and shard tag filters remain in their introspected order.
+    """
+    replay = []
+    saw_order = False
+    saw_seed = False
+    index = 0
+    while index < len(cmd):
+        arg = cmd[index]
+        if arg in ("--order", "--rng-seed"):
+            if index + 1 < len(cmd):
+                if arg == "--order" and not saw_order:
+                    replay += [arg, cmd[index + 1]]
+                    saw_order = True
+                elif arg == "--rng-seed" and not saw_seed:
+                    replay += [arg, cmd[index + 1]]
+                    saw_seed = True
+            index += 2
+            continue
+        if arg.startswith("--order="):
+            if not saw_order:
+                replay.append(arg)
+                saw_order = True
+            index += 1
+            continue
+        if arg.startswith("--rng-seed="):
+            if not saw_seed:
+                replay.append(arg)
+                saw_seed = True
+            index += 1
+            continue
+        replay.append(arg)
+        index += 1
+    if not saw_seed and seed is not None:
+        replay += ["--rng-seed", str(seed)]
+    if not saw_order:
+        replay += ["--order", "rand"]
+    return replay
+
+
 def gdb_argv(cmd, seed, budget, kill_after):
     """timeout(1) + gdb batch argv for one replay.
 
@@ -208,10 +253,7 @@ def gdb_argv(cmd, seed, budget, kill_after):
     escaping also means the shell never globs `[pg]` against the cwd. `_selftest`
     asserts this end-to-end against a real gdb wherever one exists, rather than
     trusting the Python list — asserting the list is what let this through."""
-    replay = list(cmd)
-    if seed is not None:
-        replay += ["--rng-seed", str(seed)]
-    replay += ["--order", "rand"]
+    replay = replay_command(cmd, seed)
     return [
         "timeout", "--signal=INT", f"--kill-after={kill_after}", str(budget),
         "gdb", "-batch",
@@ -587,6 +629,22 @@ ThreadSanitizer: data race
     check(argv[argv.index("--args") + 1:] ==
           ["/b/tests/yuzu_server_tests", "~[pg]", "--rng-seed", "222", "--order", "rand"],
           "replay argv keeps the shard's tag filter and appends the seed")
+    check(replay_command(
+              ["/b/tests/yuzu_tar_tests", "--order", "lex", "--rng-seed", "1"], 222) ==
+          ["/b/tests/yuzu_tar_tests", "--order", "lex", "--rng-seed", "1"],
+          "replay preserves Meson-pinned Catch2 options instead of duplicating them")
+    check(replay_command(
+              ["/b/tests/yuzu_server_tests", "~[pg]", "--order=lex", "--rng-seed=1"],
+              None) ==
+          ["/b/tests/yuzu_server_tests", "~[pg]", "--order=lex", "--rng-seed=1"],
+          "replay preserves equals-form options and the shard filter")
+    deduped = replay_command(
+        ["/b/tests/yuzu_tar_tests", "--order", "lex", "--order", "rand",
+         "--rng-seed", "1", "--rng-seed", "2"],
+        222,
+    )
+    check(deduped.count("--order") == 1 and deduped.count("--rng-seed") == 1,
+          "replay emits at most one occurrence of each Catch2 ordering option")
     # REGRESSION GUARD. `set startup-with-shell off` alongside --args is precisely
     # the bug: gdb escapes the args at --args parse time expecting its startup
     # shell to unescape them, so killing the shell delivers `\~\[pg\]` to the

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -373,7 +373,15 @@ tar_test_exe = executable(
   cpp_args: tar_test_cpp_args,
   dependencies: tar_test_deps,
 )
-test('tar unit tests', tar_test_exe, suite: 'tar', timeout: 90)
+# Keep TAR as one 90-second deadline domain: splitting it would add process
+# startup and an `is_parallel: false` global barrier without Windows evidence
+# that either shard stays below budget. Fixed Catch2 order + seed remove random
+# case order as an input; deleting the opportunistic retention race removes its
+# measured host-speed-dependent workload entirely.
+tar_deterministic_args = ['--order', 'lex', '--rng-seed', '1']
+test('tar unit tests', tar_test_exe,
+     args: tar_deterministic_args,
+     suite: 'tar', timeout: 90)
 
 # ── Server unit tests ─────────────────────────────────────────────────────────
 if build_server

--- a/tests/unit/test_tar_aggregator.cpp
+++ b/tests/unit/test_tar_aggregator.cpp
@@ -18,11 +18,8 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
-#include <chrono>
-#include <format>
 #include <atomic>
-#include <chrono>
-#include <condition_variable>
+#include <format>
 #include <mutex>
 #include <optional>
 #include <set>
@@ -1643,107 +1640,20 @@ TEST_CASE("TAR #2361: a NON-aborting statement error fails one table, not the wh
     CHECK(failures_of(f.guard, "tcp_hourly") == 0);
 }
 
-TEST_CASE("TAR #2361: a rolled-back retention pass does not discard another writer's work",
-          "[tar][retention][clock-guard]") {
-    // Kimi / Gate 8, and the defect that survived four rounds: driving
-    // BEGIN/COMMIT through execute_sql releases the database mutex between
-    // statements, so a concurrent collector INSERT or set_config joined
-    // retention's transaction -- and once retention rolled back on failure, that
-    // rollback discarded the other writer's work after its caller had been told
-    // it succeeded.
-    //
-    // HOW MUCH THIS TEST IS WORTH (measured, Sol round-5 review). Against a
-    // deliberately reverted implementation this catches the defect roughly 1 run
-    // in 5. Two attempts to improve that made it WORSE, not better: widening the
-    // window to a 5,000-row delete dropped detection to 0 in 6, and asserting the
-    // stronger property directly ("no writer completes while the batch is open")
-    // also passed 6 of 6 against the broken shape. The interleaving simply is not
-    // reliably reachable from outside the store.
-    //
-    // So this is an opportunistic guard, NOT a regression barrier, and it is
-    // labelled as one rather than left to look like proof. The deterministic
-    // assurance for this fix is the sibling test below (a batch rolls back as a
-    // unit and does not reach outside itself) plus the lock structure itself:
-    // execute_atomic_batch holds mu_ across the whole transaction, which is
-    // verifiable by reading it and is what two reviewers checked. The assertion
-    // here is at least sound -- a DISTINCT key per write, and every acknowledged
-    // key must survive, so a discarded write cannot be masked by a later one.
-    TarGuardFixture f;
-    seed_process_hourly_at(*f.db, kT0 - 10 * kHourlyCutoffSec, 5);
-    seed_process_hourly_at(*f.db, kT0 - 3600, 1); // survivor -> accepted, queued
-    REQUIRE(f.db->execute_sql("CREATE TRIGGER block_del BEFORE DELETE ON process_hourly "
-                              "BEGIN SELECT RAISE(ROLLBACK, 'aborted'); END;"));
-
-    std::atomic<bool> stop{false};
-    std::mutex ack_mu;
-    std::condition_variable ack_cv;
-    std::vector<int> acknowledged;
-    std::thread writer([&] {
-        int n = 0;
-        while (!stop.load(std::memory_order_relaxed)) {
-            const int mine = ++n;
-            if (f.db->set_config(std::format("collector_probe_{}", mine), std::to_string(mine))) {
-                std::lock_guard lk(ack_mu);
-                acknowledged.push_back(mine);
-                ack_cv.notify_one();
-            }
-        }
-    });
-    // Join on EVERY path: run_retention is not noexcept, and destroying a
-    // joinable thread calls std::terminate while it still holds a db reference.
-    struct Joiner {
-        std::atomic<bool>& stop;
-        std::thread& t;
-        ~Joiner() {
-            stop.store(true, std::memory_order_relaxed);
-            if (t.joinable())
-                t.join();
-        }
-    } joiner{stop, writer};
-
-    // Wait for the writer to land at least one COMMITTED write BEFORE racing it.
-    // The contract under test is "no acknowledged write is discarded", which needs
-    // an acknowledged write to exist; without this the test relied on the writer
-    // thread being scheduled during run_retention, which on a loaded box it often
-    // is not (measured: 5/10 failures under CPU contention, 0/40 idle). Both CI
-    // pools run four runner agents on ONE box, so contention is the normal
-    // condition there, not the exceptional one. The writer keeps running through
-    // run_retention below, so the race this test exists for is unchanged -- only
-    // the precondition is now waited for instead of assumed.
-    //
-    // Declared after `joiner` so a timeout here still stops and joins the writer
-    // rather than terminating on a joinable thread.
-    {
-        std::unique_lock lk(ack_mu);
-        REQUIRE(ack_cv.wait_for(lk, std::chrono::seconds(30),
-                                [&] { return !acknowledged.empty(); }));
-    }
-
-    run_retention(*f.db, kT0, f.guard);
-    stop.store(true, std::memory_order_relaxed);
-    if (writer.joinable())
-        writer.join();
-
-    std::vector<int> acked;
-    {
-        std::lock_guard lk(ack_mu);
-        acked = acknowledged;
-    }
-    REQUIRE(acked.size() > 0); // the racing writer really did commit something
-    for (int n : acked) {
-        INFO("acknowledged write " << n << " of " << acked.size());
-        CHECK(f.db->get_config(std::format("collector_probe_{}", n), "") == std::to_string(n));
-    }
-    CHECK(row_count(*f.db, "process_hourly") == 6); // retention still failed closed
-    CHECK(failures_of(f.guard, "process_hourly") >= 1);
-}
-
 TEST_CASE("TAR #2361: a batch rolls back as a unit, and does not reach outside itself",
           "[tar][retention][clock-guard]") {
-    // The deterministic half of the isolation contract, testing
-    // execute_atomic_batch directly rather than racing it. A write made BEFORE
-    // the batch must survive its rollback, and a successful statement INSIDE the
-    // batch must not survive a later failing one.
+    // The deterministic barrier for the isolation contract tests
+    // execute_atomic_batch directly. A write made BEFORE the batch must survive
+    // its rollback, a successful statement INSIDE the batch must not survive a
+    // later failure, and the connection must return to autocommit afterwards.
+    //
+    // Do not replace this with an externally scheduled writer race. The public
+    // TarDatabase interface cannot pause after BEGIN while mu_ is held, so such a
+    // probe cannot prove that a writer reached the transaction boundary. The old
+    // opportunistic version caught a deliberately reverted implementation only
+    // about 1 run in 5 and emitted up to 81,922 writes depending on host speed.
+    // Deterministic concurrent-boundary coverage would require an explicit
+    // product test seam; that is outside this CI/test-only change.
     TarGuardFixture f;
     seed_process_hourly_at(*f.db, kT0 - 10 * kHourlyCutoffSec, 4);
     for (int h = 0; h < 4; ++h) {
@@ -1761,6 +1671,7 @@ TEST_CASE("TAR #2361: a batch rolls back as a unit, and does not reach outside i
     const auto r = f.db->execute_atomic_batch(
         {"DELETE FROM tcp_hourly", "DELETE FROM process_hourly", "DELETE FROM tcp_hourly"});
 
+    CHECK(r.began);
     CHECK_FALSE(r.committed);
     REQUIRE(r.failed.size() == 3);
     for (char c : r.failed)
@@ -1768,6 +1679,11 @@ TEST_CASE("TAR #2361: a batch rolls back as a unit, and does not reach outside i
     CHECK(row_count(*f.db, "tcp_hourly") == 4);     // the successful delete was undone
     CHECK(row_count(*f.db, "process_hourly") == 4);
     CHECK(f.db->get_config("pre_batch_write", "") == "kept"); // rollback stayed inside the batch
+    REQUIRE(f.db->set_config("post_batch_write", "kept"));
+    f.db.reset();
+    auto reopened = TarDatabase::open(f.tmp.path);
+    REQUIRE(reopened.has_value());
+    CHECK(reopened->get_config("post_batch_write", "") == "kept"); // committed before close
 }
 
 TEST_CASE("TAR #2361: the latch is HELD through a capped drain, then released",


### PR DESCRIPTION
## What

- pin the TAR Catch2 entry to lexical order and seed 1 without changing its 90-second deadline
- preserve those options through flake retry and TSan/GDB replay adapters
- delete the scheduler-dependent retention race that detected its reverted defect only about 1 run in 5 and generated up to 81,922 writes
- strengthen the deterministic rollback check by closing and reopening the database before verifying the post-batch commit

This is a discrete CI-revamp unit stacked on #2608. It changes CI/test modules only.

## Why

The removed test changed its workload with host speed and could not prove that its writer reached the transaction boundary. A deterministic concurrent-boundary test needs a product seam, which is deliberately outside this CI/test-only unit. The remaining test now proves rollback scope and durable return to autocommit without scheduler timing.

## Validation

- macOS: full compile; TAR suite passed; 7/7 CI/docs contract tests passed
- Shulgi Windows: MSVC 19.44 target compile; 5 concurrent Meson repetitions passed at about 44 seconds each; 7/7 CI/docs contract tests passed
- Shulgi Linux: GCC 13 target compile; five sequential repetitions passed (first two captured at 50.1s and 50.7s); 7/7 CI/docs contract tests passed
- adapter checks: tsan-gdb selftest, flake-retry selftest, and all 13 integration scenarios passed
- independent final review: publish, no actionable findings

## Contention evidence

A deliberately parallel five-copy Shulgi Linux run drove every copy to the unchanged 90-second cap. This is retained as contention evidence, not described as a flake or a code verdict. No runner listener or runner configuration was touched.

## Stack

Base: #2608 (`ci5-u09-annotation-adapter`). Retarget to `dev` after the base lands.