### PR TITLE
test: pin Guardian refill re-arm ordering

### DIFF
--- a/tests/unit/test_guardian_outbox_drain_worker.cpp
+++ b/tests/unit/test_guardian_outbox_drain_worker.cpp
@@ -1171,18 +1171,25 @@ struct StreamLikeSink {
     std::mutex mu;
     bool stream_up{false};       ///< nullptr guardian_sink_stream_ equivalent
     bool write_fails{false};     ///< Write() returning false equivalent
+    std::size_t retained{0};
     std::vector<std::string> sent_ids;
 
     SendResult operator()(const OutboxEntry& e) {
         std::lock_guard<std::mutex> lk{mu};
-        if (!stream_up || write_fails)
+        if (!stream_up || write_fails) {
+            ++retained;
             return SendResult::Retain; // keep the head and stop this pass
+        }
         sent_ids.push_back(e.event_id);
         return SendResult::Sent;
     }
     std::size_t count() {
         std::lock_guard<std::mutex> lk{mu};
         return sent_ids.size();
+    }
+    std::size_t retain_count() {
+        std::lock_guard<std::mutex> lk{mu};
+        return retained;
     }
     void set_stream(bool up) {
         std::lock_guard<std::mutex> lk{mu};
@@ -1608,7 +1615,14 @@ TEST_CASE("R4: a refill re-arm does not wait out the periodic bound",
     // Deterministic precondition: some room, but not enough for the batch.
     REQUIRE(rig.rt->lifecycle_headroom() == kMaxJournalEntriesPerBatch - 4);
     worker.start();
-    CHECK(spin_until([&] { return rig.journal->pages() >= 1; }));
+    REQUIRE(spin_until([&] { return rig.journal->pages() >= 1; }));
+    // Pin the link-down half of the scenario before reconnecting. Merely observing
+    // the page counter is too early: the worker increments it before the following
+    // drain. If this thread raises the link during that gap, the boot drain can send
+    // the four live entries and its refill re-arm coalesces with notify() into one
+    // forced page. That is correct runtime behaviour, but the old assertion then
+    // waited for a third page that the scenario no longer required.
+    REQUIRE(spin_until([&] { return sink.retain_count() >= 1; }));
     const auto pages_before = rig.journal->pages();
 
     // Link returns. The NEXT cycle pages (blocked: the REQUIRE above pins headroom at


### PR DESCRIPTION
## Summary

- Pin the Guardian refill/re-arm test to the link-down state it claims to exercise.
- Observe an actual `SendResult::Retain` before reconnecting instead of treating a page counter increment as proof that the drain already ran.
- Make the initial page observation a required precondition because every later assertion depends on it.

## Why

PR #2612 exposed a real test defect in `R4: a refill re-arm does not wait out the periodic bound`. The journal increments its page counter before the worker performs the following drain. The old test could reconnect in that gap. Under that schedule, the boot drain legitimately sent the four live entries, and the refill request coalesced with `notify()` in the worker's Boolean force flag. Runtime behavior was correct, but the test then waited ten seconds for an unnecessary third page.

The repair records when the production-shaped fake sink actually returns `Retain`, under the fixture's existing mutex, and waits for that event before reconnecting. The final assertion still proves that refill re-arm wakes the worker without waiting for its one-hour periodic bound. No timeout was extended and no retry was added.

## Validation

- macOS/Apple Clang: target compiled; full agent suite passed (2/2, agent entry 38.12s).
- macOS stress: exact test passed 500/500 sequential runs with varied Catch2 seeds.
- Shulgi Windows/MSVC 19.44: target compiled; relevant R4 group passed 100/100 sequential runs; full agent suite passed in 58.19s.
- Shulgi WSL/Linux GCC 13.3: target compiled; relevant R4 group passed 100/100 sequential runs; full agent suite passed in 65.88s.
- Independent read-only review: PUBLISH, no required changes.
- C++ correctness and safety review: PASS; ownership changes: none.

## Scope and risk

One test file only. The added counter is protected by the same mutex as the fake sink state. Product runtime code, CI retry policy, runner configuration, and timeouts are unchanged.
