### PR TITLE
perf(tar): create the schema in one transaction; retire tar_events for real

### DIFF
--- a/agents/plugins/tar/src/tar_db.cpp
+++ b/agents/plugins/tar/src/tar_db.cpp
@@ -2,9 +2,12 @@
  * tar_db.cpp -- SQLite-backed Timeline Activity Record database
  *
  * Tables:
- *   tar_events(id, timestamp, event_type, event_action, detail_json, snapshot_id)
  *   tar_state(collector PRIMARY KEY, state_json, updated_at)
  *   tar_config(key PRIMARY KEY, value)
+ *   plus every typed warehouse tier the schema registry declares.
+ *
+ * The legacy tar_events log was retired by schema v3 and is no longer created;
+ * see kCreateSchema below.
  *
  * All queries use parameterized SQL to prevent injection.
  * A std::mutex guards all sqlite3* access for thread safety (Darwin pitfall).
@@ -114,23 +117,19 @@ int tar_query_authorizer(void* /*ctx*/, int action, const char* arg1, const char
 }
 
 /// Schema DDL for all TAR tables.
+///
+/// `tar_events` is deliberately ABSENT. Schema v3 retired it, and the migration
+/// in open() still drops it from any pre-v3 database that carries one. Creating
+/// it here only to drop it a few statements later cost every fresh open one
+/// table plus three indexes, and — worse — left it PRESENT on any database
+/// whose schema_version had already reached 3+, because the v3 branch is then
+/// skipped. `is_queryable_table()` excludes tar_events specifically so that its
+/// "no such table" error cannot become an existence oracle (#760 UP-8); that
+/// reasoning holds only while the table really is absent. Dropping it here
+/// covers new databases; the v5 migration in open() covers the installed base,
+/// which had already resurrected it. Do NOT reintroduce it here — a new capture
+/// source goes through the schema registry.
 constexpr const char* kCreateSchema = R"(
-    CREATE TABLE IF NOT EXISTS tar_events (
-        id           INTEGER PRIMARY KEY AUTOINCREMENT,
-        timestamp    INTEGER NOT NULL,
-        event_type   TEXT    NOT NULL,
-        event_action TEXT    NOT NULL,
-        detail_json  TEXT    NOT NULL DEFAULT '{}',
-        snapshot_id  INTEGER NOT NULL DEFAULT 0
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_tar_events_ts
-        ON tar_events(timestamp);
-    CREATE INDEX IF NOT EXISTS idx_tar_events_type_ts
-        ON tar_events(event_type, timestamp);
-    CREATE INDEX IF NOT EXISTS idx_tar_events_snapshot
-        ON tar_events(snapshot_id);
-
     CREATE TABLE IF NOT EXISTS tar_state (
         collector   TEXT PRIMARY KEY,
         state_json  TEXT NOT NULL DEFAULT '{}',
@@ -212,6 +211,98 @@ quarantine_corrupt_db(const std::filesystem::path& path) {
         }
     }
     return dest;
+}
+
+/// Execute a multi-statement DDL batch inside ONE transaction.
+///
+/// SQLite gives every bare statement its own implicit transaction, and WAL
+/// defaults to `synchronous=FULL` — so handing `sqlite3_exec` a ~75-statement
+/// schema batch costs ~75 separate commits, each with its own fsync. Measured
+/// on the Windows CI runner (91 iterations, best of 3, #2093): 72.4 ms per
+/// `TarDatabase::open()` unwrapped against 11.0 ms for the identical DDL in a
+/// single transaction. Every agent pays this at boot, on every endpoint.
+///
+/// It is also the atomicity fix. Unwrapped, a batch that fails partway through
+/// leaves a half-built schema on disk and `open()` returns an error, so the
+/// next open inherits the debris; wrapped, the database is left exactly as it
+/// was found.
+///
+/// Returns SQLITE_OK, or the first failing rc with `*err_msg` set — ownership
+/// of which passes to the caller, as with `sqlite3_exec` itself.
+/// True if the legacy `tar_events` table (or one of its indexes) is still on
+/// disk. One indexed sqlite_master read; no write.
+bool tar_events_present(sqlite3* db) {
+    const char* sql = "SELECT 1 FROM sqlite_master WHERE name = 'tar_events' OR name LIKE "
+                      "'idx_tar_events%' LIMIT 1";
+    sqlite3_stmt* raw = nullptr;
+    if (sqlite3_prepare_v2(db, sql, -1, &raw, nullptr) != SQLITE_OK) {
+        return false; // can't tell — treat as absent; the next open retries
+    }
+    StmtPtr stmt(raw);
+    return sqlite3_step(stmt.get()) == SQLITE_ROW;
+}
+
+int exec_ddl_batch(sqlite3* db, const char* ddl, char** err_msg) {
+    // A caller may already hold a transaction — create_warehouse_tables() is
+    // public. Detect that EXPLICITLY rather than inferring it from a failed
+    // BEGIN: SQLITE_BUSY, a read-only handle and OOM all fail BEGIN too, and
+    // treating those as "nested, carry on unwrapped" would silently restore
+    // both the per-statement fsync cost and the non-atomicity with no trace.
+    if (sqlite3_get_autocommit(db) == 0) {
+        return sqlite3_exec(db, ddl, nullptr, nullptr, err_msg);
+    }
+
+    // IMMEDIATE, not DEFERRED. A deferred BEGIN takes its write lock at the
+    // first writing statement, and in WAL a concurrent committer between the
+    // read snapshot and that upgrade yields SQLITE_BUSY_SNAPSHOT — for which
+    // SQLite does NOT invoke the busy handler, so the 5000 ms busy_timeout set
+    // in open() would not help. IMMEDIATE takes the lock up front, where the
+    // busy handler does apply. This matches purge_source() and
+    // execute_atomic_batch() elsewhere in this file.
+    char* begin_err = nullptr;
+    int rc = sqlite3_exec(db, "BEGIN IMMEDIATE", nullptr, nullptr, &begin_err);
+    if (rc == SQLITE_BUSY || rc == SQLITE_BUSY_SNAPSHOT) {
+        // Another connection holds the write lock and outlasted the busy
+        // timeout. Do NOT fall back to unwrapped: each of the ~75 statements
+        // would then wait out its own busy timeout under mu_, stalling every
+        // collector for minutes. Fail and let the caller retry on the next open.
+        if (err_msg) {
+            *err_msg = begin_err;
+        } else {
+            sqlite3_free(begin_err);
+        }
+        return rc;
+    }
+    if (rc != SQLITE_OK) {
+        spdlog::warn("TarDatabase: could not open a transaction for the schema batch ({}) — "
+                     "running it unwrapped; this is slower and not atomic",
+                     begin_err ? begin_err : "unknown");
+        sqlite3_free(begin_err);
+        return sqlite3_exec(db, ddl, nullptr, nullptr, err_msg);
+    }
+    sqlite3_free(begin_err);
+
+    rc = sqlite3_exec(db, ddl, nullptr, nullptr, err_msg);
+    if (rc != SQLITE_OK) {
+        sqlite3_exec(db, "ROLLBACK", nullptr, nullptr, nullptr);
+        return rc;
+    }
+
+    rc = sqlite3_exec(db, "COMMIT", nullptr, nullptr, err_msg);
+    if (rc != SQLITE_OK) {
+        // A failed COMMIT leaves the transaction open. Drop it, or every later
+        // write on this connection silently joins a transaction that is never
+        // committed and is discarded at close.
+        sqlite3_exec(db, "ROLLBACK", nullptr, nullptr, nullptr);
+        if (sqlite3_get_autocommit(db) == 0) {
+            // ROLLBACK failed too — the connection is wedged. Say so loudly:
+            // every subsequent write on it will be lost at close.
+            spdlog::error("TarDatabase: schema transaction could neither commit nor roll back — "
+                          "this connection is wedged and its writes will be discarded. Restart "
+                          "the agent.");
+        }
+    }
+    return rc;
 }
 
 } // namespace
@@ -345,9 +436,10 @@ std::expected<TarDatabase, std::string> TarDatabase::open(const std::filesystem:
     }
     sqlite3_free(err_msg);
 
-    // Create schema
+    // Create schema — one transaction, not one per statement (see
+    // exec_ddl_batch: ~75 fsync'd commits otherwise, #2093).
     err_msg = nullptr;
-    rc = sqlite3_exec(raw_db, kCreateSchema, nullptr, nullptr, &err_msg);
+    rc = exec_ddl_batch(raw_db, kCreateSchema, &err_msg);
     if (rc != SQLITE_OK) {
         std::string err = err_msg ? err_msg : "unknown error";
         sqlite3_free(err_msg);
@@ -385,6 +477,18 @@ std::expected<TarDatabase, std::string> TarDatabase::open(const std::filesystem:
             spdlog::info("TarDatabase: migrated to schema version 2 (typed warehouse tables)");
         }
     } else {
+        // A failed batch that could neither commit nor roll back leaves this
+        // connection inside a transaction. Publishing that handle would mean
+        // every collector write silently joins a transaction that is never
+        // committed and is discarded at close — data loss reported as success.
+        // Fail closed instead; the next open starts from a clean connection.
+        if (sqlite3_get_autocommit(raw_db) == 0) {
+            // `db` owns raw_db by now — returning destroys it, which closes both
+            // connections. Do NOT sqlite3_close(raw_db) here as well.
+            return std::unexpected(
+                std::string{"tar.db schema transaction could neither commit nor roll back; "
+                            "refusing to open on a wedged connection"});
+        }
         spdlog::warn("TarDatabase: warehouse table creation failed{}",
                      db.schema_version() < 2 ? ", continuing in legacy mode" : "");
     }
@@ -473,6 +577,64 @@ std::expected<TarDatabase, std::string> TarDatabase::open(const std::filesystem:
             sqlite3_exec(raw_db, "ROLLBACK TO v4_migration", nullptr, nullptr, nullptr);
             sqlite3_exec(raw_db, "RELEASE v4_migration", nullptr, nullptr, nullptr);
         }
+    }
+
+    // Version 5: retire tar_events for real, on the INSTALLED BASE.
+    //
+    // v3 already dropped it — but `kCreateSchema` used to recreate it on every
+    // open, and the v3 branch is gated on `schema_version() == 2`, so every
+    // database that had already reached v3 resurrected the table on each open
+    // with nothing left to remove it. Dropping the DDL (above) stops the
+    // resurrection for good, yet every agent already in the field sits at v3/v4
+    // WITH the table present. Without this bump a fresh install and an upgraded
+    // endpoint would carry permanently divergent schemas, and the #760 UP-8
+    // argument — that `is_queryable_table()` may exclude tar_events because it
+    // is genuinely absent — would hold for fresh installs only.
+    //
+    // Gated on PRESENCE, not on a version number. A version gate (`== 4`) is
+    // armed exactly once and then never again: roll an endpoint back to a
+    // pre-fix binary and its kCreateSchema recreates the table while the stored
+    // version stays 5, so rolling forward would find the gate false and strand
+    // the table forever — reinstating the very divergence this fixes. Agent
+    // rollback is supported, so the gate has to be the fact on disk. It is also
+    // the only gate that reaches a database stranded at v3 by a failed v4 ALTER.
+    // Cost is one sqlite_master read per open; the DROP still happens at most
+    // once per resurrection, so no endpoint takes a write on every boot (and
+    // with secure_delete=ON a populated table is never re-zeroed at each start).
+    if (tar_events_present(raw_db)) {
+        std::lock_guard lock(db.mu_);
+        char* emsg = nullptr;
+        sqlite3_exec(raw_db, "SAVEPOINT v5_migration", nullptr, nullptr, nullptr);
+        int mrc = sqlite3_exec(raw_db, "DROP TABLE IF EXISTS tar_events", nullptr, nullptr, &emsg);
+        if (mrc == SQLITE_OK) {
+            sqlite3_free(emsg);
+            // The indexes go with the table; these cover a database that somehow
+            // kept an index without it.
+            for (const char* idx :
+                 {"idx_tar_events_ts", "idx_tar_events_type_ts", "idx_tar_events_snapshot"}) {
+                const auto drop = std::format("DROP INDEX IF EXISTS {}", idx);
+                sqlite3_exec(raw_db, drop.c_str(), nullptr, nullptr, nullptr);
+            }
+            sqlite3_exec(raw_db, "RELEASE v5_migration", nullptr, nullptr, nullptr);
+            spdlog::info("TarDatabase: retired the legacy tar_events table");
+        } else {
+            // WARN, not ERROR: nothing reads or writes tar_events, so the cost of
+            // failing here is a residual empty table. The next open retries.
+            spdlog::warn("TarDatabase: could not drop the legacy tar_events table: {} — it will be "
+                         "retried on the next open; to clear it by hand, stop the agent and run "
+                         "`DROP TABLE tar_events;` against the tar.db",
+                         emsg ? emsg : "unknown");
+            sqlite3_free(emsg);
+            sqlite3_exec(raw_db, "ROLLBACK TO v5_migration", nullptr, nullptr, nullptr);
+            sqlite3_exec(raw_db, "RELEASE v5_migration", nullptr, nullptr, nullptr);
+        }
+    }
+    // The version marker is independent of the drop above: it records that this
+    // binary's schema contract has been applied, for in-band auditability.
+    if (db.schema_version() == 4) {
+        std::lock_guard lock(db.mu_);
+        db.set_config_locked("schema_version", "5");
+        spdlog::info("TarDatabase: migrated to schema version 5 (legacy tar_events retired)");
     }
 
     // Open a dedicated read-only, authorizer-sandboxed connection for untrusted
@@ -746,7 +908,9 @@ bool TarDatabase::create_warehouse_tables() {
 
     auto ddl = generate_warehouse_ddl();
     char* err_msg = nullptr;
-    int rc = sqlite3_exec(db_, ddl.c_str(), nullptr, nullptr, &err_msg);
+    // One transaction for the whole registry DDL — the dominant cost of an
+    // open, and the larger of the two batches (#2093). See exec_ddl_batch.
+    int rc = exec_ddl_batch(db_, ddl.c_str(), &err_msg);
     if (rc != SQLITE_OK) {
         spdlog::error("TarDatabase::create_warehouse_tables failed: {}",
                       err_msg ? err_msg : "unknown");

--- a/agents/plugins/tar/src/tar_db.hpp
+++ b/agents/plugins/tar/src/tar_db.hpp
@@ -7,9 +7,12 @@
  * service state changes, user sessions) with snapshot IDs for correlation.
  *
  * Schema:
- *   tar_events — core event log (timestamp, type, action, detail_json, snapshot_id)
  *   tar_state  — last-known state per collector for diff computation
  *   tar_config — key/value config (retention_days, redaction patterns, etc.)
+ *   plus the typed warehouse tiers generated from the schema registry.
+ *
+ * The legacy tar_events event log was retired by schema v3; it is neither
+ * created nor queryable (#760 UP-8).
  *
  * Thread-safe: a std::mutex guards all sqlite3* operations. The ONE exception is
  * the `db_`/`query_db_` liveness probes (is_open / query_engine_available),

--- a/agents/plugins/tar/src/tar_schema_registry.hpp
+++ b/agents/plugins/tar/src/tar_schema_registry.hpp
@@ -165,7 +165,8 @@ std::optional<std::string> translate_dollar_name(std::string_view dollar_name);
 /**
  * Return true if `real_table_name` is a table that untrusted operator SQL
  * (the tar.sql action) is permitted to read: the typed warehouse tables from
- * the registry plus the base tar_state / tar_config / tar_events tables. Used
+ * the registry plus the base tar_state / tar_config tables (tar_events is NOT
+ * included — schema v3 retired it and v5 drops it from the installed base). Used
  * by the read-only SQL sandbox's SQLite authorizer (#760). The set is computed
  * once from the registry, so it stays in sync as new capture sources land.
  */

--- a/changelog.d/2093-tar-db-ddl-one-transaction.changed.md
+++ b/changelog.d/2093-tar-db-ddl-one-transaction.changed.md
@@ -1,0 +1,9 @@
+- **`TarDatabase::open()` creates its schema in one transaction instead of ~75.** SQLite gives every
+  bare statement its own implicit transaction, and WAL defaults to `synchronous=FULL`, so handing
+  `sqlite3_exec` the schema batch cost roughly 75 separate commits each with its own fsync. Measured
+  on the Windows CI runner (91 iterations, best of 3): **72.4 ms per open against 11.0 ms** for the
+  identical DDL wrapped in a single transaction. Every agent paid this at boot on every endpoint,
+  and the `tar` unit suite paid it ~95 times — which is what pushed that suite into its 90 s meson
+  budget on 48 of 437 Windows CI runs. The wrapper is also an atomicity fix: a batch that fails
+  partway through now rolls back instead of leaving a half-built schema for the next open to
+  inherit. (#2093)

--- a/changelog.d/2093-tar-events-resurrected-on-reopen.fixed.md
+++ b/changelog.d/2093-tar-events-resurrected-on-reopen.fixed.md
@@ -1,0 +1,10 @@
+- **The retired `tar_events` table is no longer recreated on every agent restart.** Schema v3
+  dropped it, but `kCreateSchema` still created the table and its three indexes on *every* open
+  while the drop was gated on `schema_version == 2` — so once a database reached v3, each reopen
+  resurrected all four objects with nothing left to remove them. `is_queryable_table()` excludes
+  `tar_events` precisely so its "no such table" error cannot become an existence oracle (#760
+  UP-8), and that reasoning holds only while the table is genuinely absent. Nothing has written to
+  `tar_events` since v3 retired it, so a resurrected copy is always empty: this clears a stray
+  empty table, not data. The DDL is removed, and the table and its indexes are now dropped wherever
+  they are still found — gated on presence rather than on a version number, so rolling an agent
+  back to an older binary and forward again cannot strand them. Schema version bumps to 5. (#2093)

--- a/docs/tar-implementer.md
+++ b/docs/tar-implementer.md
@@ -118,8 +118,9 @@ patterns to `kDefaultRedactionPatterns` in `tar_collectors.hpp` rather
 than scrubbing per-callsite.
 
 **Schema versioning.** `tar_db.cpp` runs an idempotent migration at open
-time. Current schema version is 3 (legacy `tar_events` retired in PR
-M14; see the migration in `apply_migrations`). Bumps go in the same
+time. Current schema version is **5** (legacy `tar_events` was retired at v3 in
+PR M14, but `kCreateSchema` kept recreating it on every open — v5 stops that and
+drops it from already-migrated databases, #2093). Bumps go in the same
 function, never in `applies_*` collectors.
 
 ---

--- a/tests/unit/test_tar_store.cpp
+++ b/tests/unit/test_tar_store.cpp
@@ -46,7 +46,7 @@ struct TestTarDb {
 };
 
 static TestTarDb make_test_db() {
-    auto tmp = yuzu::test::unique_temp_path("tar_");
+    auto tmp = yuzu::test::unique_temp_path("yuzu_test_tar_");
     auto result = TarDatabase::open(tmp);
     REQUIRE(result.has_value());
     return TestTarDb{std::move(*result), tmp};
@@ -1215,7 +1215,7 @@ TEST_CASE("TarDatabase: missing warehouse tables are re-created on reopen (upgra
     // tar.db — inserts then failed every 30 s. The fix runs the idempotent
     // IF-NOT-EXISTS DDL on EVERY open. Simulate the upgrade by dropping a
     // "new" table from a closed v3 DB, then reopening.
-    auto tmp = yuzu::test::unique_temp_path("tar_upg_");
+    auto tmp = yuzu::test::unique_temp_path("yuzu_test_tar_upg_");
     {
         auto db = TarDatabase::open(tmp);
         REQUIRE(db.has_value());
@@ -1246,6 +1246,153 @@ TEST_CASE("TarDatabase: missing warehouse tables are re-created on reopen (upgra
     fs::remove(fs::path{tmp.string() + "-shm"}, ec);
 }
 
+TEST_CASE("TarDatabase: a fresh open creates no tar_events table (#760 UP-8)",
+          "[tar][store][lifecycle][tar-events]") {
+    // is_queryable_table() excludes tar_events specifically so that its "no such
+    // table" error cannot become an existence oracle distinct from the generic
+    // authorizer denial. That reasoning only holds while the table is genuinely
+    // absent, so pin it: kCreateSchema must never create it again. It used to,
+    // and the v3 migration dropped it a few statements later — which left it
+    // PRESENT on any database already at schema_version>=3, since that branch is
+    // then skipped.
+    const char* count_sql = "SELECT COUNT(*) FROM sqlite_master WHERE name = 'tar_events' OR name "
+                            "LIKE 'idx_tar_events%'";
+    auto t = make_test_db();
+    auto q = t.db.execute_query(count_sql);
+    REQUIRE(q.has_value());
+    REQUIRE(q->rows.size() == 1);
+    CHECK(q->rows[0][0] == "0");
+
+    // The case that actually bit: a REOPEN. kCreateSchema runs on every open,
+    // but the v3 DROP is gated on schema_version()==2 — so once a database has
+    // reached v3+, re-running the create resurrected the table with nothing left
+    // to remove it. Every agent restart did this.
+    { TarDatabase discard = std::move(t.db); }
+    auto reopened = TarDatabase::open(t.path);
+    REQUIRE(reopened.has_value());
+    CHECK(reopened->schema_version() == 5);
+    auto q2 = reopened->execute_query(count_sql);
+    REQUIRE(q2.has_value());
+    CHECK(q2->rows[0][0] == "0");
+    t.db = std::move(*reopened); // hand back so TestTarDb's destructor cleans up
+}
+
+TEST_CASE("TarDatabase: a pre-v3 database still has tar_events dropped on open",
+          "[tar][store][lifecycle][tar-events]") {
+    // The other half of the same invariant: field databases created before v3
+    // DO carry the table, and the migration must still retire it. Seed the exact
+    // pre-v3 shape by hand (same technique as the v4 ALTER test below).
+    auto tmp = yuzu::test::unique_temp_path("yuzu_test_tar_v2_");
+    {
+        sqlite3* raw = nullptr;
+        REQUIRE(sqlite3_open(tmp.string().c_str(), &raw) == SQLITE_OK);
+        const char* seed = R"(
+            CREATE TABLE tar_config (key TEXT PRIMARY KEY, value TEXT NOT NULL DEFAULT '');
+            INSERT INTO tar_config (key, value) VALUES ('schema_version', '2');
+            CREATE TABLE tar_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp INTEGER NOT NULL,
+                event_type TEXT NOT NULL, event_action TEXT NOT NULL,
+                detail_json TEXT NOT NULL DEFAULT '{}', snapshot_id INTEGER NOT NULL DEFAULT 0);
+            CREATE INDEX idx_tar_events_ts ON tar_events(timestamp);
+            INSERT INTO tar_events (timestamp, event_type, event_action)
+                VALUES (1000, 'process', 'started');
+        )";
+        REQUIRE(sqlite3_exec(raw, seed, nullptr, nullptr, nullptr) == SQLITE_OK);
+        sqlite3_close(raw);
+    }
+
+    {
+        auto db = TarDatabase::open(tmp);
+        REQUIRE(db.has_value());
+        CHECK(db->schema_version() == 5); // the 2→3→4→5 walk ran
+        auto q =
+            db->execute_query("SELECT COUNT(*) FROM sqlite_master WHERE name = 'tar_events' OR "
+                              "name LIKE 'idx_tar_events%'");
+        REQUIRE(q.has_value());
+        CHECK(q->rows[0][0] == "0");
+    }
+
+    std::error_code ec;
+    fs::remove(tmp, ec);
+    fs::remove(fs::path{tmp.string() + "-wal"}, ec);
+    fs::remove(fs::path{tmp.string() + "-shm"}, ec);
+}
+
+TEST_CASE("TarDatabase: schema v5 drops tar_events from an ALREADY-MIGRATED database",
+          "[tar][store][lifecycle][tar-events]") {
+    // The installed-base case, and the reason removing the DDL is not enough on
+    // its own. Every agent in the field reached v3/v4 while kCreateSchema was
+    // still recreating tar_events on each open, so those databases carry it
+    // NOW. The v3 drop is gated on schema_version()==2 and will never fire for
+    // them again — only the v5 bump reaches them. Without it a fresh install and
+    // an upgraded endpoint would hold permanently divergent schemas.
+    auto tmp = yuzu::test::unique_temp_path("yuzu_test_tar_v5_");
+    {
+        // A v4 database that already carries the resurrected table, exactly as a
+        // pre-fix binary would have left it.
+        auto seeded = TarDatabase::open(tmp);
+        REQUIRE(seeded.has_value());
+        REQUIRE(seeded
+                    ->execute_query("CREATE TABLE tar_events (id INTEGER PRIMARY KEY "
+                                    "AUTOINCREMENT, timestamp INTEGER NOT NULL)")
+                    .has_value());
+        REQUIRE(seeded->execute_query("CREATE INDEX idx_tar_events_ts ON tar_events(timestamp)")
+                    .has_value());
+        REQUIRE(seeded->set_config("schema_version", "4"));
+    }
+
+    {
+        auto db = TarDatabase::open(tmp);
+        REQUIRE(db.has_value());
+        CHECK(db->schema_version() == 5);
+        auto q = db->execute_query("SELECT COUNT(*) FROM sqlite_master WHERE name = 'tar_events' "
+                                   "OR name LIKE 'idx_tar_events%'");
+        REQUIRE(q.has_value());
+        CHECK(q->rows[0][0] == "0");
+    }
+
+    std::error_code ec;
+    fs::remove(tmp, ec);
+    fs::remove(fs::path{tmp.string() + "-wal"}, ec);
+    fs::remove(fs::path{tmp.string() + "-shm"}, ec);
+}
+
+TEST_CASE("TarDatabase: create_warehouse_tables joins a transaction the caller already holds",
+          "[tar][store][lifecycle][ddl-batch]") {
+    // exec_ddl_batch wraps the DDL in its own transaction for cost and
+    // atomicity, but create_warehouse_tables() is public and a caller may
+    // already hold one. It must then run the batch unwrapped and JOIN that
+    // transaction rather than failing or nesting, and must leave the
+    // connection's autocommit state undisturbed either way.
+    auto t = make_test_db();
+    auto process_live_tables = [&] {
+        auto r = t.db.execute_query(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='process_live'");
+        REQUIRE(r.has_value());
+        return r->rows[0][0];
+    };
+
+    // Drop a table so the nested call has real work to do, then roll the
+    // CALLER's transaction back. Had create_warehouse_tables opened and
+    // committed a transaction of its own, the re-created table would SURVIVE
+    // that rollback; joining the caller's transaction means it must not. This is
+    // what makes the test discriminating rather than merely green.
+    REQUIRE(t.db.execute_query("DROP TABLE process_live").has_value());
+    REQUIRE(process_live_tables() == "0");
+
+    REQUIRE(t.db.execute_sql("BEGIN IMMEDIATE"));
+    CHECK(t.db.create_warehouse_tables());
+    CHECK(process_live_tables() == "1"); // recreated inside the caller's txn
+    REQUIRE(t.db.execute_sql("ROLLBACK"));
+    CHECK(process_live_tables() == "0"); // ...and discarded with it
+
+    // The ordinary un-nested path commits on its own and leaves a usable handle.
+    CHECK(t.db.create_warehouse_tables());
+    CHECK(process_live_tables() == "1");
+    auto q = t.db.execute_query("SELECT COUNT(*) FROM process_live");
+    REQUIRE(q.has_value());
+}
+
 TEST_CASE("TarDatabase: schema v4 ALTERs version onto a pre-existing procperf tier (upgrade path)",
           "[tar][store][lifecycle][procperf]") {
     // The deployment-critical path the fresh-DB tests never exercise: an
@@ -1253,7 +1400,7 @@ TEST_CASE("TarDatabase: schema v4 ALTERs version onto a pre-existing procperf ti
     // schema_version=3, so create_warehouse_tables' IF-NOT-EXISTS leaves them
     // alone and the v4 block's ALTER TABLE ADD COLUMN must run. Seed that exact
     // pre-v4 shape by hand, then open and prove the ALTER fired.
-    auto tmp = yuzu::test::unique_temp_path("tar_v4_");
+    auto tmp = yuzu::test::unique_temp_path("yuzu_test_tar_v4_");
     {
         sqlite3* raw = nullptr;
         REQUIRE(sqlite3_open(tmp.string().c_str(), &raw) == SQLITE_OK);
@@ -1274,7 +1421,7 @@ TEST_CASE("TarDatabase: schema v4 ALTERs version onto a pre-existing procperf ti
     {
         auto db = TarDatabase::open(tmp);
         REQUIRE(db.has_value());
-        CHECK(db->schema_version() == 4); // the v3→v4 walk ran
+        CHECK(db->schema_version() == 5); // the v3→v4→v5 walk ran
 
         // Both tiers now carry `version` (added by the ALTER, not the DDL).
         for (const char* tbl : {"procperf_live", "procperf_hourly"}) {
@@ -1358,7 +1505,7 @@ TEST_CASE("TarDatabase: insert and query dns events (ADR-0015)", "[tar][store][c
 
 TEST_CASE("TarDatabase: a corrupt tar.db is quarantined and re-initialised fresh (#559)",
           "[tar][store][lifecycle][corruption]") {
-    auto tmp = yuzu::test::unique_temp_path("tar_corrupt_");
+    auto tmp = yuzu::test::unique_temp_path("yuzu_test_tar_corrupt_");
 
     // 1. Create a real DB and persist a deliberately-paused source. This is the
     //    forensic-preservation state a corrupt read must NOT silently undo.
@@ -1414,7 +1561,7 @@ TEST_CASE("TarDatabase: a second corruption never overwrites the first quarantin
     // that would shred preserved forensic evidence. Drive two corrupt-open
     // cycles back-to-back (same second) and assert TWO distinct `.corrupt-*`
     // files survive.
-    auto tmp = yuzu::test::unique_temp_path("tar_collide_");
+    auto tmp = yuzu::test::unique_temp_path("yuzu_test_tar_collide_");
     const std::string prefix = tmp.filename().string() + ".corrupt-";
 
     auto corrupt_then_open = [&]() {
@@ -1454,7 +1601,7 @@ TEST_CASE("TarDatabase: a valid DB opens cleanly with no quarantine and preserve
     // The happy path: integrity_ok returns true, so a previously-written DB is
     // re-opened in place with its data intact and NO `.corrupt-*` sidecar minted
     // (guards against an integrity_ok that wrongly fails every open).
-    auto tmp = yuzu::test::unique_temp_path("tar_valid_");
+    auto tmp = yuzu::test::unique_temp_path("yuzu_test_tar_valid_");
     {
         auto opened = TarDatabase::open(tmp);
         REQUIRE(opened.has_value());
@@ -1491,7 +1638,7 @@ TEST_CASE("TarDatabase: a corrupt-and-unmovable tar.db fails closed (#559 primar
         SKIP("root bypasses directory permissions; cannot make the rename fail");
     }
 
-    auto dir = yuzu::test::unique_temp_path("tar_unmovable_");
+    auto dir = yuzu::test::unique_temp_path("yuzu_test_tar_unmovable_");
     REQUIRE(fs::create_directory(dir));
     // RAII: re-add write perms and remove the dir even if an assertion throws,
     // so a read-only temp dir never leaks onto a CI box that reuses workspaces.


### PR DESCRIPTION
## Why

The `tar` unit suite times out at its 90s meson budget on **48 of 437 Windows CI runs** (p50 20.8s, p90 53.1s, p99 85.0s). The same suite is 0.5s on Linux. On an idle Wee Tam runner it is 10.55s, of which `[store]` (4.16s) + `[retention]` (4.48s) are **82%** — the ~95 cases that build a `TarDatabase`, spread flat across ~100 cases with no hot test.

Decomposing one open on Windows (91 iterations, best of 3, real captured schema — 36 tables + 42 indexes, 75 statements):

| variant | ms/open |
|---|---|
| **current** (each statement its own commit) | **72.4** |
| **one explicit transaction** | **11.0** |
| `synchronous=NORMAL` | 11.9 |
| transaction + NORMAL | 10.7 |
| `synchronous=OFF` | 8.4 |
| DDL only, against `:memory:` | 1.1 |
| file + WAL + 2 conns + delete, no DDL | 8.5 |

Neither the DDL nor the file lifecycle explains 72.4 ms. SQLite gives every bare statement its own implicit transaction and WAL defaults to `synchronous=FULL`, so a ~75-statement batch is **~75 commits, each with an fsync**. Every agent pays this at boot on every endpoint — not just the tests.

## What changed

**1. `exec_ddl_batch`** wraps both DDL batches (`kCreateSchema`, `generate_warehouse_ddl()`) in one transaction. Also an atomicity fix: unwrapped, a batch failing partway left a half-built schema for the next open to inherit.

- `BEGIN IMMEDIATE`, not deferred — a deferred begin takes its write lock at the first writing statement, and in WAL a concurrent committer then yields `SQLITE_BUSY_SNAPSHOT`, for which SQLite does **not** invoke the busy handler, so `open()`'s 5000ms `busy_timeout` would not apply. Matches `purge_source()` / `execute_atomic_batch()` in the same file.
- Nesting detected via `sqlite3_get_autocommit()` rather than inferred from a failed `BEGIN`, so BUSY / read-only / OOM cannot masquerade as "caller holds a transaction" and silently restore the old cost.
- On BUSY we return rather than fall back — an unwrapped batch would wait out the busy timeout ~75 times under `mu_`, stalling collectors for minutes.
- If the batch can neither commit nor roll back, `open()` now **fails closed** instead of publishing a wedged connection whose every later write would be discarded at close.

`synchronous` is deliberately left at FULL — changing durability on an agent's data store is a separate decision, and the transaction alone gets 72.4 → 11.0.

**2. `tar_events` retired for real.** `kCreateSchema` created the v3-retired table + 3 indexes on **every** open, while the v3 DROP is gated on `schema_version == 2`. Once a database reached v3 the gate never fired again — so **every agent restart resurrected all four objects, permanently**. `is_queryable_table()` excludes `tar_events` precisely so its "no such table" cannot become an existence oracle (#760 UP-8), and that holds only while it is genuinely absent.

Nothing has written to the table since v3, so a resurrected copy is always empty — this clears a stray table, not data.

Removing the DDL alone would have fixed new installs only: the entire installed base is already at v3/v4 **with** the table. The drop is gated on **presence, not version** — a version gate arms once, so rolling an endpoint back to a pre-fix binary (which recreates it) and forward again would strand it forever. Presence-gating also reaches a database left at v3 by a failed v4 ALTER. Cost is one `sqlite_master` read per open.

## Measured end-to-end (real MSVC binary, Shulgi)

Same checkout, patch applied in place, MSVC debug:

| | baseline | fixed | |
|---|---|---|---|
| 91 DB-opening cases | 21.35s | **7.46s** | **2.86×** |
| full tar suite | 27.00s | **9.48s** | **2.85×** |

The fixed side runs **95 cases against the baseline's 91** (it carries the new regression tests), so this understates the gain. All 379 cases pass on Windows.

The 90s budget is deliberately **unchanged**: per the ladder documented on the server shards in `tests/meson.build`, per-op cost is the first move and a bigger number the last.

## Tests

Four regression tests, **each verified red without the fix**:

- a fresh open **and a reopen** carry no `tar_events` objects — fails `"4" == "0"` against unmodified `dev`
- a hand-seeded pre-v3 database still has them dropped
- a database that already carries them is cleaned — fails `"2" == "0"`
- `create_warehouse_tables()` joins a caller's transaction — proven by rolling that transaction back and asserting the re-created table does **not** survive

Fixture temp paths in `test_tar_store.cpp` move to the `yuzu_test_` prefix so they land inside the Wee Tam Defender path exclusion (`yuzu*`), per the CLAUDE.md test conventions.

## Validation

- `/test --quick`: Preflight, Build (C++), Build (Erlang), EUnit (212), Dialyzer all PASS. Server shard B has 5 pre-existing failures in `test_sqlite_raii.cpp` (from #2360) on macOS — `yuzu_server_tests` compiles none of the changed files.
- `/governance origin/dev..HEAD`: 11 agents across Gates 2/3/4/6 plus a mandatory security re-review of each hardening round. **No CRITICAL or HIGH.** One BLOCKING (installed-base divergence) and two MEDIUMs (wedged-handle publication, downgrade re-arming) found and fixed in-PR.

> Governance also caught a **vacuous test** in an earlier draft — an assertion that could not fail. Every test here was verified red before commit.

## Follow-ups (not in this PR)

- `tar status` exposes no `schema_version` / `warehouse_tables_ok`, so a TAR agent with zero warehouse tables reads as healthy — atomicity makes that state newly reachable (SRE Gate 6).
- `server/core/src/rbac_store.cpp` `seed_defaults()` has the same unwrapped-DDL shape (37+ statements). Server-boot-once and Postgres-bound, so low value.
- TAR's exact-equality migration gating (`== 2`, `== 3`) diverges from `MigrationRunner`'s `<=` convention.
- No documented rollback policy for agent-local schema migrations.

Refs #2093

🤖 Generated with [Claude Code](https://claude.com/claude-code)
