### PR TITLE
docs(agents): trim AGENTS.md to a routing layer and tighten reviewer contracts

### DIFF
--- a/.codex/skills/auth-and-authz/SKILL.md
+++ b/.codex/skills/auth-and-authz/SKILL.md
@@ -42,7 +42,7 @@ skill claims anything is "done."
 | Capability | Status | Source of truth |
 |---|---|---|
 | Local password auth (PBKDF2-SHA256) | Shipped (v0.10) | `auth.cpp:69` `pbkdf2_sha256()` (OpenSSL `PKCS5_PBKDF2_HMAC` + BCrypt path) |
-| Persistent auth store (`auth.db`, SQLite) | Shipped (v0.12) | `auth_db.cpp:222-236` chmod 0600 + L402 `MigrationRunner::run`; agent-doc `.codex/agents/authdb.md` |
+| Persistent auth store (`auth.db`, SQLite) | Shipped (v0.12) | `docs/auth-architecture.md` "AuthDB — persistent authentication store" |
 | Session-cookie auth (HTMX dashboard) | Shipped | `auth_routes.cpp:43,386` (`extract_session_cookie`, `Set-Cookie: yuzu_session=…`) |
 | API tokens — Bearer + `X-Yuzu-Token` | Shipped | `api_token_store.cpp` (store); both header forms parsed at `auth_routes.cpp:108-119` |
 | Owner-scoped token revocation (#222) | Shipped | `rest_api_v1.cpp:1058-1082` (owner-vs-admin check at L1060) |
@@ -95,9 +95,8 @@ SOC 2 alignment: CC6.1 (logical access), CC6.2 (provisioning), CC6.3
 
 ### Hard invariants that must NOT regress when adding any of the above
 
-These are pulled from `docs/auth-architecture.md` and
-`.codex/agents/authdb.md`. Every PR adding a feature in Section 2 above
-must check them:
+These are pulled from `docs/auth-architecture.md`. Every PR adding a feature
+in Section 2 above must check them:
 
 - HTTPS by default; refuse to start without `--https-cert` + `--https-key`
   unless `--no-https` is passed.
@@ -233,7 +232,8 @@ For every feature in Section 3:
      invariants.
    - `docs/enterprise-readiness-soc2-first-customer.md` §3.2 for the
      enterprise/SOC 2 framing.
-   - `.codex/agents/authdb.md` if the feature touches `auth.db`.
+   - `docs/auth-architecture.md` "AuthDB — persistent authentication store"
+     if the feature touches `auth.db`.
    - `docs/mcp-server.md` if the feature touches the MCP surface.
 
 2. **Plan.** Produce a short plan covering:
@@ -255,13 +255,13 @@ For every feature in Section 3:
    reference.
 
 5. **Governance.** Run `/governance dev..HEAD` before pushing — Gate 2
-   (security-guardian + docs-writer mandatory deep-dive) plus the AuthDB
-   review agent (`.codex/agents/authdb.md`) for any `auth_db.*` touch.
+   (security-guardian + docs-writer mandatory deep-dive) plus the `authdb`
+   role from the governance reviewer contract for any `auth_db.*` touch.
    CRITICAL/HIGH findings block merge.
 
-6. **Docs.** docs-writer always picks up the user-manual + REST API
-   updates during Gate 2; verify the change is in the findings report
-   and ship the doc edit in the same PR (or the immediate follow-up).
+6. **Docs.** docs-writer reviews the user-manual and REST API impact during
+   Gate 2. Ship required documentation in the same reviewed baseline; a
+   blocking documentation gap is not an immediate-follow-up item.
 
 7. **Compliance evidence.** For features that close a SOC 2 control gap,
    add an entry to `docs/security-reviews/` for the change record. The
@@ -272,8 +272,7 @@ For every feature in Section 3:
 ## 5. Cross-references
 
 - **Routed reference doc:** `docs/auth-architecture.md`
-- **AuthDB review agent:** `.codex/agents/authdb.md`
-- **Security review agent:** `.codex/agents/security-guardian.md`
+- **Governance reviewer roles:** `.codex/skills/governance/references/reviewers.md`
 - **MCP token + tier policy:** `docs/mcp-server.md`
 - **Enterprise readiness plan:** `docs/enterprise-readiness-soc2-first-customer.md`
 - **SOC 2 evidence pattern:** `docs/security-reviews/*` and audit-log

--- a/.codex/skills/cpp-expert/SKILL.md
+++ b/.codex/skills/cpp-expert/SKILL.md
@@ -1,20 +1,21 @@
 ---
 name: cpp-expert
-description: Review Yuzu C++ source changes for C++23 correctness, idiomatic standard-library use, ABI boundaries, threading primitives, and cross-compiler portability across GCC, Clang, MSVC, and Apple Clang. Use for any governance Gate 3 review when `.cpp`, `.hpp`, or `.h` files change.
+description: Review Yuzu C++ source changes for C++23 correctness, project-native idioms, ABI boundaries, threading primitives, and portability across GCC, Clang, MSVC, and Apple Clang. Use for every governance review that changes `.cpp`, `.hpp`, or `.h` files.
 ---
 
 # C++ Expert
 
-Use this skill for general C++ language review. Pair it with `cpp-safety` for ownership and lifetime proof; this skill covers correctness, idiom, portability, and ABI shape.
+Pair with `cpp-safety`. Load `docs/cpp-conventions.md`, then inspect the owning module's adjacent implementation and tests before judging style or shape.
 
-## Review Focus
+## Review
 
-- Load `docs/cpp-conventions.md` before reviewing C++ source changes.
-- Check `std::expected`, `std::string_view`, `std::span`, `std::format`, templates, concepts, move semantics, and concurrency primitives for correct C++23 use.
-- Check plugin ABI boundaries: no C++ types, exceptions, or unstable ownership contracts cross `sdk/include/yuzu/plugin.h`.
-- Check cross-compiler behavior against the supported matrix: GCC 13+, Clang 18+, MSVC 19.38+, and Apple Clang 15+.
-- Flag undefined behavior, use-after-move, ODR hazards, narrowing conversions, missing includes, non-portable extensions, and unnecessary copies on hot paths.
+- Prove language-level correctness: undefined behavior, conversions, object lifetime, move/copy behavior, exception boundaries, templates, atomics, locks, and missing direct includes.
+- Check C++23 and library use against the supported compilers. A newer construct is not preferable when the established local construct is correct and clearer.
+- Preserve the stable C plugin ABI: no C++ types, exceptions, layout accidents, or unclear ownership cross `sdk/include/yuzu/plugin.h`.
+- Prefer an existing project helper or local pattern. Request a new abstraction only when it establishes a necessary safety boundary or removes demonstrated duplication.
+- Keep fixes narrow. Do not request drive-by modernization, cosmetic renaming, alternate-but-equivalent syntax, or use of a particular standard-library type without a concrete benefit.
+- Comments explain the invariant or external constraint, never the reviewer, finding ID, or governance round.
 
 ## Output
 
-Return findings first, with severity `BLOCKING`, `SHOULD`, or `NICE`, each grounded in `file:line` and a concrete fix. End with `PASS` or `BLOCKED`.
+Return only evidence-backed `BLOCKING` or `SHOULD` findings with `file:line`, consequence, and the smallest project-native fix. Return exactly `PASS` when there are none.

--- a/.codex/skills/cpp-safety/SKILL.md
+++ b/.codex/skills/cpp-safety/SKILL.md
@@ -1,20 +1,22 @@
 ---
 name: cpp-safety
-description: Review Yuzu C++ source changes for resource ownership, RAII, borrowed lifetimes, C ABI contexts, casts, process/syscall boundaries, callbacks, threads, and sanitizer coverage. Use for any governance Gate 3 review when C++ files change, paired with cpp-expert.
+description: Review Yuzu C++ source changes for RAII ownership, borrowed lifetimes, C ABI contexts, casts, process/syscall boundaries, callbacks, threads, and proportionate sanitizer coverage. Use for every governance review that changes C++ files, paired with cpp-expert.
 ---
 
 # C++ Safety
 
-Use this skill for C++ ownership and lifetime proof. Pair it with `cpp-expert`, which covers general C++23 correctness and portability.
+Pair with `cpp-expert`. Load `docs/cpp-conventions.md` and inspect existing owner types and shutdown patterns in the owning module.
 
-## Review Focus
+## Review
 
-- Load `docs/cpp-conventions.md` before reviewing C++ source changes.
-- Verify every owning raw resource boundary in the Gate 1 Resource Ledger: fd, HANDLE, SOCKET, `FILE*`, SQLite, OpenSSL, BCrypt, allocated C string, mapped library, temp path, subprocess, callback context, and thread.
-- Review broad mechanical hits such as `new`, `delete`, `malloc`, `free`, `release()`, `raw()`, casts, shell/process APIs, callback registration, and thread creation. Require ledger entries only when a hit creates, transfers, or releases ownership of an owning raw resource boundary.
-- Flag leaks, double-release, early-return cleanup gaps, borrowed data escape, unsafe shell construction, ambiguous thread teardown, and undocumented cast assumptions.
-- Require targeted ASan/UBSan/TSan or platform-specific validation when ownership, callbacks, shared state, or OS handles change.
+- Require an ownership note only when the range adds an owning resource boundary or changes acquisition, transfer, release, callback, or thread lifetime. Name the owner, acquire/transfer/release points, and failure cleanup.
+- Prefer an existing RAII owner. Otherwise use the smallest fitting mechanism: value ownership, `std::unique_ptr` with a deleter, a move-only wrapper, or a local scope guard.
+- Treat manual cleanup as blocking when a concrete return, exception, transfer, retry, or concurrency path can leak or double-release. Its mere presence in untouched legacy code is not a finding.
+- Prove borrowed `std::string_view`, `std::span`, raw pointers, C callback contexts, and returned C strings cannot outlive their owners.
+- Prove threads and callbacks have explicit stop, join, unregister, and destruction ordering. Review shared-state synchronization and casts at ABI/syscall boundaries.
+- Prefer argv-style process execution. Require validation and a documented constraint when a shell is genuinely necessary.
+- Ask for the narrowest useful ASan/UBSan, TSan, or platform test only when the changed risk warrants it; do not demand every sanitizer mechanically.
 
 ## Output
 
-Return findings first, with severity `BLOCKING`, `SHOULD`, or `NICE`, each grounded in `file:line` and a concrete fix. End with `Resource Ledger: complete/incomplete`, sanitizer coverage needed, and `PASS` or `BLOCKED`.
+Return only evidence-backed `BLOCKING` or `SHOULD` findings with `file:line`, consequence, and the smallest project-native fix. End with `Ownership note: complete`, `incomplete`, or `not required`, then `PASS` or `BLOCKED`.

--- a/.codex/skills/governance/SKILL.md
+++ b/.codex/skills/governance/SKILL.md
@@ -1,83 +1,67 @@
 ---
 name: governance
-description: Run Yuzu's Codex governance review pipeline on a commit range with slash-name parity to Claude `/governance`. Use when the user says `/governance <range>`, "full governance", or asks for the multi-gate security/docs/domain/ops review on commits or a PR.
+description: Run or maintain Yuzu's bounded Codex governance review on a commit range. Produces evidence-backed security, documentation, domain, correctness, and operational findings with a compact ledger. Use for `/governance RANGE`, "full governance", a multi-gate PR review, or an audit of the governance workflow and reviewer prompts.
 ---
 
 # Governance
 
-Run Yuzu governance as a Codex-native review fanout. This skill may use Codex subagents because invoking `/governance` is an explicit request for delegated review. Keep each delegated role bounded to review only; do not let review agents edit files.
+Review the exact range with bounded, read-only reviewer fanout. The primary agent owns scope, deduplication, adjudication, and the final decision. Do not expose raw reviewer transcripts.
+
+Before launching reviewers, read [references/reviewers.md](references/reviewers.md) completely. Use its shared contract in every reviewer prompt and append only the matching role focus.
+
+Give each reviewer the resolved range, the compact Gate 1 facts, changed paths, and only prior finding IDs relevant to that role. Do not paste another reviewer's prose.
 
 ## Range
 
-- Default range: `dev..HEAD`.
-- Treat a bare commit like `HEAD` as `HEAD~1..HEAD`.
-- If `dev..HEAD` is empty on branch `dev`, ask whether `origin/dev..HEAD` is intended.
+- Default to `dev..HEAD`.
+- Treat a bare commit as `<commit>~1..<commit>`.
+- If `dev..HEAD` is empty on `dev`, ask whether `origin/dev..HEAD` is intended.
+- Resolve and record the base and head SHAs before review. A later fix changes the reviewed baseline and triggers only the re-review described below.
+
+## Review Standard
+
+- Review changed behavior and directly affected call paths, not unrelated backlog.
+- Load the documents routed by `AGENTS.md`; durable invariants belong there, not in reviewer prompts.
+- Compare adjacent production code and tests before proposing a pattern. Prefer the smallest change that fits the owning module. Do not request a rename, abstraction, helper, or modernization without a concrete correctness, safety, duplication, or contract reason.
+- For C++ changes, always run `cpp-expert` and `cpp-safety`. Prefer automatic ownership and existing RAII helpers. Add an ownership note only when the range adds a resource boundary or changes acquisition, transfer, release, callback, or thread lifetime.
+- Production comments explain the invariant or failure mode. They do not cite governance rounds, agents, or finding IDs.
+- Treat wording as a finding only when it is factually wrong, contradicts a normative term or public contract, or is materially ambiguous to its intended reader. Existing nearby terminology wins when several phrasings are equivalent.
 
 ## Gates
 
-1. Change Summary: write this locally from `git log`, `git diff --stat`, and targeted diffs.
-2. Mandatory review: launch `security-guardian` and `docs-writer` in parallel.
-3. Domain review: select roles by changed files and launch them in parallel.
-4. Correctness review: launch `happy-path`, `unhappy-path`, and `consistency-auditor` in parallel.
-5. Chaos analysis: run only if Gate 4 produced unhappy-path or consistency findings.
-6. Operational review: launch `compliance-officer`, `sre`, and `enterprise-readiness` in parallel.
-7. Findings resolution: consolidate findings and fix blocking items.
-8. Iteration and ledger: re-run affected gates, record deferrals, and make the blocking decision.
+1. **Summary** — Record range and intent, changed contracts or risks, validation already run, triggered roles, and either `Ownership changes: none` or a compact ownership note.
+2. **Mandatory** — Run `security-guardian` and `docs-writer` in parallel on every changed file. Neither role may be skipped.
+3. **Domain** — Run only roles triggered by `AGENTS.md`, changed files, or affected contracts. C++ always triggers both C++ roles; a feature or bug fix triggers `quality-engineer`.
+4. **Correctness** — Run `happy-path`, `unhappy-path`, and `consistency-auditor` in parallel.
+5. **Chaos** — Run `chaos-injector` only for an unresolved Gate 4 finding where a reproducible fault test would change the merge decision. Do not generate a general chaos backlog.
+6. **Operations** — Run `compliance-officer`, `sre`, and `enterprise-readiness` in parallel. A role with no affected surface returns `PASS`.
+7. **Resolution** — Merge duplicates, reject inadmissible findings, and decide blockers. Modify files only when the user's request authorizes fixes; otherwise return `BLOCKED` with the smallest required fix.
+8. **Final baseline** — If fixes changed the baseline, re-run `docs-writer`, any security role affected by the fix, and only the original owners of still-relevant findings. Produce the ledger and decision.
 
-Blocking contract: CRITICAL/HIGH security findings block. Any `BLOCKING` docs finding blocks user-facing changes. `BLOCKING` from Gate 4-6 blocks. MEDIUM/SHOULD findings need either a fix or an explicit deferral with an issue.
+## Blocking
 
-## Gate 1 Output
+- Security `CRITICAL` and `HIGH` findings block.
+- A docs finding blocks when changed user-visible, operational, API, configuration, permission, audit, compatibility, or upgrade behavior is missing or inaccurate in its required documentation or changelog fragment.
+- Other roles use `BLOCKING` only for a demonstrated correctness, safety, compatibility, data, test-validity, or operability defect in scope.
+- `SHOULD` requires a concrete in-scope defect but does not block. Fix it when local and low risk; otherwise record a concise rationale or an existing issue. Do not create issues without user authorization.
+- Omit style preferences, generic hardening, praise, `LOW`, `INFO`, and `NICE` observations from the ledger.
 
-Include:
+## Convergence
 
-- commits in scope: sha, subject, branch/push state if known
-- files touched: path and behavioral delta
-- interfaces affected: REST, stores, proto, plugin ABI, CLI/env, CI, docs
-- security surface: opened, closed, or net neutral
-- Resource Ledger for C++ changes: every new or modified fd, HANDLE, SOCKET, `FILE*`, `sqlite3_stmt*`, `sqlite3*`, OpenSSL object, BCrypt handle, allocated C string, mapped library, temp path, subprocess, callback context, and thread; for each, name the owner type, acquisition point, release point, transfer behavior, and failure cleanup
-- user-facing impact and compatibility notes
-- validation already performed with exact commands and exit status
-- Gate 3 roles selected and why
+- Consolidate accepted fixes into one coherent remediation round, then perform one targeted re-review.
+- Never re-run a role against an unchanged baseline and unchanged evidence.
+- A reviewer may keep a finding open only with evidence that its original consequence remains. It may open a new finding only for a regression introduced by the remediation or newly inspected changed code.
+- Do not reopen a finding under a new ID, raise severity, or argue alternate wording without new evidence.
+- Resolve reviewer disagreement from tests, code behavior, routed docs, and established neighboring patterns. If those sources do not decide a material product or contract question, stop and ask the user; reviewers do not debate each other.
+- Allow at most two remediation rounds. If a blocker remains after the second targeted re-review, stop with `BLOCKED`; do not launch the same loop again.
 
-## Role Prompts
+## Final Output
 
-Use compact role prompts and include the Gate 1 summary plus prior gate findings as context.
+Lead with findings. For each accepted finding, emit its ID, severity, `file:line`, consequence, evidence, and smallest fix once. Then include:
 
-- `security-guardian`: read every modified file; check authz, ownership, validation, audit, command execution, path handling, crypto, secret handling, sibling handler parity, and new error branches. For C++ diffs, also require an ownership proof for every raw resource boundary: fd, HANDLE, SOCKET, `FILE*`, `sqlite3_stmt*`, `sqlite3*`, OpenSSL/BCrypt object, allocated C string, thread, callback context, subprocess, mapped library, and temp path must have exactly one owner; manual cleanup in new/touched code is blocking unless wrapped in a small RAII/scope guard or justified as impossible; every early return between acquire and release must be checked. Findings use CRITICAL/HIGH/MEDIUM/LOW/INFO with file:line and recommended fix.
-- `docs-writer`: check REST docs, user manual, CHANGELOG, upgrade notes, permission/audit/error tables, and operator workflow docs. Findings use BLOCKING/SHOULD-FIX/NICE-TO-HAVE.
-- `architect`: public contracts, stores, REST boundaries, schema, lifecycle, coupling, and hard-to-reverse design.
-- `cpp-expert`: C++23 correctness, idioms, standard-library use, ABI boundaries, threading primitives, and cross-compiler portability across GCC, Clang, MSVC, and Apple Clang.
-- `cpp-safety`: RAII ownership, lifetime, move/copy semantics, C ABI boundaries, `std::string_view`/`std::span` validity, cast safety, thread lifetime, syscall/process boundaries, shell execution, and sanitizer coverage. BLOCKING for leaks, double-close risk, UAF risk, unjoined/detached thread ambiguity, unsafe shell construction, or borrowed data escaping its owner.
-- `quality-engineer`: test seams, integration coverage, fixture isolation, flaky patterns, temp DB/path hygiene, weak assertions. For C++ safety-sensitive changes, require coverage for cleanup paths, partial failure, short read/write, EINTR, failed `pclose`, failed `CloseHandle`, failed `sqlite3_prepare`, and concurrent teardown where relevant; for new RAII wrappers, require a test or compile-time assertion covering move-only/non-copyable behavior when feasible.
-- `build-ci`: Meson, vcpkg, workflows, release scripts, runner assumptions, cache behavior.
-- `plugin-developer`: plugin descriptors, SDK boundaries, YAML definitions, plugin execution behavior.
-- `gateway-erlang`: rebar3, OTP supervision, grpcbox/gpb, gateway proto mirrors, EUnit/CT/Dialyzer implications.
-- `dsl-engineer`: CEL, scope DSL, YAML DSL, trigger templates, validation and backward compatibility.
-- `cross-platform`: Darwin, Linux, Windows/MSVC, paths, sockets, filesystem, service behavior.
-- `performance`: SQLite hot paths, BFS/graph traversals, authz loops, gateway throughput, allocations.
-- `release-deploy`: Docker, packages, systemd, installers, upgrade and rollback behavior.
-- `happy-path`: trace normal request/store/plugin/gateway flows end to end and call out idempotency.
-- `unhappy-path`: produce a risk register with ID, trigger, symptom, severity, and chaos candidate.
-- `consistency-auditor`: check sibling parity, error/audit naming, schema/docs/tests drift, and CHANGELOG ordering.
-- `chaos-injector`: convert Gate 4 risk registers into executable chaos test designs; do not run them.
-- `compliance-officer`: SOC 2 control alignment, evidence chain, audit traceability, retention, approvals.
-- `sre`: health/readiness, metrics, alerts, recovery, capacity, backpressure, runbooks.
-- `enterprise-readiness`: pilot-visible rough edges, upgrade notes, breaking changes, customer assurance.
+- validation performed, with command and result;
+- one compact role ledger: `PASS`, `FINDINGS`, or `SKIPPED` with counts;
+- unresolved blockers and accepted deferrals only;
+- `PASS`, `PASS WITH DEFERRED`, or `BLOCKED`.
 
-## Domain Routing
-
-Always include `quality-engineer` for feature or bug-fix changes. Always include `architect` for public store contracts or REST API surfaces. Always include `performance` for `get_*_ids`, SQLite BFS/graph traversal, or per-authz hot paths.
-
-Always include `cpp-expert` and `cpp-safety` when C++ files change. Also include `cpp-safety` for any diff that introduces or modifies `popen`, `system`, shell strings, `fork`/`exec`, `CreateProcess`, `dlopen`, `LoadLibrary`, `open`, `socket`, `sqlite3_prepare`, `EVP_*_new`, `BCrypt*`, `LocalAlloc`, `yuzu_ctx_*`, `raw()`, `release()`, `reinterpret_cast`, `const_cast`, or a background thread/callback that stores a pointer or reference. Run `rg` over changed C++ files for raw resource APIs and verify owning raw resource boundary hits appear in the Resource Ledger.
-
-Use `$yuzu-proto`, `$yuzu-plugin-abi`, `$yuzu-meson`, `$yuzu-windows-msvc`, and `$yuzu-build` when the changed files touch their domains.
-
-## Ledger
-
-End with a governance ledger:
-
-- Gate status table: role, result, blocking count, deferred count
-- Blocking findings with owner/fix status
-- Deferred findings with issue number or explicit rationale
-- Re-review scope and result
-- Final decision: PASS / PASS WITH DEFERRED / BLOCKED
+Keep pass entries to one line. Do not narrate gates, repeat the change summary, reproduce reviewer prose, or list speculative follow-ups.

--- a/.codex/skills/governance/references/reviewers.md
+++ b/.codex/skills/governance/references/reviewers.md
@@ -1,0 +1,57 @@
+# Governance Reviewer Contract
+
+Use the shared contract for every role, followed by one role focus below. Reviewer tasks are read-only.
+
+## Shared Contract
+
+- Inspect the changed hunks and enough surrounding code, tests, and routed documentation to prove behavior. Do not review from the summary alone.
+- Stay within the change and directly affected call paths. Report inherited defects only when the change worsens them, relies on them, or makes the stated behavior unsafe.
+- A finding needs a concrete consequence, evidence at `file:line`, and the smallest project-native fix. If any element is missing, omit it.
+- Prefer existing helpers, types, test seams, names, and control flow from the owning module. Do not propose speculative generalization, drive-by refactoring, or a second implementation style.
+- Do not request comments that record the review process. A useful comment explains a non-obvious invariant or external constraint.
+- Do not report praise, summaries, generic best practice, future wishlist items, or equivalent wording preferences.
+- Wording is actionable only when it changes meaning, contradicts code or a normative project term, or leaves the target reader unable to act correctly. Cite the conflicting source.
+- Do not duplicate a supplied prior finding. Add evidence to its ID or state that it is resolved.
+
+Use this compact form:
+
+```text
+[SEVERITY ID] path:line — consequence
+Evidence: observable code path, contract, or failing/missing test.
+Fix: smallest change that removes the consequence.
+```
+
+Security uses `CRITICAL`, `HIGH`, or `MEDIUM`; every other role uses `BLOCKING` or `SHOULD`. Return exactly `PASS` when there are no findings.
+
+## Mandatory Roles
+
+- **security-guardian** — Trace changed trust boundaries, authentication, authorization, ownership checks, external input, command/process execution, secrets, cryptography, audit, and failure behavior. Load the security documents routed by `AGENTS.md`. Do not duplicate general C++ style review.
+- **docs-writer** — Review every modified file for operator, agentic-worker, API, configuration, permissions, audit, compatibility, and upgrade impact. Verify facts against code, tests, and normative docs; code is not automatically right when they disagree. A mandatory review does not imply a mandatory edit: an internal-only change may pass without docs. Require `changelog.d/` only for operator-visible changes under its own rules. Specify the destination and missing facts, not polished prose. Run on the final baseline whenever remediation changed files.
+
+## Domain Roles
+
+- **architect** — Module ownership, dependency direction, public contracts, schemas, lifecycle, compatibility, and hard-to-reverse coupling. Prefer the current architecture unless the change proves it inadequate.
+- **authdb** — Load the AuthDB section of `docs/auth-architecture.md`; review only changes to AuthDB storage, lifetime, sessions, users, enrollment tokens, or their routes.
+- **cpp-expert** — Load `docs/cpp-conventions.md`; review C++23 correctness, undefined behavior, ABI shape, standard-library use, threading primitives, includes, conversions, and supported-compiler behavior. Do not demand a different idiom when the local one is correct.
+- **cpp-safety** — Load `docs/cpp-conventions.md`; prove ownership, cleanup, borrowed lifetimes, callback and thread teardown, C ABI context, casts, and process/syscall boundaries. Prefer an existing RAII owner, then the smallest local owner or scope guard. Presence of legacy manual cleanup is not itself a finding.
+- **quality-engineer** — Test the changed behavior and credible failure paths at the narrowest stable seam. Check assertion strength, isolation, determinism, regression value, and Meson registration. Do not demand one test per file or exhaustive permutation coverage.
+- **build-ci** — Load `docs/ci-architecture.md`, applicable build docs, and `ci-cache` when caching changes. Review the actual workflow/build graph, pins, platform split, and failure semantics; do not carry incident timelines in the finding.
+- **plugin-developer** — Load the plugin ABI skill/docs. Review descriptor and loader contracts, action behavior, C ABI compatibility, and required instruction definitions.
+- **gateway-erlang** — Load `docs/erlang-gateway-build.md`. Review OTP lifecycle, supervision, message ownership, proto mirrors, test isolation, EUnit/CT, and Dialyzer implications; do not restate Erlang tutorials.
+- **dsl-engineer** — Load the owning DSL docs. Review grammar, evaluation semantics, bounds, compatibility, and parser tests against implemented behavior, not roadmap phases.
+- **cross-platform** — Load the relevant OS build/compatibility docs. Review only affected platforms, including paths, APIs, types, service behavior, build guards, and validation gaps.
+- **performance** — Review demonstrated hot paths, query plans, contention, allocation, cardinality, backpressure, and bounded growth. Require a benchmark only when the change makes a performance claim or creates a material regression risk.
+- **release-deploy** — Load the deployment and UAT docs routed by `AGENTS.md`. Review packaging, configuration, upgrade/rollback, images, services, and release artifacts without duplicating topology reference material.
+
+## Correctness Roles
+
+- **happy-path** — Trace each changed public behavior end to end under valid inputs. Report only broken or incomplete flows, wrong outputs, unintended side effects, or violated idempotency claims.
+- **unhappy-path** — Test credible failures at changed boundaries: partial work, retry, duplicate, timeout, restart, corruption, exhaustion, and teardown. Trace only failure modes supported by code evidence.
+- **consistency-auditor** — Compare representations of the same changed contract across code, schema, proto, tests, docs, audit, metrics, and sibling handlers. Naming differences are findings only when a consumer or operator can observe the mismatch.
+- **chaos-injector** — Convert the cited unresolved Gate 4 finding into the smallest safe, reproducible fault test with injection point, observable pass condition, and rollback. Produce no unrelated scenarios.
+
+## Operational Roles
+
+- **compliance-officer** — Review only controls and evidence paths actually affected by the change. Cite the governing control or project document; do not turn general compliance aspirations into findings.
+- **sre** — Review changed health, metrics, alerts, logs, recovery, shutdown, capacity, queues, backpressure, and operator diagnosis. Require new telemetry only when it supports a concrete operational decision.
+- **enterprise-readiness** — Review changed installation, configuration, upgrades, integrations, assurance claims, and pilot-blocking behavior. Do not duplicate docs findings unless customer assurance has a separate consequence.

--- a/.codex/skills/release/SKILL.md
+++ b/.codex/skills/release/SKILL.md
@@ -52,7 +52,7 @@ Preflight checks:
 3. CHANGELOG has a `## [X.Y.Z]` section with non-empty content
 4. Working tree is clean
 5. `Dockerfile.server` includes `--data-dir`
-6. All `actions/cache@v*` steps in release.yml have `save-always: true`
+6. Release caches are restore-only: no bare `actions/cache@` and no `save-always`
 7. `docker-compose.full-uat.yml` includes `--data-dir`
 8. `origin/dev` and `origin/main` are reconciled (no divergence either direction)
 
@@ -172,8 +172,8 @@ Match the failure against this table. **All entries have happened in real Yuzu r
 | `Build and push` fails with `unauthorized` on GHCR | `GITHUB_TOKEN` `packages: write` scope missing | Verify `permissions: packages: write` at workflow root. |
 | `vcpkg install` fails with version baseline mismatch | `VCPKG_COMMIT` env var in workflow drift from `vcpkg.json` baseline | Sync both — workflow env + manifest baseline must match. Tracked by `.github/workflows/vcpkg-baseline-update.yml`. |
 | `Run EUnit tests` fails with non-zero exit + "Failed: 0" in log | meck fixture cancellation false-positive (known #336/#337 class) | Workflow already has the `if grep -q "Failed: 0"` workaround — should pass with warning. If it doesn't, paste the eunit.log tail and check if a new module is leaking processes. |
-| `actions/cache` save fails with EOF | GitHub cache backend transient | `save-always: true` ensures partial saves; retry the workflow. |
-| `Linking target server/core/yuzu-server` fails with LNK2038 on Windows | vcpkg cache poisoned with mixed runtime-libraries (the option-D issue from #375 / PR #373) | Bust the Windows vcpkg cache, re-run. Long-form: see `.codex/agents/build-ci.md` "Windows MSVC static-link history and #375". |
+| `actions/cache` save fails with EOF | GitHub cache backend transient | Retry the workflow. Do not add `save-always: true`; follow the `ci-cache` skill. |
+| `Linking target server/core/yuzu-server` fails with LNK2038 on Windows | vcpkg cache poisoned with mixed runtime libraries (the option-D issue from #375 / PR #373) | Bust the Windows vcpkg cache, re-run. Long-form: see `docs/windows-build.md` "Windows gRPC/protobuf linkage". |
 
 For any failure not in the table: pull `gh run view "$RUN_ID" --log-failed` in full, summarize the error, and ask the operator how to proceed (re-run? skip? abort?).
 
@@ -300,7 +300,6 @@ After all verification passes:
 1. **Bump dev branch to next dev version.** On `dev`:
    ```bash
    # Update meson.build version to X.Y.(Z+1)-dev or (X+1).Y.0-dev (operator's call)
-   # Add new ## [Unreleased] section to CHANGELOG.md
    git commit -m "chore(post-release): bump dev to X.Y.Z+1-dev"
    git push origin dev
    ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Yuzu is an agentic enterprise endpoint management platform — a single control 
 The word **agent** is overloaded; the rest of this file relies on these definitions:
 
 - **Agent daemon** — the C++ binary in `agents/core/` that runs on each managed endpoint and executes plugins. The thing the rest of this codebase usually means by "agent".
-- **Governance agent** — the `.codex/agents/*.md` review actors run during the `/governance` pipeline.
+- **Governance agent** — a bounded review subagent launched by `/governance`; the tracked role contract lives in `.codex/skills/governance/references/reviewers.md`.
 - **Agentic worker** — an external LLM-driven client (Claude, GPT, in-house) that drives Yuzu through MCP, REST, or the dashboard. The thing the agentic-first principle (`docs/agentic-first-principle.md`) is about.
 
 When in doubt in commit messages, PR descriptions, or new docs, use the disambiguated form.
@@ -65,7 +65,7 @@ The same source tree is built from multiple hosts; per-OS dirs prevent clobberin
 - **Shipped content is build-time embedded** (`embed_content.py` → `bundled_content.cpp`, seeded into `instructions.db` on first boot). The runtime never reads YAML from disk — **there is no `--content-dir` flag**. Rationale: `docs/Instruction-Engine.md` "Build-time content embedding".
 - **Every `dependency()` in meson files is marked `include_type: 'system'`** so vcpkg/gRPC/abseil/protobuf/Catch2 warnings are silenced while our code stays at `warning_level=3`. Do not remove it when adding dependencies.
 - **Windows build: never `vcvars64.bat`** (extension exit-1 corrupts wrappers) and **never Clang from `C:\Program Files\LLVM\bin`** (must be cl.exe/MSVC). Source of truth: `docs/windows-build.md`.
-- **vcpkg** — manifest `vcpkg.json`, pinned baseline `4b77da7fed37817f124936239197833469f1b9a8` (matches CI's `vcpkgGitCommitId`); `builtin-baseline` is required by the abseil `version>=` constraint. OpenSSL is an **unconditional** dependency on every platform including Windows (`grpc.lib` has unresolved OpenSSL references; schannel was never wired — #375). Static libpq's closure (`libpgcommon`/`libpgport` + OpenSSL) is hand-wired in the meson `libpq_dep` block; on Windows libpq is a **DLL** (ADR-0008 Correction); `libpq_dep` is gated on `build_server`. The Windows grpc/protobuf/abseil static-link pairing (the `triplets/x64-windows.cmake` override **and** the hand-wired `find_library` construction) is load-bearing — **do not simplify either half** without reading `.codex/agents/build-ci.md` "Windows MSVC static-link history and #375".
+- **vcpkg** — manifest `vcpkg.json`, pinned baseline `4b77da7fed37817f124936239197833469f1b9a8` (matches CI's `vcpkgGitCommitId`); `builtin-baseline` is required by the abseil `version>=` constraint. OpenSSL is an **unconditional** dependency on every platform including Windows (`grpc.lib` has unresolved OpenSSL references; schannel was never wired — #375). Static libpq's closure (`libpgcommon`/`libpgport` + OpenSSL) is hand-wired in the meson `libpq_dep` block; on Windows libpq is a **DLL** (ADR-0008 Correction); `libpq_dep` is gated on `build_server`. The Windows grpc/protobuf/abseil static-link pairing (the `triplets/x64-windows.cmake` override **and** the hand-wired `find_library` construction) is load-bearing — **do not simplify either half** without reading `docs/windows-build.md` "Windows gRPC/protobuf linkage".
 
 ## Test
 
@@ -113,7 +113,7 @@ Domain docs: `CONTEXT.md` at the repo root, ADRs under `docs/adr/` (see `docs/ag
 
 ## Workflows
 
-- **Governance** — specialized review agents live in `.codex/agents/`; the `/governance` skill (`.codex/skills/governance/SKILL.md`) runs the 8-gate pipeline on a commit range (CRITICAL/HIGH findings block merge). Use `/governance <range>`, not hand-running — waves 1–4 shipped 4 CRITICAL command-injection vulns without it.
+- **Governance** — the `/governance` skill (`.codex/skills/governance/SKILL.md`) owns the reviewer prompts and runs the bounded 8-gate pipeline on a commit range. Security and docs review are mandatory; CRITICAL/HIGH findings block merge. Use `/governance <range>`, not hand-running — waves 1–4 shipped 4 CRITICAL command-injection vulns without it.
 - **Pre-commit/pre-push testing** — the `/test` skill (`.codex/skills/test/SKILL.md`): `--quick` (~10 min), default (~30–45 min), `--full` (~60–120 min). Results persist to `~/.local/share/yuzu/test-runs.db` (override with `YUZU_TEST_DB`); query via `scripts/test/test-db-query.sh`. CI runner test-DB topology and provisioning: `docs/ci-architecture.md`.
 - **CI** — three tiers: PR fast-path (`ci.yml`), push to dev/main (full matrix, no sanitizers/coverage per #410), nightly cron (`nightly.yml`, sanitizers + coverage; failure auto-opens `nightly-broken` — **no merge to main while that issue is open**). New workflows fire only once merged to main. Reference: `docs/ci-architecture.md`; cache rules: `.codex/skills/ci-cache/SKILL.md`.
 - **Release** — before tagging, bump the `${YUZU_VERSION:-X.Y.Z}` default in every tracked compose file and verify with `bash scripts/check-compose-versions.sh X.Y.Z`; the `release:` job runs that script first and fails after ~30–60 min of wasted matrix builds otherwise. New compose files must be added to the script's `FILES` array (opt-in, no auto-discovery).
@@ -140,7 +140,7 @@ Rows are discriminators — **trigger → what to read first → who loads it**.
 |---|---|---|
 | Authentication, RBAC, headers, tokens | `docs/auth-architecture.md` | `security-guardian` on auth/RBAC/crypto/header/token change |
 | PKI / internal CA | `docs/pki-architecture.md` | `security-guardian` + `cpp-safety` + `docs-writer` on `x509_ca.*`, `key_provider.*`, `secure_buffer.hpp`, `aes_gcm.hpp`, `pg/secret_codec.*`, `ca_store.*`, `agent_csr.*`, `ca_routes.*`, `/api/v1/ca/`, or any new `KeyProvider`/`KekProvider` subclass; `gateway-erlang` on gateway TLS config / `*_pb.erl` |
-| AuthDB invariants | `.codex/agents/authdb.md` | `authdb` agent on `auth_db.*` / `auth_routes.*` / `auth.*` change |
+| AuthDB invariants | `docs/auth-architecture.md` "AuthDB — persistent authentication store" | `authdb` reviewer on `auth_db.*` / `auth_routes.*` / `auth.*` change |
 | Enterprise A&A (OIDC, SAML, SCIM, MFA, AD/Entra) | `.codex/skills/auth-and-authz/SKILL.md` | invoke `/auth-and-authz` for any A&A planning, audit, or implementation work |
 | MCP server | `docs/mcp-server.md` | `security-guardian` on `/mcp/v1/`, `mcp_server.*`, `mcp_jsonrpc.hpp`, `mcp_policy.hpp` change |
 | Executions-history ladder | `docs/executions-history-ladder.md` | any change to `agent_service_impl.cpp` `cmd_execution_ids_`, `response_store` execution queries, `execution_event_bus.*`, `execution_tracker.*`, `rest_a4_envelope.*`, the `/api/v1/events` handler, MCP `execute_instruction`, or executions-drawer markup |
@@ -152,7 +152,7 @@ Rows are discriminators — **trigger → what to read first → who loads it**.
 | Instruction engine (YAML content plane) | `docs/Instruction-Engine.md` + `docs/yaml-dsl-spec.md` | any instruction-definition / DSL / content change |
 | Prometheus metrics, audit envelope, event format | `docs/observability-conventions.md` | `sre` and `architect` on any metrics/audit/event change |
 | Response data types, inventory analytics | `docs/data-architecture.md` | `architect` and `sre` when designing schemas |
-| User manual / YAML defs / REST API docs | `.codex/agents/docs-writer.md` | `docs-writer` on every change as part of governance gate 2 |
+| User manual / YAML defs / REST API docs | `.codex/skills/governance/references/reviewers.md` "docs-writer" | `docs-writer` on every change and on any remediated final baseline |
 | Guardian / Guaranteed State + DEX | `docs/yuzu-guardian-design-v1.1.md` (§9.1 schema, §24 invariants) + `docs/guardian-baseline-model.md` + `docs/dex-signal-catalog.md` + `docs/user-manual/guaranteed-state.md` + `docs/user-manual/dex.md` | `security-guardian` + `docs-writer` on any `guaranteed_state*`, `guardian_*`, `guard_*.{hpp,cpp}`, `dex_*`, `tar_proc_perf`, `/api/v1/dex/perf`, `__guard__`, or `__observation__` change |
 | TAR dashboard | `docs/tar-dashboard.md` + `docs/tar-implementer.md` + `docs/tar-module-loads.md` | `architect` on `/tar` or `/fragments/tar/...`; `plugin-developer` on the TAR action surface; `cross-platform` + `cpp-safety` on `tar_proc_{stream,etw,es}.*`; `cpp-safety` + `docs-writer` on `tar_db.cpp` or `canonical_source_enabled` |
 | Scope walking (result sets) | `docs/scope-walking-design.md` | `architect` + `dsl-engineer` on scope-engine/DSL/result-set change; `consistency-auditor` on the audit chain; `security-guardian` on cross-operator authz |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,46 +2,14 @@
 
 ## What is Yuzu?
 
-Yuzu is an agentic enterprise endpoint management platform — a single control plane where agentic colleagues can query, command, scan, patch, and enforce policy compliance on Windows, Linux, and macOS fleets in real time. Think of it as an open-source alternative to commercial endpoint management platforms, built from scratch in C++23.
-
-The project's goal is to match the full capability set of mature enterprise platforms (see `docs/capability-map.md`) while using modern architecture: gRPC/Protobuf transport, Prometheus-native metrics, **PostgreSQL as the server-side storage substrate with SQLite embedded on the agent** (ADR-0006 — see "Server storage substrate" in Routed concerns), and a plugin ABI that is stable across compiler versions.
-
-## Target Architecture
-
-```
-Operators (agentic AI, humans with a browser, REST API, automation scripts)
-    │
-    ▼
-Yuzu Server
-    ├── REST API (v1) — versioned, JSON, token or session auth
-    ├── HTMX Dashboard — server-rendered, dark theme (light theme is not supported and I will not be discussing it further)
-    ├── Instruction Engine — definitions, scheduling, approval workflows
-    ├── Policy Engine (Guaranteed State) — desired-state rules + triggers + auto-remediation
-    ├── Response Store (SQLite) — persistent, filterable, aggregatable
-    ├── Scope Engine — expression-tree device targeting (AND/OR/NOT, tags, OS, groups)
-    ├── RBAC — principals, roles, securable types, per-operation permissions
-    ├── Audit Log — who did what, when, on which devices
-    ├── Scheduler — cron-style recurring instructions
-    ├── Metrics — Prometheus /metrics endpoint
-    └── Management Groups — hierarchical device grouping for access scoping
-         │
-         │ gRPC / Protobuf / mTLS (bidirectional streaming)
-         │
-    Yuzu Agent (per endpoint)
-    ├── Plugin Host — dynamic .so/.dll loading via stable C ABI
-    ├── Trigger Engine — interval, file change, service status, event log, registry, startup
-    ├── KV Storage — SQLite-backed persistent storage for cross-instruction state
-    ├── Content Distribution — HTTP download with hash verification, stage-and-execute
-    ├── User Interaction — desktop notifications, questions, surveys (Windows)
-    └── Metrics — Prometheus-compatible, per-plugin counters
-```
+Yuzu is an agentic enterprise endpoint management platform — a single control plane where agentic colleagues can query, command, scan, patch, and enforce policy compliance on Windows, Linux, and macOS fleets in real time. An open-source alternative to commercial endpoint management platforms, built from scratch in C++23: gRPC/Protobuf transport, Prometheus-native metrics, **PostgreSQL server-side storage with SQLite embedded on the agent** (ADR-0006 — see the Postgres row in Routed concerns), and a compiler-stable plugin ABI. Architecture reference: `docs/architecture.md`; capability targets: `docs/capability-map.md`.
 
 ## Glossary — three meanings of "agent"
 
 The word **agent** is overloaded; the rest of this file relies on these definitions:
 
 - **Agent daemon** — the C++ binary in `agents/core/` that runs on each managed endpoint and executes plugins. The thing the rest of this codebase usually means by "agent".
-- **Governance agent** — the `.codex/agents/*.md` review actors run during the `/governance` pipeline. The thing the "Agent Team & Governance" section below describes.
+- **Governance agent** — the `.codex/agents/*.md` review actors run during the `/governance` pipeline.
 - **Agentic worker** — an external LLM-driven client (Claude, GPT, in-house) that drives Yuzu through MCP, REST, or the dashboard. The thing the agentic-first principle (`docs/agentic-first-principle.md`) is about.
 
 When in doubt in commit messages, PR descriptions, or new docs, use the disambiguated form.
@@ -56,127 +24,52 @@ Context is the scarce resource. Keep this thread lean; spend file-reading budget
 - **Summarise and hand off proactively** — don't wait for a context threshold. When a thread gets long, record: files touched, facts learned, open questions, next command — then continue from that summary.
 - **For code changes:** find the owning module → find its tests → make the smallest coherent patch → run the targeted suite (`meson test -C build-<os> --suite <agent|server|tar>`) before the broad one.
 
-## Agent Team & Governance
-
-Specialized agents live in `.codex/agents/` (each file declares its own role, triggers, and reference docs). The `workflow-orchestrator` agent owns the gate sequence; the `/governance` skill (`.codex/skills/governance/SKILL.md`) is the entry point for running the full pipeline on a commit range.
-
-Pipeline (8 gates, convention-enforced — no git hook): Change Summary + Resource Ledger (C++ resource changes) → security-guardian + docs-writer deep-dive → domain-triggered review (`cpp-expert` + `cpp-safety` on any C++ change; `cpp-safety` on raw resource/process/cast) → happy-path + unhappy-path + consistency-auditor (parallel) → chaos-injector (skipped if no findings) → compliance-officer + sre + enterprise-readiness (parallel) → findings addressed (CRITICAL/HIGH block merge) → iterate. Use `/governance <range>`, not hand-running — waves 1–4 shipped 4 CRITICAL command-injection vulns without it.
-
-## Darwin Compatibility
-
-This Codex instance is the designated **macOS/Darwin compatibility guardian**. The `cross-platform` agent loads `docs/darwin-compat.md` on any change that may affect macOS — that doc holds the standing reconciliation workflow (fetch → pull → diff → reconfigure → compile → `bash scripts/run-tests.sh all` → commit) and the standing pitfalls table (`/var` symlink, SQLite mutex, `rebar3 ct --dir`, `curl -f`, `prometheus_httpd`).
-
-## Erlang Gateway Build & Quality
-
-Touching `gateway/` or any `*.erl` file? **Read `docs/erlang-gateway-build.md` first.** It holds the build/verify commands, toolchain activation (`source scripts/ensure-erlang.sh`), the always-run-dialyzer rule, the mandatory-`--dir`/#337 and eunit-isolation/#336 gotchas, and the standing pitfalls table (`ctx` dep, `-spec` contracts, circuit-breaker dead code, benign `gpb` warning, stray `.beam`, shutdown flush). The `gateway-erlang` agent loads it automatically on any `gateway/`/`.erl` change; use the `/gateway-eunit` and `/gateway-dialyzer` skills for routine runs.
-
-## UAT Environment (Server ↔ Gateway ↔ Agent)
-
-Standing up or debugging the stack? **Read `docs/uat-environment.md` first.** It covers the three mutually-exclusive rigs (`scripts/start-UAT.sh` native; `scripts/start-viz-uat.sh` containerised viz; `scripts/start-demo.sh` release-pinned Cedar & Vale sales demo — full runbook in `docs/demo-environment.md`), the port-assignment table, and gateway command forwarding (the `--gateway-upstream` / `--gateway-mode` / `--gateway-command-addr` flags, `--trusted-nat-cidr`, and the `agent_registry.cpp` `send_to()` dispatch flow). All three rigs bind host ports 8080 + 50051, so only one runs at a time. The `release-deploy` agent loads the doc on any compose / UAT-script change.
-
-## Pre-commit testing with /test
-
-The `/test` skill (`.codex/skills/test/SKILL.md`) is the single-command pre-commit/pre-push gate — compiles HEAD, upgrades from the previous release image, runs the standard test surface, persists every gate result and sub-step timing to a SQLite test-runs DB at `~/.local/share/yuzu/test-runs.db` (XDG dir, survives `git clean`; override with `YUZU_TEST_DB=path`). Three modes: `--quick` (~10 min sanity), default (~30–45 min), `--full` (~60–120 min — adds OTA, dispatched sanitizers, coverage enforcement, perf measure-and-report). Query history via `bash scripts/test/test-db-query.sh --latest|--last N|--diff A B|--trend ...|--flaky`. Coverage baseline (`tests/coverage-baseline.json`) and perf calibration (`docs/perf-baseline-calibration-2026-05-03.md`) details live in the skill — perf is measure-only as of 2026-05-03 (no σ band, ceiling-bounded distributions).
-
-CI history is separate from the developer-local DB: every Big Tam and Wee Tam runner agent owns a persistent `test-runs.db` outside its checkout (never one shared host-wide SQLite file). Big Tam uses `/srv/ci/work-N/_tool/yuzu-test-runs/yuzu-bigtam-linux-N/test-runs.db`; Wee Tam uses `D:\ci\test-runs\yuzu-weetam-windows-N\test-runs.db`. `ci.yml` records job and Meson test-entry outcomes/timings plus recovered known flakes. Query with `test-db-query.sh ci-stats|ci-suite-stats|ci-flakes`; provisioning and the full contract live in `docs/ci-architecture.md`.
-
-## Instruction Engine
-
-The content plane: YAML-defined `InstructionDefinition` → `InstructionSet` → `ProductPack`, executed via the `CommandRequest` wire protocol; `yaml_source` is authoritative, denormalized columns are for queries. Architecture: `docs/Instruction-Engine.md`; DSL spec: `docs/yaml-dsl-spec.md`; tutorial: `docs/getting-started.md`.
-
-**Build-time gotcha:** PyYAML is a **hard build dependency** — `meson setup` fails the configure step without it. Shipped content is build-time embedded (`embed_content.py` → `bundled_content.cpp`, seeded into `instructions.db` on first boot); the runtime never reads YAML from disk — there is no `--content-dir` flag. Details + rationale: `docs/Instruction-Engine.md` "Build-time content embedding".
-
-The **executions-history ladder** (PR 2/3 `execution_id` correlation + SSE) carries a stack of invariants every successor PR must check — see `docs/executions-history-ladder.md` (also in Routed concerns below).
-
-## Enterprise Readiness and SOC 2
-
-The path from feature-complete to enterprise-deployable is scoped in `docs/enterprise-readiness-soc2-first-customer.md` across 7 workstreams (A GRC, B Identity, C AppSec, D Reliability, E Data, F Secure SDLC, G Customer Assurance). Every code change is evaluated against this plan by the compliance-officer, sre, and enterprise-readiness agents during Gate 6 of the governance pipeline.
-
-## Development Roadmap
-
-Roadmap: `docs/roadmap.md`. Capability map: `docs/capability-map.md`. Headline progress figure in the capability map is overstated — treat with skepticism (see memory `project_capability_map_accuracy.md`). When working on an issue, check the roadmap for dependencies and the capability map for target context.
-
 ## Build
 
 Meson is the sole build system. **Every time you add, remove, or rename a source file, update `meson.build` in the affected directory** and verify the build compiles.
 
-### Prerequisites
-- Meson 1.11.1, Ninja
-- CMake (required by Meson's cmake dependency method — not used as a build system)
-- C++23 compiler: GCC 13+, Clang 18+, MSVC 19.38+, or Apple Clang 15+
-- vcpkg (set `VCPKG_ROOT`)
-- **Linux:** `bison`, `flex` — vcpkg's libpq port (Postgres substrate, ADR-0006) builds
-  postgresql from source and cannot auto-acquire them on Linux (`sudo apt-get install -y
-  bison flex`)
-- **macOS:** `autoconf`, `automake`, `libtool` — same libpq port runs autoreconf
-  (`brew install autoconf automake libtool`)
-- **Windows:** no new packages — vcpkg auto-acquires winflexbison
+Prerequisites: Meson 1.11.1, Ninja, CMake (required by Meson's cmake dependency method — not a build system here), a C++23 compiler (GCC 13+, Clang 18+, MSVC 19.38+, or Apple Clang 15+), vcpkg (set `VCPKG_ROOT`), and **PyYAML** (hard configure-time dependency — `meson setup` fails without it). Linux also needs `bison flex`; macOS needs `autoconf automake libtool` (vcpkg's libpq port builds postgres from source); Windows needs nothing new (vcpkg auto-acquires winflexbison).
 
-### Quick start (setup script)
 ```bash
 ./scripts/setup.sh                              # debug build, default compiler
 ./scripts/setup.sh --buildtype release --lto    # release + LTO
 ./scripts/setup.sh --tests                      # enable tests
-./scripts/setup.sh --native-file meson/native/linux-gcc13.ini
-./scripts/setup.sh --cross-file meson/cross/aarch64-linux-gnu.ini
+./scripts/setup.sh --native-file meson/native/linux-gcc13.ini       # CI compiler selection
+./scripts/setup.sh --cross-file meson/cross/aarch64-linux-gnu.ini   # cross-compile
 ```
-The script runs `vcpkg install` then `meson setup` automatically.
+The script runs `vcpkg install` then `meson setup` automatically. Cross files live in `meson/cross/`, native files in `meson/native/`.
 
-### Manual configure
+Manual configure (when not using setup.sh):
 ```bash
-# 1. Install vcpkg packages
 vcpkg install --triplet x64-linux --x-manifest-root=.
-
-# 2. Configure (use the per-OS canonical name — see "Per-OS build directory convention" below)
 meson setup build-linux \
   --buildtype=debug \
   -Dcmake_prefix_path=$VCPKG_ROOT/installed/x64-linux \
   -Dbuild_tests=true
-
-# 3. Build
 meson compile -C build-linux
 ```
 
-### Build options
 | Option | Default | Notes |
 |---|---|---|
-| `-Dbuild_agent` | true | Agent daemon |
-| `-Dbuild_server` | true | Server daemon |
-| `-Dbuild_tests` | false | Catch2 test suite |
-| `-Dbuild_examples` | true | Example plugins |
+| `-Dbuild_agent` / `-Dbuild_server` / `-Dbuild_examples` | true | Components |
+| `-Dbuild_tests` | false | Catch2 suite — vcpkg installs Catch2 on `x64 \| arm64` only; the ARM64 cross-compile CI job skips tests |
 | `-Db_lto` | false | Link-time optimisation |
-| `-Db_sanitize=address,undefined` | none | AddressSanitizer + UBSan |
-| `-Db_sanitize=thread` | none | ThreadSanitizer |
-
-Sanitizers and LTO use Meson built-in options (`b_lto`, `b_sanitize`).
+| `-Db_sanitize=address,undefined` / `-Db_sanitize=thread` | none | ASan+UBSan / TSan |
 
 ### Per-OS build directory convention
 
-Same source tree is built from multiple hosts (WSL2 + native Windows on the same box, plus a separate macOS); per-OS dirs prevent clobbering:
+The same source tree is built from multiple hosts; per-OS dirs prevent clobbering: `build-linux`, `build-windows`, `build-macos`. Use `scripts/setup.sh` (auto-picks the dir) or pass `-C build-<os>`. If setup.sh finds a dir whose recorded source path looks like another host's, it refuses to reconfigure unless `--wipe` — prevents opaque ninja "dyndep is not an input"/Windows-path failures when a Windows builddir is reused under WSL2. setup.sh never auto-wipes; it defaults to `--reconfigure`.
 
-| Host    | Build dir       |
-|---------|-----------------|
-| Linux   | `build-linux`   |
-| Windows | `build-windows` |
-| macOS   | `build-macos`   |
+### Build landmines
 
-Use `scripts/setup.sh` (auto-picks the dir) or pass `-C build-<os>` to `meson compile`/`meson test`. If setup.sh finds a dir whose recorded source path looks like another host's, it refuses to reconfigure unless `--wipe` — prevents opaque ninja "dyndep is not an input"/Windows-path failures when a Windows builddir is reused under WSL2. `setup.sh` no longer auto-wipes; defaults to `--reconfigure`.
-
-### Windows build
-
-`docs/windows-build.md` is the source of truth — MSYS2 bash sequence, the `setup_msvc_env.sh` + `scripts/ensure-erlang.sh` activation pair, full path inventory, and the two hard rules: **never use `vcvars64.bat`** (extension exit-1 corrupts wrappers) and **never Clang from `C:\Program Files\LLVM\bin`** (must be cl.exe/MSVC). `cross-platform` and `build-ci` agents load this on any Windows-touching change.
-
-**Provisioning a native Windows CI runner** is codified in `deploy/windows/` (the analog of `deploy/docker/Dockerfile.ci-linux`): a versioned provisioning spec, a `toolchain-manifest.json`, a runner self-test, and the CCD-pin wrapper. The gateway build resolves its toolchain from `YUZU_ESCRIPT`/`YUZU_REBAR3` (no hardcoded host paths — `scripts/build_gateway.py`), and the 4 CCD-pinned runners share one vcpkg binary cache via `RUNNER_TOOL_CACHE`. See `deploy/windows/README.md`.
-
-### Cross-compilation
-```bash
-./scripts/setup.sh --cross-file meson/cross/aarch64-linux-gnu.ini
-```
-Cross files live in `meson/cross/`. Native files for CI compiler selection live in `meson/native/`.
+- **Shipped content is build-time embedded** (`embed_content.py` → `bundled_content.cpp`, seeded into `instructions.db` on first boot). The runtime never reads YAML from disk — **there is no `--content-dir` flag**. Rationale: `docs/Instruction-Engine.md` "Build-time content embedding".
+- **Every `dependency()` in meson files is marked `include_type: 'system'`** so vcpkg/gRPC/abseil/protobuf/Catch2 warnings are silenced while our code stays at `warning_level=3`. Do not remove it when adding dependencies.
+- **Windows build: never `vcvars64.bat`** (extension exit-1 corrupts wrappers) and **never Clang from `C:\Program Files\LLVM\bin`** (must be cl.exe/MSVC). Source of truth: `docs/windows-build.md`.
+- **vcpkg** — manifest `vcpkg.json`, pinned baseline `4b77da7fed37817f124936239197833469f1b9a8` (matches CI's `vcpkgGitCommitId`); `builtin-baseline` is required by the abseil `version>=` constraint. OpenSSL is an **unconditional** dependency on every platform including Windows (`grpc.lib` has unresolved OpenSSL references; schannel was never wired — #375). Static libpq's closure (`libpgcommon`/`libpgport` + OpenSSL) is hand-wired in the meson `libpq_dep` block; on Windows libpq is a **DLL** (ADR-0008 Correction); `libpq_dep` is gated on `build_server`. The Windows grpc/protobuf/abseil static-link pairing (the `triplets/x64-windows.cmake` override **and** the hand-wired `find_library` construction) is load-bearing — **do not simplify either half** without reading `.codex/agents/build-ci.md` "Windows MSVC static-link history and #375".
 
 ## Test
 
-Every test target carries a short `suite:` label (`agent`, `tar`, `server`) so `--suite <name>` filters directly — no more guessing `"yuzu:server unit tests"`:
+Every test target carries a short `suite:` label (`agent`, `tar`, `server`) so `--suite <name>` filters directly:
 
 ```bash
 meson test -C build-linux --suite server --print-errorlogs
@@ -185,11 +78,7 @@ meson test -C build-linux --suite tar --print-errorlogs
 meson test -C build-linux --print-errorlogs              # everything
 ```
 
-Tests require `-Dbuild_tests=true`. The Catch2 dependency is only installed by vcpkg on `x64 | arm64` platforms. The ARM64 cross-compile CI job intentionally skips tests.
-
-### Direct binary invocation
-
-For Catch2 tag filtering (`[rest][token]`, `[mgmt][cycle]`, etc.) or when you want raw output, call the test binary directly. `scripts/link-tests.sh` maintains symlinks at a stable top-level path per component and triplet so you never have to remember the build-dir layout:
+Tests require `-Dbuild_tests=true`. For Catch2 tag filtering (`[rest][token]`, `[mgmt][cycle]`) or raw output, call the binaries directly — `scripts/link-tests.sh` (run automatically at the end of setup.sh) maintains stable symlinks per component and triplet (`linux_x64`, `linux_arm64`, `macos_arm64`, `windows_x64`):
 
 ```bash
 tests-build-server-linux_x64/yuzu_server_tests "[rest][token]"
@@ -197,13 +86,13 @@ tests-build-agent-linux_x64/yuzu_agent_tests "[metrics]"
 tests-build-tar-linux_x64/yuzu_tar_tests
 ```
 
-The symlinks are created automatically at the end of `scripts/setup.sh`. If you build from a fresh checkout with plain `meson setup`, run `bash scripts/link-tests.sh` once after the first successful `meson compile` to populate them. Triplet suffix is derived from the host (`linux_x64`, `linux_arm64`, `macos_arm64`, `windows_x64`). Binaries stay live because the symlinks point at the real build output — no need to re-run the script after every rebuild.
-
 `tests-build-*/` is gitignored.
 
-### Third-party warning suppression
+### Test conventions — shared helpers
 
-Every `dependency()` in `meson.build` and subdirectory files is marked `include_type: 'system'` so vcpkg / gRPC / abseil / protobuf / Catch2 deprecation warnings are treated as `-isystem` and silenced. Our own code is still under `warning_level=3`. **Do not remove `include_type: 'system'`** when adding new dependencies — it's load-bearing for build-log readability.
+- Temp files and SQLite DBs: `yuzu::test::unique_temp_path(prefix)` / `yuzu::test::TempDbFile` from `tests/unit/test_helpers.hpp`. **Never** salt uniqueness with `std::hash<std::thread::id>` or `std::chrono::steady_clock` — silent collisions under Defender-induced I/O serialisation on `yuzu-local-windows` (flake #473; rationale in the header comment + #482).
+- Live `ExecutionTracker` wired into `AgentServiceImpl`: the `TrackerScope` RAII helper in `tests/unit/server/test_agent_service_impl.cpp` — `GatewayResponseHarness h; TrackerScope ts{h.svc}; auto exec_id = ts.make_exec();`.
+- Live **PostgreSQL**: `PostgresTestDb` + the `YUZU_REQUIRE_PG_DB(var)` macro from `tests/unit/test_helpers.hpp`. Skip-vs-fail contract: `YUZU_TEST_POSTGRES_DSN` **unset** → test skips cleanly; **set but broken** → test FAILS. Local instance: `docker run -d -e POSTGRES_USER=yuzu -e POSTGRES_PASSWORD=yuzu -e POSTGRES_DB=yuzu -p 5433:5432 postgres:18` then `export YUZU_TEST_POSTGRES_DSN=postgresql://yuzu:yuzu@localhost:5433/yuzu`.
 
 ## Project layout
 
@@ -218,106 +107,68 @@ tests/unit/       Catch2 unit tests
 docs/             Architecture docs, conventions, roadmap, capability map
 ```
 
-`proto/meson.build` invokes `proto/gen_proto.py` which runs `protoc` and rewrites `#include` paths to flatten subdirectory prefixes — generated headers ship as `"common.pb.h"` rather than `"yuzu/common/v1/common.pb.h"`. Result is the `yuzu_proto` static library, exposed via `yuzu_proto_dep`. The `build-ci` agent owns this codegen flow.
+`proto/meson.build` invokes `proto/gen_proto.py`, which runs `protoc` and rewrites `#include` paths to flatten subdirectory prefixes — generated headers ship as `"common.pb.h"` rather than `"yuzu/common/v1/common.pb.h"`; the result is the `yuzu_proto` static library, exposed via `yuzu_proto_dep` (owned by `build-ci`).
 
-## vcpkg
-- Manifest: `vcpkg.json`. Pinned baseline: `4b77da7fed37817f124936239197833469f1b9a8` (matches `vcpkgGitCommitId` in CI).
-- `builtin-baseline` is required because of the `version>=` constraint on abseil. Without it vcpkg resolves against HEAD.
-- OpenSSL is a **required dependency on every platform including Windows**. vcpkg's gRPC port compiles its TLS / JWT / PEM code paths against OpenSSL headers regardless of linkage mode, so `grpc.lib` has unresolved references to `BIO_*`, `EVP_*`, `PEM_*`, `X509_*`, `OPENSSL_sk_*` that must be satisfied by `libssl.lib` + `libcrypto.lib` at final link time. A previous iteration of `vcpkg.json` marked openssl `"platform": "!windows"` with a comment that gRPC would use schannel — that was aspirational, never actually wired up, and confirmed wrong by the #375 option D canary's LNK2019 errors. The comment and platform filter have been removed; openssl is an unconditional top-level dep.
-- `catch2` is platform-filtered to `x64 | arm64` (not 32-bit ARM).
-- **libpq (Postgres substrate, ADR-0006/0008): no cmake target carries static libpq's full closure.** `libpgcommon`/`libpgport` (scram/auth helpers) and OpenSSL appear only in `libpq.pc`'s `Libs.private`, so the meson `libpq_dep` block wires them explicitly (unix: cmake `FindPostgreSQL` + `find_library`; Windows: hand-wired per the #375 pattern below). On Windows libpq is a **DLL** (the triplet's static override covers the grpc stack only) and ships via the release zip's vcpkg-DLL sweep — see the ADR-0008 Correction (2026-06-10). `libpq_dep` is gated on `build_server` (the agent stays SQLite). Manifest pins `default-features: false, features: [openssl]`. Pure-C libpq carries no MSVC `detect_mismatch` records, so a wrong-CRT lib pick links silently — the buildtype-conditional `_vcpkg_lib_win` selection is load-bearing. Cold vcpkg builds need bison/flex (Linux) and autotools (macOS) — see Prerequisites.
-- **Windows grpc/protobuf/abseil is load-bearing — both halves.** The `triplets/x64-windows.cmake` static-linkage override AND `meson.build`'s Windows-specific `cxx.find_library()` hand-wired `protobuf_dep`/`grpcpp_dep` construction are the **only configuration we've found** that simultaneously avoids LNK2038 (meson cmake-dep bug) and LNK2005 (abseil DLL symbol conflicts). Do not simplify either half without reading `.codex/agents/build-ci.md` "Windows MSVC static-link history and #375" — full timeline, every failed approach, and the #376 strategic escape (migrate off gRPC to QUIC) are there. Linux/macOS are unaffected.
+Domain docs: `CONTEXT.md` at the repo root, ADRs under `docs/adr/` (see `docs/agents/domain.md`).
 
-## CI architecture
+## Workflows
 
-Three-tier split (April 2026): Tier 1 PR fast-path (`ci.yml`, one Linux + one Windows + one macOS + `proto-compat`, <10 min), Tier 2 push to dev/main (full matrix, no sanitizers/coverage per #410), Tier 3 nightly cron (`nightly.yml`, sanitizers + coverage on Linux self-hosted — failure auto-opens `nightly-broken`; **no merge to main while that issue is open**). Full reference (cache contract, runner topology, persistence, canary, corruption recovery): `docs/ci-architecture.md`. `workflow_dispatch` and cron only fire once the workflow file is on `main` — new workflows added on `dev` are dormant until merged. `build-ci` owns the matrix; `cross-platform` owns Windows/macOS specifics.
+- **Governance** — specialized review agents live in `.codex/agents/`; the `/governance` skill (`.codex/skills/governance/SKILL.md`) runs the 8-gate pipeline on a commit range (CRITICAL/HIGH findings block merge). Use `/governance <range>`, not hand-running — waves 1–4 shipped 4 CRITICAL command-injection vulns without it.
+- **Pre-commit/pre-push testing** — the `/test` skill (`.codex/skills/test/SKILL.md`): `--quick` (~10 min), default (~30–45 min), `--full` (~60–120 min). Results persist to `~/.local/share/yuzu/test-runs.db` (override with `YUZU_TEST_DB`); query via `scripts/test/test-db-query.sh`. CI runner test-DB topology and provisioning: `docs/ci-architecture.md`.
+- **CI** — three tiers: PR fast-path (`ci.yml`), push to dev/main (full matrix, no sanitizers/coverage per #410), nightly cron (`nightly.yml`, sanitizers + coverage; failure auto-opens `nightly-broken` — **no merge to main while that issue is open**). New workflows fire only once merged to main. Reference: `docs/ci-architecture.md`; cache rules: `.codex/skills/ci-cache/SKILL.md`.
+- **Release** — before tagging, bump the `${YUZU_VERSION:-X.Y.Z}` default in every tracked compose file and verify with `bash scripts/check-compose-versions.sh X.Y.Z`; the `release:` job runs that script first and fails after ~30–60 min of wasted matrix builds otherwise. New compose files must be added to the script's `FILES` array (opt-in, no auto-discovery).
+- **Planning** — roadmap `docs/roadmap.md`; capability map `docs/capability-map.md` (headline progress figure is overstated — treat with skepticism). Enterprise/SOC 2 plan: `docs/enterprise-readiness-soc2-first-customer.md` (evaluated at governance Gate 6). Issues at `github.com/Tr3kkR/Yuzu` via `gh` — see `docs/agents/issue-tracker.md` and `docs/agents/triage-labels.md`.
 
-## Release workflow gates
+## Product UI conventions
 
-The `release:` job in `.github/workflows/release.yml` runs `scripts/check-compose-versions.sh` as its **first step**, before any artifact download. The script walks an explicit list of tracked compose files (including `docker-compose.demo.yml`) and rejects any `ghcr.io/<owner>/yuzu-{server,gateway,agent}(-chisel)?:X.Y.Z` reference that is (a) a bare numeric tag rather than `${YUZU_VERSION:-...}`, or (b) a parameterised default that does not equal the tag being released (`${GITHUB_REF_NAME#v}`). The `-chisel` repo suffix is recognised; floating tags (`latest`, `local`, sha-pinned) are ignored. Passing explicit file paths after the version overrides the tracked list (used by `tests/shell/test_check_compose_versions.sh`).
+The operator dashboard is HTMX-first, server-rendered, and **dark-theme-only** (`server/core/src/*_ui.cpp`, `server/core/static/*`). **Never use htmx `hx-on`**: the dashboard CSP is `script-src 'self' 'unsafe-inline'` (no `unsafe-eval`), and htmx compiles `hx-on:*` handlers with `new Function()` — CSP blocks them and the handler **silently does nothing**. Use a plain inline `onclick`/`oninput` calling a JS helper, or a `document.body.addEventListener('htmx:afterSettle', …)` listener. htmx core attrs (`hx-get`/`hx-post`/`hx-target`/`hx-swap`/`hx-trigger`/`hx-swap-oob`, the `HX-Trigger` header) are fine. Verify button-driven JS by clicking it in a headless browser and checking for a CSP `pageerror`, not just that the page renders.
 
-**Before tagging a release**, bump the `${YUZU_VERSION:-X.Y.Z}` default in every tracked compose file to the new version and verify locally:
+The `frontend-design` plugin is scoped to **marketing / sales / demo surfaces only** (the Cedar & Vale deck at `deploy/docker/cedar-vale/app/`). Never use it on product UI — and the in-product fleet visualization (`viz_page_ui.cpp`, `yuzu-viz*.js`, governed by `docs/fleet-viz-invariants.md`) **is product**, despite the name.
 
-```bash
-bash scripts/check-compose-versions.sh 0.12.0
-```
+## Cross-cutting landmines
 
-The release job will otherwise fail after all build matrix jobs have run, wasting ~30–60 min of runner time without publishing anything. When adding a new compose file to the repo, also add it to the `FILES` array at the top of `scripts/check-compose-versions.sh` — auto-discovery is deliberately off so opt-in is explicit.
+Rules with no single owning routed doc — read before touching the named area:
+
+- **SQLite `sqlite3_changes()` after `sqlite3_step()` on a shared FULLMUTEX connection is a data race** — it reads `db->nChange` without the per-connection mutex and races any concurrent `step()`. Use `RETURNING` on the statement itself, or wrap the pair under `sqlite3_db_mutex` when a count is genuinely needed. Issue #1033 tracks the remaining legacy sites; until it closes, every new or modified store must use one of the two correct idioms.
+- **Secrets are never a plain column** in a server store — verify-only hashes or AES-256-GCM envelope blobs via `SecretCodec` (KEK behind `KekProvider`), per ADR-0010.
 
 ## Routed concerns (read the doc, not this file)
 
-| Concern | Doc | Loaded by |
+Rows are discriminators — **trigger → what to read first → who loads it**. The invariants live in the target docs, not in this table.
+
+| Concern | Read first | Loaded by / trigger |
 |---|---|---|
-| Authentication, RBAC, headers, tokens, self-target principal-destruction guard (#397/#403) | `docs/auth-architecture.md` | `security-guardian` on auth/RBAC/crypto/header/token change |
-| PKI / internal CA — the CA root **private key is never in `ca.db`** (`CaStore` holds cert metadata + CRL versions + the opaque `key_ref` only); the key lives behind `KeyProvider` (`FileKeyProvider`, 0600 PEM). `key_ref` is opaque (pass to `load_key`, never parse); `revoke()` uses `RETURNING`, never `sqlite3_changes()` (#1033). The agent never links `x509_ca` — agent-side keygen+CSR is the self-contained `agent_csr.*`; `sign_csr` is the one guarded chokepoint (server-chosen subject/SAN/EKU, CSR's ignored). Default-cert bootstrap, per-agent mTLS, REST `/api/v1/ca/*`, gateway TLS (agent edge one-way; **mgmt listener strict-mTLS-only — one-way would leave it unauthenticated**), through-gateway issuance (`ProxyRegister` → same `sign_agent_csr`), and subordinate-CA are all WIRED (PR2–PR6). Shipped composes stay plaintext until the PR5b distribution flip — **do not internet-expose `:50051`**. Full PR ladder + threat model in the doc. | `docs/pki-architecture.md` | `security-guardian` + `cpp-safety` + `docs-writer` on any change to `x509_ca.{hpp,cpp}` / `key_provider.{hpp,cpp}` / `secure_buffer.hpp` / `aes_gcm.hpp` / `pg/secret_codec.{hpp,cpp}` (ADR-0010 secrets seam — also on any new `KeyProvider`/`KekProvider` subclass) / `ca_store.{hpp,cpp}` / `agent_csr.{hpp,cpp}` / `ca_routes.{hpp,cpp}` / `/api/v1/ca/`; `gateway-erlang` on `gateway/config/sys.config*` / gateway `*_pb.erl` / `yuzu_gw_app.erl` TLS |
-| AuthDB invariants — `auth.db` mode, migration, lifetime, seed-vs-live, role-field-ignored, gate audit, cleanup cadence, snapshot-and-release | `.codex/agents/authdb.md` | `authdb` agent on `auth_db.{hpp,cpp}` / `auth_routes.*` / `auth.{hpp,cpp}` change |
-| Enterprise A&A roadmap — RBAC, OIDC, SAML, SCIM, MFA, AD/Entra, API tokens, session lifecycle, audit | `.codex/skills/auth-and-authz/SKILL.md` | invoke `/auth-and-authz` for any A&A planning, audit, or implementation work |
-| MCP server architecture, tier-before-RBAC ordering, kill switches, audit pattern | `docs/mcp-server.md` | `security-guardian` on `/mcp/v1/`, `mcp_server.{hpp,cpp}`, `mcp_jsonrpc.hpp`, `mcp_policy.hpp` change |
-| Executions-history ladder — `command_id → execution_id` map, partial-index planner contract, SSE event bus, drawer data-attribute binding, two-consumer / one-bus / one-taxonomy invariant (sprint W5.1 second consumer `/api/v1/events`), `api.v1.events.subscribe` audit verb split, MCP `execute_instruction` as a tracked-execution producer (#1088) | `docs/executions-history-ladder.md` | any change to `agent_service_impl.cpp` `cmd_execution_ids_`, `response_store` execution queries, `execution_event_bus.*`, `execution_tracker.*`, `rest_a4_envelope.{hpp,cpp}`, the `/api/v1/events` handler in `rest_api_v1.cpp`, the `execute_instruction` handler in `mcp_server.cpp`, or executions-drawer markup |
-| Compliance evaluation pipeline — `PolicyEvaluator` background thread (10s cadence, 15s grace, interval ≥60s floor, default 3600s) drives the check→verdict→`PolicyStore::update_agent_status` path so authored policies actually evaluate (was dead code). Wired in `server.cpp` (hoisted shared `command_dispatch_fn`, `policy_eval_thread_`, joined before stores in `~ServerImpl`/`stop()`). Mints `polchk-*` correlation ids that `notify_exec_tracker` **skips** (no tracker row, no SSE — compliance is NOT in the executions drawer). Remediation is manual/operator-gated only. | `docs/user-manual/policy-engine.md` | `cpp-safety` + `docs-writer` on any change to `policy_evaluator.{hpp,cpp}`, the `PolicyStore` status writer, or the `polchk-` guard in `agent_service_impl.cpp` |
-| C++23 conventions, naming, headers, plugin ABI boundary | `docs/cpp-conventions.md` | `cpp-expert` on any C++ source change |
-| C++ resource ownership and lifetime — fd/HANDLE/SOCKET/`FILE*`/SQLite/OpenSSL/BCrypt/C-string/thread/callback/temp-path ownership, RAII/scope guards, `string_view`/`span` validity, casts, syscall/process boundaries, sanitizer coverage | `docs/cpp-conventions.md` | `cpp-safety` on any C++ source change; `security-guardian` also enforces the ownership proof during Gate 2 |
-| macOS workflow + Darwin pitfalls table | `docs/darwin-compat.md` | `cross-platform` on any macOS-affecting change |
-| Prometheus metrics, label set, audit envelope, event format | `docs/observability-conventions.md` | `sre` and `architect` on any metrics/audit/event change |
-| Response data types, audit envelope, inventory data for analytics | `docs/data-architecture.md` | `architect` and `sre` when designing schemas |
-| User manual / YAML defs / REST API / Substrate primitive registration | docs-writer agent (`.codex/agents/docs-writer.md`) | docs-writer on every change as part of governance gate 2 |
-| Guardian / Guaranteed State — real-time agent-side enforcement; reserved plugin name `__guard__` intercepted in `agent.cpp` before the plugin match loop; standing invariants §24 (Push-seed scope, `__guard__` defence-in-depth, gateway-safe wire payloads). **DEX ruleless observations** are the reserved `rule_id="__observation__"` + `event_type`=obs_type — the ruleless-ness IS the discriminator (no category field); privacy drops at the edge, per-type rate caps. Subsystems (each its own `.cpp`, see Loaded-by): `dex_signal_catalog`/`dex_observer`/`dex_event`, `dex_win_poll`, `dex_perf_breach`, server-side `dex_blast_radius` (N-device incident → `dex.blast_radius` webhook) + `dex_alert_router` (per-signal routing → `dex.signal`), and continuous perf telemetry (`tar_proc_perf` → `$ProcPerf_*`, `yuzu_fleet_perf_*` gauges). BRD coverage map `docs/dex-brd-coverage.md` is local-only — ask the operator if missing. | `docs/yuzu-guardian-design-v1.1.md` + `docs/yuzu-guardian-windows-implementation-plan.md` + `docs/dex-signal-catalog.md` + `docs/user-manual/dex.md` + `docs/adr/0013-attack-chain-correlation.md` | `security-guardian` + `docs-writer` on any `guaranteed_state*`, `guardian_*` (engine, routes, ingest, **push_builder**), `guard_*.{hpp,cpp}`, `dex_observer.*`, `dex_event.*`, `dex_signal_catalog.*`, `dex_win_poll.*`, `dex_linux_collector.*`, `dex_linux_proc.*`, `dex_linux_storage.*`, `dex_linux_journal.*`, `dex_perf_breach.*`, `dex_blast_radius.*`, `dex_alert_router.*`, `dex_routes.*`, `dex_perf_model.*`, `dex_perf_ui.*`, `dex_perf_rules.*`, `/api/v1/dex/perf`, `__guard__`, or `__observation__` change |
-| TAR dashboard — capture-source frames, scope-walking SQL, process-tree + DNS/ARP panels, URL structure, permissions. **Untrusted `tar.sql` operator SQL MUST go through `TarDatabase::execute_user_query`** (read-only connection + `sqlite3` authorizer allowlisting registry warehouse tables), never the trusted `execute_query` (#760/#631). Per-source enable/disable is a fail-closed tri-state via `canonical_source_enabled` (`true`/`false`/`errored`, never a bare `!= "false"`, #560); `TarDatabase::open` integrity-checks and quarantines a corrupt `tar.db` aside or fails closed (#559). Gap-free process capture is the cross-platform `ProcStreamCollector` interface (Windows ETW / macOS Endpoint Security, build+runtime-gated, **NOTIFY-only**, names-only) — implement that interface, never a parallel path. New capture source: the CORE pattern, not the perf/procperf/netqual tier pattern. ARP/DNS are ADR-0015 (opt-in, Windows-first). | `docs/tar-dashboard.md` + `docs/tar-implementer.md` + `docs/darwin-compat.md` | `architect` on `/tar` or `/fragments/tar/...` change; `plugin-developer` on TAR action surface; `cross-platform` + `cpp-safety` on `tar_proc_{stream,etw,es}.*`; `cpp-safety` + `docs-writer` on `tar_db.cpp` open/quarantine or `canonical_source_enabled`; `docs-writer` on dashboard nav |
-| Scope walking — composable scope from previous query results (Yuzu's product differentiator). Result-set primitive, `result_sets.db`, `from_result_set:<id>` Scope kind, REST/DSL surface, lineage, audit chain | `docs/scope-walking-design.md` | `architect` + `dsl-engineer` on scope-engine/DSL/result-set change; `consistency-auditor` on audit chain; `security-guardian` on cross-operator authz |
-| System architecture — cross-cutting design reference (Operator/Server/Agent/Gateway, REST/MCP/dashboard surfaces, plugin ABI boundary) | `docs/architecture.md` | `architect` on cross-cutting design changes |
-| Tag/scope DSL operator reference — `tag:X`, `props.X`, `ostype`, `hostname`, `arch`, `agent_version` resolution; recipes for asset tagging | `docs/asset-tagging-guide.md` | `dsl-engineer` on scope/tag-DSL changes; `architect` when a new scope kind is added |
-| Agentic-first invariants A1–A5 (dashboard parity, discovery, observability, error envelope, agentic context contract) — applies to every new MCP tool, REST route, dashboard fragment, or error site. A5 (exec-plan Decision 16, track 2g): every new/materially-changed MCP tool ships standard annotations (`destructiveHint` truthful vs tier), decision-grade description, bounded input schema, typed output schema, honest `retry_after_ms` — machine metadata, never prose-only. Shape contracts for the JSON SSE envelope and the A4 error envelope live in `server/core/src/rest_a4_envelope.hpp` and are reusable by future MCP / discovery surfaces. | `docs/agentic-first-principle.md` | `consistency-auditor` on every PR; `security-guardian` + `architect` on relevant surfaces; on any change to `rest_a4_envelope.{hpp,cpp}` or the `/api/v1/events` handler |
-| Enterprise-platform parity matrix — competitor capability comparison and gap analysis (complements `docs/capability-map.md`) | `docs/enterprise-parity-plan.md` | `architect` on capability-map / roadmap changes; `enterprise-readiness` agent during Gate 6 |
-| CI cache patterns — split `actions/cache/restore` + paired `actions/cache/save` for GHA-hosted; local `runner.tool_cache` for self-hosted; **never `save-always: true`** (zizmor guard enforces) | `.codex/skills/ci-cache/SKILL.md` | `build-ci` on any change touching `actions/cache@`, vcpkg cache scope, ccache scope, or self-hosted-runner cache wiring |
-| Agent privilege model — dedicated `_yuzu` / `yuzu` / `NT SERVICE\YuzuAgent` account, narrow `sudo NOPASSWD` entries (Linux/macOS) and LSA privileges (Windows), per-plugin privilege matrix, **production virtual-service-account vs dev local-user paths**, install scripts at `scripts/install-agent-user.{sh,ps1}` | `docs/agent-privilege-model.md` | `security-guardian` on any plugin shell-out / sudoers / setcap change; `cross-platform` on any change that gates a plugin behind a privileged command; `plugin-developer` when adding a new privileged plugin (the doc has the procedure) |
-| Fleet visualization (3D) — REST surface, page-shell, renderer, and process-layer invariants for the 11-PR `feat/viz-engine` ladder | `docs/fleet-viz-invariants.md` | `security-guardian` + `docs-writer` on any change to `viz_routes.{hpp,cpp}` / `fleet_topology_store.{hpp,cpp}` / `viz_page_ui.cpp` / `static/yuzu-viz.js` / `--viz-disable` / `Config::viz_disable` |
-| Network quality dashboard (`/network`) — MEASUREMENT-FIRST device/local-link health lens. `yuzu.net_retrans_pct` is an INTERVAL delta (recent-window loss smoothed over heartbeats), NOT a lifetime ratio; `yuzu.net_degraded` is RETIRED (parsed defensively for rolling upgrades, gauge absent-not-zero). Heartbeat `yuzu.net_*` facts → `yuzu_fleet_net_*` gauges via the SHARED `network_perf_rules.hpp` validators. The Windows retransmit MIB is whole-stack + measurement-first UNVALIDATED, so it is **WITHHELD from the `yuzu_fleet_net_retrans_pct` gauge** (server gate `retrans_gauge_eligible(os)`, Linux-only today, #1465) — it still shows on the page/REST, caveated. Net gauges carry an `os` label; **never alert on a cross-OS aggregate**. Agent `yuzu.net_*` keys MUST match `kNetTag*` (pinned by `static_assert`). | `docs/user-manual/network.md` | `security-guardian` + `docs-writer` on any change to `network_routes.{hpp,cpp}` / `network_perf_model.{hpp,cpp}` / `network_perf_rules.hpp` / `network_ui.cpp` / `net_quality_sampler.{hpp,cpp}` / `tar_netqual.hpp` / the `yuzu.net_*` heartbeat block / `yuzu_fleet_net_*` |
-| Device pages (`/devices` fleet list + `/device?id=` entity page) — SHARED device surface with Device info / DEX / Guardian lens tabs + a cross-cutting "Get live info" that dispatches read-only instructions NOW and polls the response store (`device.live.<kind>` verbs, allowlist in `resolve_live_kind`; `process_tree` joins live connections by PID via a second dispatch). Per-device behavioral/compliance PII gates `GuaranteedState:Read` (+ `Execution:Execute` for live probes) and audits per-kind. **All behavioural-PII access-audit funnels through `server/core/src/rest_audit.hpp` (#1647)**: REST is bool + fail-closed **503 + `Sec-Audit-Failed` serving NO PII** (#1549/#1585), dashboard/MCP set-and-proceed — any NEW such route MUST use this helper. Poll reads scoped at the store seam (`ResponsesFn` → `ResponseQuery{.agent_id}`, #1634); scoring is per-render, never fleet-wide. `sha256_file` is `YUZU_EXPORT`, 512 MiB cap. Inline JS is CSP-safe (`onclick`, never `hx-on`). | `docs/user-manual/device-management.md` | `security-guardian` + `docs-writer` on any change to `device_routes.{hpp,cpp}` / `device_ui.cpp` / `DeviceRoutes` / the `device.live.*` audit verbs / `processes/{list_hashed,list_tree}` / `network_config/arp` / the live-snapshot JS in `guardian_page_ui.cpp` / `rest_audit.hpp` |
-| OS capability matrix — per-capability × per-OS (Windows/Linux/macOS) snapshot of what the agent collects/enforces, each row citing its in-code source of truth (the Linux-only-network gap surprised us). Curated snapshot that **will drift**; durable fix = generate it from the machine-readable per-OS metadata (`tar_schema_registry` `OsSupportStatus`, guard support arrays, the DEX signal catalogue). When adding/changing a per-OS collector/guard/signal, record the other platforms' status here too. | `docs/os-capability-matrix.md` | `docs-writer` + `cross-platform` on any per-OS support change |
-| SQLite `sqlite3_changes()` after `sqlite3_step()` on a FULLMUTEX connection is a data race + correctness bug — `sqlite3_changes()` reads `db->nChange` without the per-connection mutex, so it races any concurrent `step()` on the same handle. FULLMUTEX serialises individual API calls but not the `step → changes` pair. **Use `RETURNING` on the statement itself** so the result is carried in the step return code; or for cases that genuinely need a count, wrap the pair under `sqlite3_db_mutex`. Issue #1033 tracks 24 live store sites still carrying this anti-pattern; until it is closed, every new or modified store must use one of the two correct idioms. | issue #1033 | `cpp-expert` and `architect` on any new `sqlite3_changes()` call site on a shared store connection |
-| **Server storage substrate — PostgreSQL** (since 2026-06-09; agent stays SQLite). New server stores default to Postgres and ALL existing server stores migrate incrementally — none stays SQLite, each behind its own per-store ADR (ADR-0006 Update). Boot **fails closed with no SQLite fallback** when `--postgres-dsn`/`YUZU_POSTGRES_DSN` is empty/unreachable (ADR-0007). **Secrets are never a plain column** — verify-only hashes or AES-256-GCM envelope blobs via `SecretCodec` (KEK behind `KekProvider`), ADR-0010; gated stores `auth`/`webhooks`/`offload_targets`/`runtime_config`. Schema name = `snake_case(FullClassName)` incl. the `Store` suffix (ADR-0008). Failure posture + one-pool lease discipline + cross-store query-owner seam = ADR-0012. Substrate (`pg/`: `PgConn`/`PgResult`/`PgTxn`, `PgPool`, `PgMigrationRunner`) + the flip SHIPPED (#1320 PR1/PR3). **In-flight #1368 (keep resident):** GUC `statement_timeout`/`lock_timeout`, TCP keepalives, connect circuit-breaker, `yuzu_pg_*` metrics, schema-drift guard, runner serialization via `pg_advisory_xact_lock`, store-name regex `[a-z_][a-z0-9_]{0,62}` excluding `public`/`information_schema`/`pg_`, libpq buffers freed only with `PQfreemem`/`PQconninfoFree`. BREAKING deploy change (compose/Dockerfile/systemd/UAT + CI Postgres). | `docs/adr/0012-server-postgres-store-contract.md` + `docs/postgres-store-playbook.md` + `docs/postgres-migration-ladder.md` + `docs/adr/0006-server-postgresql-substrate.md` + `docs/adr/0008-postgres-substrate-architecture.md` incl. its Correction (+ ADR-0004, its first instance; ADR-0010 for secrets-at-rest) | `architect` + `sre` on any server store/schema change; `build-ci` on CI Postgres service; `release-deploy` on deploy/compose; `security-guardian` on any secret-at-rest |
-
-## Guardian engine — stores
-
-Working on Guardian / Guaranteed State? **Read `docs/yuzu-guardian-design-v1.1.md` first** — §9.1 has the `guaranteed-state.db` / `GuaranteedStateStore` schema and §24 the standing invariants (`Push`-seed scope, `__guard__` defence-in-depth, gateway-safe wire payloads). Key facts: agent-side `guardian_engine.{hpp,cpp}` does two-phase startup (`start_local()` pre-network, `sync_with_server()` post-Register); KV namespace `__guardian__`; reserved plugin name `__guard__` intercepted in `agent.cpp` before the plugin match loop; proto `proto/yuzu/guardian/v1/guaranteed_state.proto` (package `yuzu.guardian.v1`, separate from `yuzu.agent.v1`). PR ladder: `docs/yuzu-guardian-windows-implementation-plan.md`. (Also in Routed concerns below.)
-
-**Second store — Baselines (`guardian-baselines.db` / `BaselineStore`, `server/core/src/baseline_store.{hpp,cpp}`).** A **Baseline** is the only deployable unit (M:N member Guards + an include/exclude management-group assignment + a draft/deployed lifecycle). The push fan-out and heartbeat reconcile gate on `BaselineStore::deployed_member_rule_ids()`, which sources the enforced set from each deployed Baseline's **`deployed_snapshot`** (the members captured at deploy), **not** the live member set — so editing a deployed Baseline's members only reaches agents after a Push-gated re-deploy rewrites the snapshot (this is the load-bearing invariant: it keeps "what is enforced" behind `Push`, not `Write`). New/modified SQLite transactions in the Guardian stores use the `SqliteTxn` + `SqliteStmt` RAII owners in `server/core/src/sqlite_raii.hpp` (ROLLBACK-unless-`commit()` + guaranteed `finalize`, so an exception between `BEGIN` and `COMMIT` can't wedge the shared connection). Operator-facing: `docs/user-manual/guaranteed-state.md`; model: `docs/guardian-baseline-model.md`.
-
-**Guard types & the enforce-safety gate.** Live guards: `registry` (`guard_registry`, Windows-only), `file` (`guard_file`, Windows-only), `service` (run-state — `service-running`/`service-stopped`). The `registry`/`file` guards are no-op off-Windows (`start()` returns false → never reads as armed). The **service guard is cross-platform via the `make_service_guard()` factory** (`guard_systemd.hpp`): Windows `ServiceGuard` (SCM `NotifyServiceStatusChange`, `guard_service`, PR5) or Linux `SystemdServiceGuard` (systemd sd-bus `ActiveState` watch, `guard_systemd`, **observe-only — enforce deferred to a polkit-gated PR**); no-op on other platforms. So "no-op off-Windows" now applies only to `registry`/`file`. The Linux guard maps systemd's richer `ActiveState` onto the published `{running, stopped}` tokens (`active`→running; `inactive`/`failed`/absent→stopped; `activating`/`deactivating`/`reloading`/`maintenance`→transitional, held) — **deliberately adding NO new schema token**, so the H2/G9 cross-check stays untouched. When Linux enforce lands it must EXTEND `dangerous_enforce_service_stop` with a Linux critical-unit denylist, never fork the gate. `dangerous_enforce_in_spec` (`guardian_rule_spec.cpp`) is the **single chokepoint** gating dangerous enforce-promotion at every path that can set `enforcement_mode` — create (`derive_rule_spec`), the metadata update (`rest_api_v1`), and the push backstop (`guardian_push_builder`, which *downgrades* to audit). (The dashboard mode-toggle is gone — `enforcement_mode` is immutable-after-creation in the Baseline redesign.) It denylists enforce-writes to persistence/privilege registry keys (H1) AND enforce-stops of security/critical-infra/self services. **Any new guard type with a dangerous enforce action must EXTEND `dangerous_enforce_in_spec`, never add a parallel gate.** Published schema enums (`guardian_schema_registry.cpp`) and the agent's per-type support arrays (`registry_support::kHives`, `service_support::kStates`) are bound by schema↔handler cross-check unit tests (H2/G9): add or remove a type in BOTH or neither.
-
-## Test conventions — shared helpers
-
-Use `yuzu::test::unique_temp_path(prefix)` / `yuzu::test::TempDbFile` from `tests/unit/test_helpers.hpp` for any test temp file or SQLite DB. **Never** salt uniqueness with `std::hash<std::thread::id>` or `std::chrono::steady_clock` — silent collisions under Defender-induced I/O serialisation on `yuzu-local-windows` (flake #473). Rationale and residual adoption: header comment + #482.
-
-For server tests that need a live `ExecutionTracker` wired into `AgentServiceImpl`, use the `TrackerScope` RAII helper in `tests/unit/server/test_agent_service_impl.cpp` — it opens a `:memory:` SQLite DB, constructs the tracker, calls `set_execution_tracker`, and nulls the borrowed pointer before the tracker destructs (matches the production shutdown contract at `agent_service_impl.hpp:113`). Pattern: `GatewayResponseHarness h; TrackerScope ts{h.svc}; auto exec_id = ts.make_exec();`. The `:memory:` choice deliberately sidesteps the `unique_temp_path` race for shutdown-ordered tests; promote to `test_helpers.hpp` once a second test file needs the pattern (tracked via the H-9 follow-up issue from PR #1068 governance).
-
-For server tests that need a live **PostgreSQL** connection, use `PostgresTestDb` + the `YUZU_REQUIRE_PG_DB(var)` macro from `tests/unit/test_helpers.hpp` (behind `YUZU_TEST_ENABLE_PG` — compiled only into the server suite, which links libpq). The fixture connects to `YUZU_TEST_POSTGRES_DSN`, creates an ephemeral `yuzu_test_<salt>_<n>` database, exposes `var.dsn()`, and drops it `WITH (FORCE)` on destruction. Skip-vs-fail contract: env **unset** → test skips cleanly (local dev); env **set but broken** → test FAILS (`scripts/ci/ensure-postgres.sh` guarantees a reachable instance on every CI server-test leg, `SOFT_EXIT=1`). Local Postgres: `docker run -d -e POSTGRES_USER=yuzu -e POSTGRES_PASSWORD=yuzu -e POSTGRES_DB=yuzu -p 5433:5432 postgres:18` then `export YUZU_TEST_POSTGRES_DSN=postgresql://yuzu:yuzu@localhost:5433/yuzu`.
-
-## Agent skills
-
-Per-repo configuration for the Matt Pocock engineering skills (`to-issues`, `triage`, `to-prd`, `improve-codebase-architecture`, `diagnose`, `tdd`, `zoom-out`, `grill-with-docs`). These are installed **user-global** (`~/.codex/skills/` → `~/.agents/skills/`), not committed to the repo, so they follow the operator rather than collaborators. Re-run `/setup-matt-pocock-skills` to change.
-
-### Plugin scope — `frontend-design` is marketing-only
-
-The `frontend-design` plugin (`frontend-design@claude-plugins-official`) is scoped to **marketing / sales / demo presentation surfaces only**. Its design ethos — bold, deliberately-varied aesthetics that "vary between light and dark themes" — is right for a standalone pitch surface and wrong for the product, which prizes consistency and is **dark-theme-only**.
-
-- **Use it on:** the Cedar & Vale sales deck at `deploy/docker/cedar-vale/app/` (standalone Node app — `deck.css`, `machine.js`, slide assets) and any future standalone marketing/landing page. These are presentation apps, not the product.
-- **Do NOT use it on:** the operator dashboard or any product UI — `server/core/src/*_ui.cpp`, `server/core/static/*`. This explicitly includes the **in-product fleet visualization** (`viz_page_ui.cpp`, `viz_host_page_ui.cpp`, `server/core/static/yuzu-viz*.js`, governed by `docs/fleet-viz-invariants.md`) — despite the name, it is product, not marketing. Product UI stays HTMX-first, server-rendered, dark-theme-only; follow the existing dashboard conventions, never `frontend-design`.
-
-**Product UI — no htmx `hx-on`.** The dashboard CSP is `script-src 'self' 'unsafe-inline'` (no `unsafe-eval`); htmx compiles `hx-on:*` handlers with `new Function()`, which CSP **blocks at runtime — the handler silently does nothing**. Use a plain inline `onclick`/`oninput` (allowed by `unsafe-inline`) calling a JS helper, or a `document.body.addEventListener('htmx:afterSettle', …)` body listener, instead. htmx core attrs (`hx-get`/`hx-post`/`hx-target`/`hx-swap`/`hx-trigger`/`hx-swap-oob`, the `HX-Trigger` response header) are fine — they don't eval. Verify button-driven JS by clicking it in a headless browser and checking for a CSP `pageerror`, not just that the page renders. See memory `project-dashboard-csp-no-hx-on.md`.
-
-### Issue tracker
-
-GitHub issues at `github.com/Tr3kkR/Yuzu` via the `gh` CLI. See `docs/agents/issue-tracker.md`.
-
-### Triage labels
-
-Canonical defaults (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) — all five now exist in the repo's label set, alongside a broader categorization set (`bug`, `security`, `P0`/`P1`/`P2`, `enhancement`, `documentation`, `reliability`, workstream-* and phase-* tags, etc.). See `docs/agents/triage-labels.md`.
-
-### Domain docs
-
-Single-context layout — `CONTEXT.md` at the repo root, ADRs under `docs/adr/`. See `docs/agents/domain.md`.
+| Authentication, RBAC, headers, tokens | `docs/auth-architecture.md` | `security-guardian` on auth/RBAC/crypto/header/token change |
+| PKI / internal CA | `docs/pki-architecture.md` | `security-guardian` + `cpp-safety` + `docs-writer` on `x509_ca.*`, `key_provider.*`, `secure_buffer.hpp`, `aes_gcm.hpp`, `pg/secret_codec.*`, `ca_store.*`, `agent_csr.*`, `ca_routes.*`, `/api/v1/ca/`, or any new `KeyProvider`/`KekProvider` subclass; `gateway-erlang` on gateway TLS config / `*_pb.erl` |
+| AuthDB invariants | `.codex/agents/authdb.md` | `authdb` agent on `auth_db.*` / `auth_routes.*` / `auth.*` change |
+| Enterprise A&A (OIDC, SAML, SCIM, MFA, AD/Entra) | `.codex/skills/auth-and-authz/SKILL.md` | invoke `/auth-and-authz` for any A&A planning, audit, or implementation work |
+| MCP server | `docs/mcp-server.md` | `security-guardian` on `/mcp/v1/`, `mcp_server.*`, `mcp_jsonrpc.hpp`, `mcp_policy.hpp` change |
+| Executions-history ladder | `docs/executions-history-ladder.md` | any change to `agent_service_impl.cpp` `cmd_execution_ids_`, `response_store` execution queries, `execution_event_bus.*`, `execution_tracker.*`, `rest_a4_envelope.*`, the `/api/v1/events` handler, MCP `execute_instruction`, or executions-drawer markup |
+| Compliance evaluation pipeline (`PolicyEvaluator`, `polchk-*`) | `docs/user-manual/policy-engine.md` | `cpp-safety` + `docs-writer` on `policy_evaluator.*`, the `PolicyStore` status writer, or the `polchk-` guard in `agent_service_impl.cpp` |
+| C++23 conventions, resource ownership, plugin ABI | `docs/cpp-conventions.md` | `cpp-expert` / `cpp-safety` on any C++ source change |
+| macOS/Darwin compatibility | `docs/darwin-compat.md` | `cross-platform` on any macOS-affecting change |
+| Erlang gateway build & quality | `docs/erlang-gateway-build.md` | `gateway-erlang` on any `gateway/` or `*.erl` change; `/gateway-eunit` and `/gateway-dialyzer` skills |
+| UAT rigs & demo environment | `docs/uat-environment.md` (+ `docs/demo-environment.md`) | `release-deploy` on any compose / UAT-script change |
+| Instruction engine (YAML content plane) | `docs/Instruction-Engine.md` + `docs/yaml-dsl-spec.md` | any instruction-definition / DSL / content change |
+| Prometheus metrics, audit envelope, event format | `docs/observability-conventions.md` | `sre` and `architect` on any metrics/audit/event change |
+| Response data types, inventory analytics | `docs/data-architecture.md` | `architect` and `sre` when designing schemas |
+| User manual / YAML defs / REST API docs | `.codex/agents/docs-writer.md` | `docs-writer` on every change as part of governance gate 2 |
+| Guardian / Guaranteed State + DEX | `docs/yuzu-guardian-design-v1.1.md` (§9.1 schema, §24 invariants) + `docs/guardian-baseline-model.md` + `docs/dex-signal-catalog.md` + `docs/user-manual/guaranteed-state.md` + `docs/user-manual/dex.md` | `security-guardian` + `docs-writer` on any `guaranteed_state*`, `guardian_*`, `guard_*.{hpp,cpp}`, `dex_*`, `tar_proc_perf`, `/api/v1/dex/perf`, `__guard__`, or `__observation__` change |
+| TAR dashboard | `docs/tar-dashboard.md` + `docs/tar-implementer.md` + `docs/tar-module-loads.md` | `architect` on `/tar` or `/fragments/tar/...`; `plugin-developer` on the TAR action surface; `cross-platform` + `cpp-safety` on `tar_proc_{stream,etw,es}.*`; `cpp-safety` + `docs-writer` on `tar_db.cpp` or `canonical_source_enabled` |
+| Scope walking (result sets) | `docs/scope-walking-design.md` | `architect` + `dsl-engineer` on scope-engine/DSL/result-set change; `consistency-auditor` on the audit chain; `security-guardian` on cross-operator authz |
+| System architecture | `docs/architecture.md` | `architect` on cross-cutting design changes |
+| Tag/scope DSL operators | `docs/asset-tagging-guide.md` | `dsl-engineer` on scope/tag-DSL changes; `architect` when a new scope kind is added |
+| Agentic-first invariants A1–A5 | `docs/agentic-first-principle.md` | `consistency-auditor` on every PR; `security-guardian` + `architect` on relevant surfaces; any change to `rest_a4_envelope.*` or the `/api/v1/events` handler |
+| Enterprise-platform parity matrix | `docs/enterprise-parity-plan.md` | `architect` on capability-map / roadmap changes; `enterprise-readiness` agent during Gate 6 |
+| Agent privilege model | `docs/agent-privilege-model.md` | `security-guardian` on any plugin shell-out / sudoers / setcap change; `cross-platform` on privilege-gated plugins; `plugin-developer` when adding a privileged plugin |
+| Fleet visualization (3D) | `docs/fleet-viz-invariants.md` | `security-guardian` + `docs-writer` on `viz_routes.*`, `fleet_topology_store.*`, `viz_page_ui.cpp`, `static/yuzu-viz*.js`, `--viz-disable` |
+| Network quality dashboard (`/network`) | `docs/user-manual/network.md` | `security-guardian` + `docs-writer` on `network_routes.*`, `network_perf_*`, `net_quality_sampler.*`, `tar_netqual.hpp`, the `yuzu.net_*` heartbeat block, `yuzu_fleet_net_*` |
+| Device pages (`/devices`, `/device?id=`) | `docs/user-manual/device-management.md` | `security-guardian` + `docs-writer` on `device_routes.*`, `device_ui.cpp`, `rest_audit.hpp`, the `device.live.*` verbs, `processes/{list_hashed,list_tree}`, or the live-snapshot JS |
+| OS capability matrix | `docs/os-capability-matrix.md` | `docs-writer` + `cross-platform` on any per-OS support change |
+| Server storage substrate (PostgreSQL) | `docs/adr/0012-server-postgres-store-contract.md` + `docs/postgres-store-playbook.md` + `docs/postgres-migration-ladder.md` + ADR-0006/0007/0008(+Correction)/0010 | `architect` + `sre` on any server store/schema change; `build-ci` on CI Postgres; `release-deploy` on deploy/compose; `security-guardian` on any secret-at-rest |
+| Windows build & CI runner provisioning | `docs/windows-build.md` + `deploy/windows/README.md` | `cross-platform` + `build-ci` on any Windows-touching change |
+| CI architecture & test-runs DBs | `docs/ci-architecture.md` | `build-ci` owns the matrix; `cross-platform` owns Windows/macOS specifics |
 
 ## AGENTS.md updates
 
-Architectural decisions, new stores, new plugin patterns, churning subsystems, and cross-cutting concerns belong here so future Codex sessions read them before touching code. Stable reference material that an agent already loads belongs in `docs/` with a one-line pointer here. See memory `feedback_claude_md_scope.md` for the heuristic — Build / Release stay resident because the work is unstable or local-host-specific; mature areas route to `docs/` with a short "read this first" statement once an agent/skill/hook carries the load (precedent: the Erlang gateway build/quality section moved to `docs/erlang-gateway-build.md`).
+This file is a **routing layer, not a reference manual**. Resident content is limited to: identity, glossary, context discipline, build/test commands, product-UI conventions, and the cross-cutting landmines. Everything else is a one-line routing row — a discriminator (trigger → doc), never a summary of the doc's content. When a routed area gains an invariant, write it in the target doc; touch the row only to add or tighten a trigger. Build/Test stay resident because the work is unstable or local-host-specific; mature areas route to `docs/` with a short "read this first" row once an agent/skill/hook carries the load (precedent: the Erlang gateway section moved to `docs/erlang-gateway-build.md`). See memory `feedback_claude_md_scope.md` for the heuristic.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ docs/             Architecture docs, conventions, roadmap, capability map
 
 `proto/meson.build` invokes `proto/gen_proto.py`, which runs `protoc` and rewrites `#include` paths to flatten subdirectory prefixes — generated headers ship as `"common.pb.h"` rather than `"yuzu/common/v1/common.pb.h"`; the result is the `yuzu_proto` static library, exposed via `yuzu_proto_dep` (owned by `build-ci`).
 
-Domain docs: `CONTEXT.md` at the repo root, ADRs under `docs/adr/` (see `docs/agents/domain.md`).
+Domain docs: `CONTEXT.md` at the repo root, ADRs under `docs/adr/` (see `docs/agents/domain.md`). **Numbering a new ADR:** the number space is author-namespaced — `0xxx` platform · `1xxx` Dave Rae · `2xxx` Fraser Jarvis · `3xxx` Alex Young · `4xxx` Andy Younie. Take the next free number **in your own block**, not the next free number overall. Two numbers currently host two accepted ADRs each (`0016`, `0031`), so cite those by filename rather than number. Full convention + collision table: `docs/adr/README.md`.
 
 ## Workflows
 

--- a/CODEX.md
+++ b/CODEX.md
@@ -17,8 +17,8 @@ Use repo-local Codex skills first. Start with the narrowest matching skill and c
 
 ## Operational Workflows
 
-- `/governance` may use Codex subagents because the slash command is an explicit request for delegated review. Keep review agents bounded, read-only, and role-specific. Store role prompts in `.codex/skills/governance/SKILL.md`; do not create `.codex/agents`.
-- C++ governance requires a Resource Ledger in Gate 1 plus `cpp-expert` and `cpp-safety` in Gate 3 for any C++ diff. The ledger names every new or modified raw resource, owner type, acquisition, release, transfer behavior, and failure cleanup. New manual cleanup in touched C++ code is blocking unless wrapped by RAII/scope guard or explicitly justified.
+- `/governance` may use Codex subagents because the slash command is an explicit request for delegated review. Keep reviewers bounded, read-only, and role-specific. The tracked prompts live in `.codex/skills/governance/references/reviewers.md`; do not depend on or create an ignored `.codex/agents` mirror.
+- C++ governance always runs `cpp-expert` and `cpp-safety`. Gate 1 records an ownership note only when the range adds a resource boundary or changes acquisition, transfer, release, callback, or thread lifetime. Prefer existing RAII owners and the smallest project-native fix; a concrete unsafe cleanup path blocks, not the mere presence of legacy manual cleanup.
 - `/test` is the high-level validation orchestrator. It may run long-lived scripts and must preserve `~/.local/share/yuzu/test-runs.db` behavior. Do not stop the native UAT stack at the end of default/full test runs unless the user explicitly asks.
 - `/tdd` and `/diagnose` should read `CONTEXT.md` and relevant ADRs before naming domain concepts or selecting a regression seam.
 - `/grill-with-docs` is the ADR-adjacent workflow. ADRs live in `docs/adr/` and are created lazily only for hard-to-reverse, surprising, real trade-off decisions.

--- a/docs/auth-architecture.md
+++ b/docs/auth-architecture.md
@@ -1970,8 +1970,27 @@ on-config-flush model that lost users on every restart (#618, #388, #527).
 Operator recovery: `docs/ops-runbooks/auth-db-recovery.md`. Security review
 record: `docs/security-reviews/authdb-2026-04-30.md`.
 
-The hard invariants for AuthDB-touching changes (file-mode, migration
-pattern, lifetime, config-as-seed-only, role-field ignored, gate-level audit,
-cleanup cadence, snapshot-and-release publishing) live in
-`.claude/agents/authdb.md` — the AuthDB review agent loads them on any
-change to `auth_db.{hpp,cpp}` / `auth_routes.{hpp,cpp}` / `auth.{hpp,cpp}`.
+AuthDB-touching changes preserve these invariants:
+
+- On POSIX, tighten the data directory to `0700` and `auth.db` to `0600` on
+  open; the directory mode protects SQLite's WAL sidecars. On Windows,
+  `std::filesystem::permissions` does not install an ACL, so deployment must
+  restrict the data directory to the service account until an explicit ACL
+  implementation lands.
+- Apply schema changes through `MigrationRunner`; do not bypass the store's
+  migration sequence with ad-hoc multi-statement setup.
+- Keep the owning `AuthDB` alive longer than every injected non-owning use in
+  `AuthManager` and the server.
+- Treat `yuzu-server.cfg` as a first-boot seed. Live user state comes from
+  `auth.db` and its authenticated mutation routes.
+- User creation cannot choose an elevated role. Role changes use the
+  dedicated authorized route and preserve its audit evidence.
+- Every privileged-route denial flows through the common admin gate so the
+  denied audit event is not handler-dependent.
+- Publish to sibling subsystems after releasing `AuthDB`'s mutex; snapshot
+  the payload under lock, then call out.
+- Keep cleanup timing, session/token ownership, parameterized SQL, and the
+  recovery runbook consistent with the behavior actually shipped.
+
+Review the implementation and focused tests for the exact current names and
+cadence; do not copy line numbers or past governance findings into code.

--- a/docs/ci-troubleshooting.md
+++ b/docs/ci-troubleshooting.md
@@ -15,11 +15,9 @@ Companion docs:
 - `docs/ci-cpp23-troubleshooting.md` — C++23 / cross-compiler issues
   (Clang 18 + libstdc++, Apple Clang version drift, MSVC-only failures).
   Read that one first if you suspect a compile-time problem.
-- `.claude/agents/build-ci.md` — full Windows MSVC static-link history,
-  including the option D LNK2038 fix and the four failed approaches that
-  preceded it.
 - `docs/windows-build.md` — the canonical Windows build path
-  (MSYS2 bash + `setup_msvc_env.sh` + `scripts/ensure-erlang.sh`).
+  (MSYS2 bash + `setup_msvc_env.sh` + `scripts/ensure-erlang.sh`) and the
+  current gRPC/protobuf linkage contract.
 
 ---
 
@@ -390,15 +388,14 @@ The fix is "option D" — combination of:
 **Both halves are load-bearing.** Removing either the triplet override
 OR the hand-rolled `find_library()` wiring re-introduces the failure.
 
-**Full history** including every failed approach
-(per-build-type triplets → explicit `CMAKE_BUILD_TYPE` → drop static
-override → option H hybrid) and the strategic escape path (#376 QUIC
-migration if option D ever rots) lives in
-`.claude/agents/build-ci.md` under **"Windows MSVC static-link history
-and #375"**. **Read that file before touching the Windows build wiring.**
+The current contract and its two failure mechanisms live in
+`docs/windows-build.md` under **"Windows gRPC/protobuf linkage"**. Read it
+and the live comments in the triplet and root `meson.build` before touching
+the wiring; discarded alternatives belong in git and issue history, not a
+reviewer prompt.
 
 **Reference fix:** PR #373 merged as `bf95d3b` on 2026-04-15. Don't
-simplify either half without reading the agent doc first.
+simplify either half without reading the build reference first.
 
 ---
 

--- a/docs/cpp-conventions.md
+++ b/docs/cpp-conventions.md
@@ -1,11 +1,18 @@
 # C++ Coding Conventions — Yuzu
 
-The `cpp-expert` and `cpp-safety` agents load this document on any C++ source change. CLAUDE.md keeps a one-line pointer.
+The `cpp-expert` and `cpp-safety` reviewers load this document on any C++ source change.
 
 ## Language
 
-- **C++23 throughout.** Use `std::expected<T, E>` for errors, `std::span` for contiguous ranges, `std::string_view` for non-owning string refs, `std::format` for string formatting.
+- **C++23 throughout.** Use `std::expected`, `std::span`, `std::string_view`, and `std::format` where they fit the owning module's established interface and make ownership or behavior clearer. Do not retrofit them mechanically.
 - Cross-compiler matrix: GCC 13+, Clang 18+, MSVC 19.38+, Apple Clang 15+. See `docs/ci-cpp23-troubleshooting.md` for known feature divergences.
+
+## Project fit
+
+- Read the adjacent implementation and tests before introducing a pattern. Prefer an existing helper, owner type, error shape, and control-flow style when it is correct.
+- Make the smallest coherent change. Do not widen a patch for modernization, cosmetic renaming, or an equivalent alternate idiom.
+- Add an abstraction only when it creates a necessary ownership/contract boundary or removes demonstrated duplication. A one-use wrapper that obscures a local operation is not an improvement.
+- Comments explain invariants, failure modes, or external constraints. Do not cite a governance agent, finding ID, review round, or the fact that code was reviewed.
 
 ## Naming
 
@@ -66,9 +73,9 @@ Both the agent and the server use:
 
 ## Resource ownership and lifetime
 
-Governance is stricter than style guidance: every C++ diff must prove ownership for each resource boundary it adds or touches. The Gate 1 Resource Ledger names the owner type, acquisition point, release point, transfer behavior, and failure cleanup for every fd, HANDLE, SOCKET, `FILE*`, `sqlite3_stmt*`, `sqlite3*`, OpenSSL object, BCrypt handle, allocated C string, mapped library, temp path, subprocess, callback context, and thread.
+For a diff that adds an owning resource boundary or changes acquisition, transfer, release, callback, or thread lifetime, the Gate 1 ownership note names the owner type, acquisition point, release point, transfer behavior, and failure cleanup. Write `Ownership changes: none` when ownership is unaffected.
 
-New or touched C++ code should use a small RAII owner, `std::unique_ptr` with a deleter, or a local scope guard. Manual cleanup is a governance finding unless the code documents why a wrapper is impossible or would be less safe. Check every early return between acquisition and release.
+New ownership paths use automatic cleanup: an existing RAII owner, value type, `std::unique_ptr` with a deleter, a move-only wrapper, or a local scope guard. Manual cleanup is blocking when a concrete return, exception, retry, transfer, or concurrency path can leak or double-release; its presence in untouched legacy code is not itself a finding.
 
 Resource owner types must be non-copyable when copying would double-release. Prefer move-only wrappers with explicit transfer semantics; any use of `release()` must immediately hand the resource to another named owner.
 
@@ -78,7 +85,7 @@ Shell/process boundaries must prefer argv-style execution. New `system()`, `pope
 
 Casts at ABI or syscall boundaries need a local aliasing/lifetime proof. `reinterpret_cast` and `const_cast` sites should explain alignment, constness, and ownership assumptions unless they are isolated behind an already-reviewed wrapper.
 
-Safety-sensitive ownership changes need targeted validation. Use ASan/UBSan when memory/resource ownership changes, TSan when thread lifetime, callback ownership, shared state, or store locking changes, and platform-specific tests for Windows HANDLE/service code or POSIX fd/socket/process code.
+Safety-sensitive ownership changes need proportionate validation. Select ASan/UBSan for memory/ownership risk, TSan for thread or shared-state risk, and platform tests for OS-resource behavior when each would exercise the changed path; do not request every sanitizer mechanically.
 
 ## Static-asset translation units
 
@@ -107,12 +114,11 @@ Use for vendored assets (Three.js r168, ECharts, Inter typeface, htmx bundles la
 
 - Symbols emitted by codegen drop the file suffix (`kThreeJs`, not `kThreeMinifiedJs`). For asset families with multiple files, name the second symbol after the upstream class or module so the link is unambiguous (`kThreeOrbitControlsJs`, not `kThreeOrbitJs`). Rename history is gated on the same architectural review as any other ABI-shaped symbol change.
 
-## Forbidden in new code
+## Reject in new code
 
-- Raw error codes or output parameters (use `std::expected`).
-- printf-family calls (use `std::format` or spdlog).
-- Raw `new`/`delete` (use RAII).
-- Manual resource cleanup (use RAII / smart pointers).
-- C++ types crossing the C ABI boundary in `plugin.h`.
-- Borrowed `std::string_view`, `std::span`, raw pointer, or callback context escaping its owner.
+- Owning raw `new`/`delete` or a manual cleanup path with an unprotected failure edge.
+- C++ types or exceptions crossing the C ABI boundary in `plugin.h`.
+- A borrowed view, raw pointer, or callback context escaping its owner.
 - Shell command construction when argv-style execution is feasible.
+- A second error, logging, ownership, or threading idiom where the owning module already has a correct one.
+- Review-process provenance in production comments.

--- a/docs/dependency-rollout-2026-04-14.md
+++ b/docs/dependency-rollout-2026-04-14.md
@@ -634,8 +634,8 @@ Append-only. Newest entries at the top. Format:
   if green. The full option D iteration history (12e40ae → a61a787 →
   713ae8c → 46ea61f → 220e7bd → b33f1df) demonstrates the pattern
   for adding new transitive libs to option D's `cxx.find_library()`
-  list — see `.claude/agents/build-ci.md` "Windows MSVC static-link
-  history and #375" for the long form. P1 #376 (move off gRPC to
+  list — see `docs/windows-build.md` "Windows gRPC/protobuf linkage" for
+  the current contract. P1 #376 (move off gRPC to
   QUIC) remains the strategic escape but is deferred until customer
   commitments ship.
 - **2026-04-14 ~12:40 UTC** · Claude session · **Option H failed on release

--- a/docs/postgres-migration-ladder.md
+++ b/docs/postgres-migration-ladder.md
@@ -73,7 +73,7 @@ Migrate last because they require `SecretCodec` (or a verify-only-hash schema) i
 |---|---|---|---|
 | `CaStore` | `ca_store` | key_ref-only (**unblocked**) | private key behind `KeyProvider`, never in a column. |
 | `DeviceTokenStore` | `device_token_store` | verify/hash (confirm in ADR) | classify in its per-store ADR. |
-| auth DB (`auth_db.{hpp,cpp}`) | `auth` | `SecretCodec` (TOTP); sessions → SHA-256 verify-only | not a `*Store` class; see `.claude/agents/authdb.md`. |
+| auth DB (`auth_db.{hpp,cpp}`) | `auth` | `SecretCodec` (TOTP); sessions → SHA-256 verify-only | not a `*Store` class; see `docs/auth-architecture.md` "AuthDB — persistent authentication store". |
 | `WebhookStore` | `webhook_store` | `SecretCodec` | shared secrets. |
 | `OffloadTargetStore` | `offload_target_store` | `SecretCodec` | target credentials. |
 | `RuntimeConfigStore` | `runtime_config_store` | `SecretCodec` | secret-valued config keys. |

--- a/docs/user-manual/network.md
+++ b/docs/user-manual/network.md
@@ -163,3 +163,11 @@ from the same heartbeat facts as this page, via the shared
 disagree. The agent emits the literal `yuzu.net_*` heartbeat keys, which must
 match the server's `kNetTag*` constants — pinned by a `static_assert` in
 `test_network_perf_model.cpp`, so drift fails the build.
+
+The Windows heartbeat retransmit MIB (caveats in the platform table above) is
+whole-stack and measurement-first-unvalidated, so it is **withheld from the
+`yuzu_fleet_net_retrans_pct` gauge**: the server-side gate
+`retrans_gauge_eligible(os)` admits Linux only today (#1465). The Windows
+figure still renders on this page and the REST surface, caveated — it just
+does not feed the fleet gauge. All net gauges carry an `os` label; aggregate
+and alert **per-OS**, never on a cross-OS sum.

--- a/docs/user-manual/policy-engine.md
+++ b/docs/user-manual/policy-engine.md
@@ -212,6 +212,13 @@ before the stores are destroyed** in `~ServerImpl`/`stop()` — the eval thread
 dispatches through those stores, so the join-before-stores order is a
 use-after-free guard any shutdown refactor must preserve.
 
+Evaluation dispatches mint **`polchk-*` correlation ids**, which
+`notify_exec_tracker` (in `agent_service_impl.cpp`) deliberately **skips**:
+compliance checks get no execution-tracker row and no SSE event, so they do
+NOT appear in the executions drawer. Any change to the tracker's skip logic
+must keep the `polchk-*` exemption — a policy evaluating on a 60-second
+interval would otherwise flood execution history.
+
 > **Remediation is never automatic.** Detection runs on the schedule above;
 > applying a fix is always an explicit, operator-gated action (see
 > `POST /api/policies/{id}/remediate` below). On a server restart, any agent

--- a/docs/user-manual/server-admin.md
+++ b/docs/user-manual/server-admin.md
@@ -143,7 +143,7 @@ The server stores its configuration in files located in the **same directory as 
 | File | Purpose |
 |---|---|
 | `yuzu-server.cfg` | First-boot seed for `auth.db`. Holds the initial admin credential as PBKDF2-SHA256 with a per-user salt. After first boot, `auth.db` is authoritative and this file is no longer read for live state — keep it as the seed for disaster-recovery (re-creating `auth.db` from scratch). |
-| `auth.db` | SQLite-backed authentication database. Holds user accounts, sessions, and enrollment tokens with PBKDF2-SHA256 hashed passwords. Created in `--data-dir` on first boot. Mode `0600` on Linux; restricted ACL on Windows. **This is the live source of truth for authentication state from v0.12.0 onwards.** |
+| `auth.db` | SQLite-backed authentication database. Holds user accounts, sessions, and enrollment tokens with PBKDF2-SHA256 hashed passwords. Created in `--data-dir` on first boot. The server reapplies mode `0600` on POSIX. On Windows, run the server under a dedicated service account and restrict the data-directory ACL; the current `std::filesystem::permissions` call does not install a Windows ACL. **This is the live source of truth for authentication state from v0.12.0 onwards.** |
 | `enrollment-tokens.cfg` | Legacy enrollment-token file (Tier 2). New deployments persist tokens inside `auth.db`; this file remains writable for backwards-compatibility on upgrades from pre-AuthDB releases. |
 | `pending-agents.cfg` | Queue of agents awaiting manual approval (Tier 1 enrollment). Contains agent ID, hostname, IP, and registration timestamp. |
 

--- a/docs/windows-build.md
+++ b/docs/windows-build.md
@@ -68,3 +68,25 @@ meson test -C build-windows --suite server --print-errorlogs
 
 The release zip is unaffected — its vcpkg-DLL sweep bundles `libpq.dll`
 next to the binaries, same as `sqlite3.dll` and the OpenSSL DLLs.
+
+## Windows gRPC/protobuf linkage
+
+Two pieces are one build contract and must change together:
+
+1. `triplets/x64-windows.cmake` keeps the gRPC/protobuf/abseil family static.
+2. The Windows branch in root `meson.build` constructs `protobuf_dep` and
+   `grpcpp_dep` with `find_library()` from the build-type-specific vcpkg
+   directory. Linux and macOS continue through Meson's normal dependency
+   lookup.
+
+Removing the triplet override mixes static gRPC objects with abseil DLL
+exports and has produced LNK2005 duplicate symbols. Keeping the override but
+using Meson's CMake dependency translation has selected release libraries for
+a debug build and produced LNK2038 CRT mismatches. Review the live comments in
+both files and validate Windows debug and release before changing either half.
+
+The static abseil copy also gives each Windows image a distinct protobuf-map
+hash seed. A test must not populate a protobuf `Map` in an EXE and rely on a
+DLL to look it up. Serialize across the image boundary or construct and read
+the map in the consuming DLL; follow the existing exported test helper near
+`guardian_dispatch_push_bytes_for_test`.

--- a/docs/yuzu-guardian-design-v1.1.md
+++ b/docs/yuzu-guardian-design-v1.1.md
@@ -2490,6 +2490,29 @@ Guardian ladder must check these.
   — the push fan-out and the heartbeat reconcile both gate on it; it sources
   from each deployed Baseline's `deployed_snapshot`, not the live member set
   (the Push-not-Write invariant in `docs/user-manual/guaranteed-state.md`).
+- **Guard types are platform-gated; schema and handler arrays move together.**
+  `registry` (`guard_registry`) and `file` (`guard_file`) guards are
+  Windows-only — off-Windows `start()` returns false, so the guard never
+  reads as armed. The `service` guard is cross-platform via the
+  `make_service_guard()` factory (`guard_systemd.hpp`): Windows
+  `ServiceGuard` (SCM `NotifyServiceStatusChange`) or Linux
+  `SystemdServiceGuard` (systemd sd-bus `ActiveState` watch, **observe-only**
+  — enforce is deferred to a polkit-gated PR). The Linux guard maps systemd's
+  richer `ActiveState` onto the published `{running, stopped}` tokens
+  (`active`→running; `inactive`/`failed`/absent→stopped;
+  `activating`/`deactivating`/`reloading`/`maintenance`→transitional, held) —
+  deliberately adding NO new schema token, so the cross-checks stay
+  untouched. Published schema enums (`guardian_schema_registry.cpp`) and the
+  agent's per-type support arrays (`registry_support::kHives`,
+  `service_support::kStates`) are bound by schema↔handler cross-check unit
+  tests: add or remove a guard type in BOTH or neither.
+- **Guardian-store SQLite transactions use the RAII owners.** New or modified
+  transactions in the Guardian stores (`guaranteed-state.db`,
+  `guardian-baselines.db` / `BaselineStore`,
+  `server/core/src/baseline_store.{hpp,cpp}`) use `SqliteTxn` + `SqliteStmt`
+  from `server/core/src/sqlite_raii.hpp` (ROLLBACK-unless-`commit()` plus
+  guaranteed `finalize`), so an exception between `BEGIN` and `COMMIT` cannot
+  wedge the shared connection.
 - **Guardian wire payloads in `CommandRequest.parameters` are not
   gateway-safe.** Any field that carries raw proto bytes (serialised
   `GuaranteedStatePush`, binary signatures, etc.) must NOT be placed in a


### PR DESCRIPTION
Two commits, both aimed at the same problem: the Codex-facing guidance had grown to the point where the parts that matter were buried.

## 1 · `docs(agents): trim AGENTS.md to a routing layer` (90d04767)

`AGENTS.md` was 48.4KB — large enough that the standing invariants competed for attention with reference material an agent loads anyway. This cuts it to 20.3KB by keeping only what routes: the invariants that are catastrophic if violated, and pointers to the doc that owns each concern.

The detail moved out, not away. Content displaced from `AGENTS.md` lands in the doc that already owns it — `docs/auth-architecture.md`, `docs/cpp-conventions.md`, `docs/windows-build.md`, `docs/ci-troubleshooting.md`, `docs/yuzu-guardian-design-v1.1.md`, and the affected user-manual pages.

This mirrors the heuristic `CLAUDE.md` already states for itself: routed-concern rows hold only the catastrophic-if-violated invariant plus a doc pointer; the detail lives in the routed doc.

## 2 · `chore(governance): tighten reviewer contracts` (a681e5bb)

Sharpens the `.codex/skills/governance` reviewer definitions and adds `references/reviewers.md` so each reviewer's remit, severity vocabulary and output shape are stated once rather than re-derived per invocation. Companion edits to the `auth-and-authz`, `cpp-expert`, `cpp-safety` and `release` Codex skills.

## Conflict note

PR #2630 adds a short workstream-pointer block at the top of `AGENTS.md`. Whichever of the two lands second needs a trivial rebase — the two edits are in different regions of the file, so the resolution is mechanical.

## Scope

Documentation and agent-guidance only; no product code, no build or CI changes. No changelog fragment per `changelog.d/README.md` rule 3 — no operator-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)