### PR TITLE
fix(review): add the patsub_replacement guard to the Kimi driver too (follow-up to #2644)

### DIFF
--- a/.claude/skills/adversarial-review/run-kimi-reviewer.sh
+++ b/.claude/skills/adversarial-review/run-kimi-reviewer.sh
@@ -20,6 +20,14 @@
 
 set -euo pipefail
 
+# LOAD-BEARING — do not remove. Bash >= 5.2 defaults `patsub_replacement` ON, which
+# makes an unescaped `&` in a ${var//pat/repl} replacement expand to the MATCH. Every
+# `&` in an injected value then becomes the literal token being replaced, silently
+# corrupting `&&` in anchors, C++ reference types (`bool& x`) and URL query strings
+# in the text under review. The Codex driver carries the same guard; both render
+# their prompt with the same construct, so both need it.
+shopt -u patsub_replacement 2>/dev/null || true
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROMPT_TEMPLATE="$SCRIPT_DIR/review-prompt.md"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,7 @@ jobs:
         run: |
           bash tests/shell/test_check_compose_versions.sh
           bash tests/shell/test_detect_code_change.sh   # docs-only gate classifier (#1978)
+          bash tests/shell/test_kimi_driver_substitution.sh  # patsub_replacement prompt corruption
           python3 scripts/ci/test_runner_health_check.py
 
   # ── Lint (disabled — clang-format reorders Windows headers and breaks MSVC builds) ──

--- a/tests/shell/test_kimi_driver_substitution.sh
+++ b/tests/shell/test_kimi_driver_substitution.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# test_kimi_driver_substitution.sh — regression net for the Kimi adversarial-review
+# driver's prompt substitution.
+#
+# Bash >= 5.2 turns `patsub_replacement` ON by default, which makes an unescaped
+# `&` in a ${var//pat/repl} REPLACEMENT expand to the text that was MATCHED. The
+# driver renders its prompt template with exactly that construct (seven passes,
+# run-kimi-reviewer.sh), so without an explicit `shopt -u patsub_replacement`
+# every `&` in an injected value silently becomes the token being substituted:
+#
+#     --anchors "failure() && cancelled()"   ->   "failure() {{ANCHORS}}{{ANCHORS}} cancelled()"
+#     a C++ snippet "bool& ref"              ->   "bool{{ANCHORS}} ref"
+#     a URL "?a=1&b=2"                       ->   "?a=1{{ANCHORS}}b=2"
+#
+# The reviewer then grades against a corrupted rulebook, and any C++ reference
+# type or query string in the material under review is mangled before the model
+# sees it — silently, in a file nobody opens, on every run.
+#
+# The sibling `run-codex-reviewer.sh` has the same construct and the same guard;
+# both drivers need their own net, because a guard added to one says nothing
+# about the other. That asymmetry is exactly how this survived a first fix.
+#
+# Run:  bash tests/shell/test_kimi_driver_substitution.sh
+set -euo pipefail
+
+# The defect mechanism only exists on bash >= 5.2. On older bash the guard is
+# inert AND the corruption cannot manifest, so every assertion would pass
+# vacuously with or without the fix. Skip LOUDLY rather than print a green that
+# verified nothing (CI runs Ubuntu bash >= 5.2; this is for stock macOS 3.2).
+if (( BASH_VERSINFO[0] < 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 2) )); then
+  echo "  [SKIP] bash ${BASH_VERSION} < 5.2 — patsub_replacement does not exist here;"
+  echo "         this net cannot arm. Re-run under bash >= 5.2 (CI does)."
+  exit 0
+fi
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || { cd "$(dirname "$0")/../.." && pwd; })"
+DRIVER="$ROOT/.claude/skills/adversarial-review/run-kimi-reviewer.sh"
+[ -f "$DRIVER" ] || { echo "missing $DRIVER" >&2; exit 2; }
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/yuzu-kimisub-test.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+# Stub `kimi`: the driver probes `kimi --version`, then passes the rendered
+# prompt as the argument after `-p`.
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/kimi" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then echo "0.16.0"; exit 0; fi
+while [ \$# -gt 0 ]; do
+  if [ "\$1" = "-p" ]; then printf '%s' "\$2" > "$TMP/captured.txt"; shift 2; else shift; fi
+done
+EOF
+chmod +x "$TMP/bin/kimi"
+
+# Restricted (default) mode wants --review-dir inside --repo and clones
+# KIMI_CODE_HOME's config.toml — give it a scratch repo and a minimal config.
+mkdir -p "$TMP/repo/rev" "$TMP/kimi-home"
+printf 'model = "stub"\n' > "$TMP/kimi-home/config.toml"
+
+ANCHORS='- failure() && cancelled() guards
+- C++ `bool& ref` params
+- url?a=1&b=2'
+
+PATH="$TMP/bin:$PATH" KIMI_CODE_HOME="$TMP/kimi-home" bash "$DRIVER" \
+  --phase 1 --review-dir "$TMP/repo/rev" --repo "$TMP/repo" \
+  --self kimi --peer codex \
+  --target 'smoke && test' --anchors "$ANCHORS" \
+  >/dev/null 2>"$TMP/driver.stderr" || true
+
+if [ ! -s "$TMP/captured.txt" ]; then
+  echo "  [FAIL] driver produced no prompt — driver stderr:" >&2
+  sed 's/^/    | /' "$TMP/driver.stderr" >&2
+  exit 1
+fi
+
+pass=0 fail=0
+expect_literal() {
+  local desc="$1" needle="$2"
+  if grep -qF -- "$needle" "$TMP/captured.txt"; then
+    printf '  [pass] %s\n' "$desc"; pass=$((pass + 1))
+  else
+    printf '  [FAIL] %s — %q not found in rendered prompt\n' "$desc" "$needle"; fail=$((fail + 1))
+  fi
+}
+expect_absent() {
+  local desc="$1" needle="$2"
+  if grep -qF -- "$needle" "$TMP/captured.txt"; then
+    printf '  [FAIL] %s — %q leaked into rendered prompt\n' "$desc" "$needle"; fail=$((fail + 1))
+  else
+    printf '  [pass] %s\n' "$desc"; pass=$((pass + 1))
+  fi
+}
+
+expect_literal "&& survives in anchors"           'failure() && cancelled() guards'
+expect_literal "C++ reference type survives"      'bool& ref'
+expect_literal "URL query separator survives"     'url?a=1&b=2'
+expect_literal "&& survives in target"            'smoke && test'
+# The tell-tale of the patsub bug: the token being replaced appears in its own output.
+expect_absent  "no {{ANCHORS}} echoed back"       '{{ANCHORS}}'
+expect_absent  "no {{TARGET}} echoed back"        '{{TARGET}}'
+
+echo "  ---"
+echo "  ${pass} passed, ${fail} failed"
+[ "$fail" = 0 ]


### PR DESCRIPTION
## The maintainer is right — thanks for catching it

#2644 fixed `run-codex-reviewer.sh` and its commit message asserted the Kimi driver "already carries" the same guard. **It does not, and never did.**

The claim was true of the user-global Ollama variant I was comparing against (`~/.claude/skills/adversarial-review-kimi/`, which does carry it) and **false of this driver** — the one that ships to every collaborator. I checked one file and generalised to the other, and the comment I wrote then propagated the error.

The consequence is exactly as described: before #2644 both reviewers were graded against the same corrupted rulebook, which at least failed symmetrically. After it, Codex gets the real anchors and Kimi still gets `{{ANCHORS}}` confetti — while the commit message says it's closed. **A half-fix that reads as a whole one is worse than the original bug.**

## The fix

`run-kimi-reviewer.sh` renders its prompt with the same seven `${body//\{\{TOKEN\}\}/$VALUE}` passes (lines 72–78), so bash ≥ 5.2's `patsub_replacement` corrupts it identically:

| input | on `dev` | this branch |
|---|---|---|
| `failure() && cancelled() guards` | `failure() {{ANCHORS}}{{ANCHORS}} cancelled() guards` | unchanged ✅ |
| `` C++ `bool& ref` params `` | `` C++ `bool{{ANCHORS}} ref` params `` | unchanged ✅ |
| `url?a=1&b=2` | `url?a=1{{ANCHORS}}b=2` | unchanged ✅ |
| `--target "smoke && test"` | `smoke {{TARGET}}{{TARGET}} test` | unchanged ✅ |

Same `shopt -u patsub_replacement` guard, same LOAD-BEARING comment — with the cross-reference corrected so it states a fact rather than an assumption.

## The test, and why it's a separate file

`tests/shell/test_kimi_driver_substitution.sh` drives the **real** driver with a stub `kimi` on `PATH` and asserts the ampersands survive. **6/6 assertions fail against `dev`'s driver and pass after the guard** — verified by reverting the driver under the test and watching it go red, then restoring.

It is deliberately a **separate file** from the Codex net rather than one shared test. A guard on one driver says nothing about the other, and that asymmetry is precisely how this survived the first fix. Each driver now carries its own arming test, so fixing one can never again look like fixing both.

It also **skips loudly on bash < 5.2**, where the mechanism doesn't exist and every assertion would otherwise pass vacuously — a green that verified nothing is how this class of bug hides.

## Scope — this does not close the whole problem

Two things remain, and I'd rather state them than let this read as complete:

1. **Copies outside this repo are untouched.** The user-global `~/.claude/skills/adversarial-review-kimi/` variant already has the guard, but any other operator's local copies are theirs to fix — the maintainer's ask to circulate this is the right mechanism, since a repo PR cannot reach them.
2. **`#2644` is still open** and carries the Codex half. This PR is independent of it — neither depends on the other, and they can land in either order.

Also worth flagging: reviewing #2644 required the fixed script, because the bug would otherwise have corrupted the review of itself. The same applies here.