### PR TITLE
docs(spark): fix teardown_arm_race header's false allocation claim (fjarvis review follow-up to #2868)

### DIFF
--- a/agents/core/src/spark_engine.cpp
+++ b/agents/core/src/spark_engine.cpp
@@ -804,11 +804,15 @@ std::expected<SparkEngine::SubscriptionId, std::string> SparkEngine::arm_impl(Sp
     // watch, if any) and undo our subscription on a lost race — see
     // unregister_consumer()'s erase-before-scan ordering for why this
     // re-check is airtight. Inline subs have no registered consumer to check.
-    // The teardown is teardown_arm_race(), NOT disarm(). Both are allocation-free in
-    // their locked section now, so the reason is no longer allocation: disarm() must
-    // LOOK UP a key this caller already holds, and its last-subscriber branch is
-    // whole-key-capable, while what a lost M1 race owes is the removal of exactly ONE
-    // subscription — a sibling that deduped onto this key keeps its own.
+    // The teardown is teardown_arm_race(), NOT disarm(). Read the next clause as
+    // precisely as :580-584 above: it is NOT that either one's locked section never
+    // allocates — the log line in each still formats into a heap buffer (:902-905
+    // there, :1008-1011 in disarm()) — it is that both now CONTAIN that allocation in
+    // a catch-all rather than letting it escape. So the reason to route through
+    // teardown_arm_race is no longer allocation: disarm() must LOOK UP a key this
+    // caller already holds, and its last-subscriber branch is whole-key-capable,
+    // while what a lost M1 race owes is the removal of exactly ONE subscription — a
+    // sibling that deduped onto this key keeps its own.
     if (tier == SparkTier::Queued) {
         bool consumer_alive = false;
         {
@@ -1047,7 +1051,7 @@ void SparkEngine::disarm(SubscriptionId id) {
             if (armed_.contains(unwatch_key))
                 return; // a concurrent re-arm already renewed this key
         }
-        // CONTAINED AND COUNTED, matching teardown_arm_race (:942-953) — the fourth and
+        // CONTAINED AND COUNTED, matching teardown_arm_race (:965-977) — the fourth and
         // last lockstep difference between the two. unwatch() is not noexcept and the real
         // mechanisms allocate inside it (spark_service queues a Cmd holding a key copy;
         // spark_file grows retiring_), so under the memory pressure this layer is about it

--- a/agents/core/src/spark_engine.hpp
+++ b/agents/core/src/spark_engine.hpp
@@ -430,16 +430,19 @@ private:
     /// (The post-commit rollback this doc used to name was deleted in 6c1d6942.)
     /// Allocates nothing — map/node erases and string compares only.
     void drop_key_locked(const std::string& key);
-    /// Undo ONE subscription after arm_impl loses the M1 consumer race, allocating
-    /// nothing (the caller owns `key`/`type`/`event_driven`, so nothing has to be
-    /// copied or recomputed). A specialization of disarm() — lockstep siblings, NOT
-    /// exact duplicates. The full, authoritative enumeration of every difference
-    /// lives at the DEFINITION, not here: this comment previously carried its own
-    /// completeness claim ("differ only in that this one takes key/type from the
-    /// caller") with no number attached, and THAT drifted out of sync with the
-    /// definition just the same as a restated count would have (fjarvis's
-    /// adversarial review, PR #2863) — do not reintroduce EITHER form, a count or
-    /// an "only differs in..." claim, here. It is NOT redundant with disarm():
+    /// Undo ONE subscription after arm_impl loses the M1 consumer race. This
+    /// declaration states the interface contract; the DEFINITION owns implementation
+    /// claims — allocation posture, and the exact count/enumeration of differences
+    /// from disarm() — so this comment does not restate either. Both drifted out of
+    /// sync when restated here before, each caught by fjarvis's adversarial review
+    /// of the PR then open: a completeness claim with no number attached ("differ
+    /// only in that this one takes key/type from the caller"), found reviewing PR
+    /// #2863; and an "allocating nothing" claim, made false by the log calls this
+    /// function contains, found reviewing PR #2868. Do not reintroduce either at
+    /// THIS declaration — see the definition for both. The caller owns `key`/`type`/
+    /// `event_driven`, so nothing has to be copied or recomputed for THOSE
+    /// specifically. A specialization of disarm() — lockstep siblings, NOT exact
+    /// duplicates. It is NOT redundant with disarm():
     /// routing arm_impl's M1 teardown through disarm() would remove ONE subscription
     /// via a whole-key-capable path and reintroduce a lookup on values the caller
     /// already holds. Keep the two in lockstep.


### PR DESCRIPTION
## Summary

- Third post-merge follow-up in the #2843 -> #2863 -> #2868 chain. fjarvis's adversarial review of merged PR #2868 found `SparkEngine::teardown_arm_race`'s DECLARATION comment (`spark_engine.hpp`) still claimed the function was "allocating nothing" - false: its log calls (`spdlog::info`/`spdlog::error`) can throw `bad_alloc`, contained via try/catch, matching the `.cpp` definition's own accurate claim ("no allocation failure can escape it"). Fixed by removing the header's allocation claim entirely and consolidating it with the prior #2863 drift-warning under one "declaration states the interface contract, definition owns implementation claims" rule.
- The full four-agent routed-concern review (security-guardian, cpp-safety, cpp-expert, docs-writer - matching #2868's own review set) surfaced three further real, proactively-caught instances of the same citation/provenance-drift class this PR chain exists to close, all fixed and independently reverified in this PR:
  - **cpp-safety** caught an adjacent false claim at the `arm_impl` M1 teardown call site ("Both are allocation-free in their locked section now") - also false, for both `teardown_arm_race` and `disarm()`. Reworded to match the file's own established formulation at `:580-584`.
  - That reword's own +4-line insertion shifted its own new self-referential citations, and additionally exposed a citation in `disarm()`'s comment (`:942-953`) that was **already stale on `dev`** by ~19 of the ~23 lines this PR corrects - only 4 are attributable to this diff's own shift. cpp-expert, docs-writer, and cpp-safety each independently caught one instance; all now point at their verified-correct current targets (`:902-905`, `:1008-1011`, `:965-977`).
  - **security-guardian** caught a provenance misattribution in the consolidated header text (implying PR #2868's own diff addressed the allocation claim, when its merged commit `4e3b5fd6` only touched an unrelated completeness/count claim) - reworded and independently verified against `gh pr view`/review-body text: both fjarvis reviews (#2863, #2868) were submitted while their PR was still open, and each review's body directly states which finding it raised for the following PR to close.
- **Comment-only, no logic change**, across all commits.

## Known, explicitly out-of-scope

`docs/spark-stage2-guardian-consumer-design.md` carries several external line-number citations into these two files that are stale independent of this diff - verified against `git show origin/dev` to predate it. Not fixed here (would meaningfully expand this PR's scope into an unrelated file with its own drift history); worth a separate follow-up pass.

## Test plan

- [x] Full rebuild clean (multiple rounds, after every edit).
- [x] `yuzu_server_tests "[spark]"` 123/14 green (unchanged throughout).
- [x] `yuzu_agent_tests "[spark]"` 9163/355 green (unchanged throughout).
- [x] Reviewed by `security-guardian`, `cpp-safety`, `cpp-expert`, and `docs-writer` (the full routed-concern set for this file, matching #2868's precedent) across three rounds - every real finding (4 total, enumerated above) fixed and independently reverified against the actual code, not taken on faith.

🤖 Generated with [Claude Code](https://claude.com/claude-code)