### PR TITLE
feat(server): the dispatch chokepoint — classify + authorize every CommandRequest (PR1.9c)

### DIFF
--- a/changelog.d/1.9-dispatch-caller-threading.changed.md
+++ b/changelog.d/1.9-dispatch-caller-threading.changed.md
@@ -1,0 +1,13 @@
+- **Internal — the caller's principal now reaches the confined dispatch seam (PLAN-006).**
+  `ServerImpl::dispatch_confined`, `McpServer::DispatchFn`, `DashboardRoutes::DispatchFn`, and
+  `WorkflowRoutes::CommandDispatchFn` used to carry only the operator's Execution:Execute visible
+  set (`exec_visible`), never their identity — `dispatch_scope_ladder.hpp` could recover a
+  principal only for owner-scoped `from_result_set` expressions, so every other dispatch reached
+  the seam anonymously even though the handler had authenticated a real session moments earlier. A
+  new `DispatchCaller` struct (`server/core/src/dispatch_caller.hpp`) now travels alongside
+  `exec_visible` through every one of those seams, carrying `principal`, `principal_role`, and an
+  explicit `system` flag for the genuine background/system dispatchers (compliance-policy ticks)
+  that have no session at all. This is a pure signature-and-wiring refactor: no new authorization
+  decision, rejection, audit row, or metric — the fail-closed behaviour of an unwired derivation is
+  unchanged (a present-empty `exec_visible`, never unfiltered). It lays the plumbing a future
+  chokepoint wave needs to authorize on identity, not merely filter on visibility.

--- a/changelog.d/1.9-dispatch-chokepoint.security.md
+++ b/changelog.d/1.9-dispatch-chokepoint.security.md
@@ -43,12 +43,17 @@
   (`yuzu_server_gateway_capability_denied_total`, `yuzu_server_dispatch_tag_invalid_total`) are
   pre-registered at boot, so a dashboard distinguishes "the check ran and passed" (zero) from
   "the check never ran" (absent) during the rollout.
-- **The per-action kill switch is now enforced at dispatch.** `PluginConfigStore::action_allowed`
-  had no production caller while the REST surface advertised the switch as a reliable emergency
-  stop; `build_classified_command` now consults it after authorization and refuses with a
-  separately counted `kill_switched` reason — distinct from `forbidden`, because an operator-thrown
-  emergency stop and an authorization verdict are different facts to an incident review. A
-  degraded config store reports as disabled, never as enabled.
+- **The per-action kill-switch check point now lives at dispatch — the enforcement seam ships
+  here, its wiring ships with the plugin-config plane.** `finalize_classified_command` consults an
+  injected `action_allowed` predicate after authorization and refuses with a separately counted
+  `kill_switched` reason — distinct from `forbidden`, because an operator-thrown emergency stop
+  and an authorization verdict are different facts to an incident review. In THIS change the
+  predicate is deliberately unwired (an absent callback behaves as no-kill-switch-configured, the
+  seam's documented legacy-open form); the plugin-config PR in this stack replaces it with the
+  fail-closed `PluginConfigStore::action_allowed` callback, at which point a degraded config store
+  reports as disabled, never as enabled. Until that lands, no surface advertises the switch —
+  the REST route that describes it as a reliable emergency stop arrives in the same PR as its
+  wiring.
 - **The wire carries canonical plugin/action names.** Classification is case-insensitive but the
   agent matches plugin names case-sensitively, so a caller using `plugin="TAR"` was authorized and
   then rejected by the agent. The command is now built from the values classification resolved.

--- a/changelog.d/1.9-dispatch-chokepoint.security.md
+++ b/changelog.d/1.9-dispatch-chokepoint.security.md
@@ -1,0 +1,54 @@
+- **The dispatch chokepoint (PR1.9c): a `CommandRequest` can no longer reach an agent without
+  BOTH a classification decision and an authorization decision.** Every direct
+  `detail::pb::CommandRequest` construction site in `server.cpp` — the TAR viz fleet-snapshot
+  fetcher, both Guardian rule-push paths, the asset-tag sync push, the `/api/command` handler, and
+  the legacy `/api/chargen/*` + `/api/procfetch/fetch` sink — now routes through one private
+  builder, `ServerImpl::build_classified_command`, which classifies the `plugin.action` pair via
+  the `CommandCapabilityRegistry` composed over the full six-fragment catalogue (core +
+  filesystem/tar/registry/inventory/network/endpoint/content-distribution plugins), rejects an
+  unclassified or ambiguous pair with a distinct counted reason, and enforces the resolved
+  securable/operation against the caller's principal via `RbacStore::check_permission` before a
+  command is ever built. An empty principal on a non-system caller is refused outright (no
+  anonymous operator dispatch); a `system_reserved` capability (the three server-initiated
+  dispatches) is dispatchable only under an explicit system caller, never a caller-attributable
+  RBAC decision, and is refused to every operator regardless of what RBAC would otherwise grant
+  them. `/api/command`'s destructive-action gate (previously a single hardcoded
+  `tar.purge_source` row) now sources its elevated securable/scope-confinement treatment from the
+  same registry, so it applies automatically to every action the catalogue classifies
+  `Destructive`, not just the one it used to.
+- **Provenance, not syntax: `AgentRegistry::send_to`/`send_to_all` accept only a
+  `ClassifiedCommand`.** A syntactically valid `dispatch_tag` proved nothing on its own —
+  `encode_dispatch_tag` is a public, pure helper any caller could stamp onto a hand-built
+  protobuf. `ClassifiedCommand` (`agent_registry.hpp`) wraps the wire command behind a private
+  constructor only `ServerImpl` may call; there is no public setter, no conversion to a mutable
+  `CommandRequest`, and no overload of `send_to`/`send_to_all` that accepts a bare
+  `pb::CommandRequest` — a hand-built one cannot reach the registry at all, a compile-time
+  invariant. A defensive runtime check on the send path additionally rejects an empty or malformed
+  `dispatch_tag`, counted separately from every other refusal.
+- **Gateway capability consumption closes a dropped-on-the-floor gap (peer finding PLAN-007).**
+  `GatewayUpstreamServiceImpl::NotifyStreamStatus` now records the `wire_capabilities` a gateway
+  advertises on every CONNECTED notification against the agent's session (`AgentRegistry`),
+  replacing — never merging — on reconnect, and clearing on DISCONNECTED / session-clear. The
+  routed dispatch path now refuses (counted and logged, never silently downgraded) to route a
+  dispatch-tagged command to a gateway session that has not advertised the literal
+  `command_dispatch_tag_v1` — closing the gap where a gateway build too old to forward the tag
+  field would otherwise silently strip it in transit.
+- **Deployment ordering: upgrade the gateway BEFORE the server.** The capability gate above is
+  fail-closed, so a server on this release routing through a gateway that has not yet been
+  upgraded to advertise `command_dispatch_tag_v1` refuses **every** dispatch to agents behind
+  that gateway — the agents remain connected and healthy, and operator dispatches report as
+  undelivered. That is the intended posture (silently stripping the tag would defeat the
+  chokepoint), but it makes gateway-first the required upgrade order for any deployment using
+  the gateway. Direct-connected agents are unaffected. The two deny counters
+  (`yuzu_server_gateway_capability_denied_total`, `yuzu_server_dispatch_tag_invalid_total`) are
+  pre-registered at boot, so a dashboard distinguishes "the check ran and passed" (zero) from
+  "the check never ran" (absent) during the rollout.
+- **The per-action kill switch is now enforced at dispatch.** `PluginConfigStore::action_allowed`
+  had no production caller while the REST surface advertised the switch as a reliable emergency
+  stop; `build_classified_command` now consults it after authorization and refuses with a
+  separately counted `kill_switched` reason — distinct from `forbidden`, because an operator-thrown
+  emergency stop and an authorization verdict are different facts to an incident review. A
+  degraded config store reports as disabled, never as enabled.
+- **The wire carries canonical plugin/action names.** Classification is case-insensitive but the
+  agent matches plugin names case-sensitively, so a caller using `plugin="TAR"` was authorized and
+  then rejected by the agent. The command is now built from the values classification resolved.

--- a/changelog.d/20260814-deployment-dispatch-caller-security.security.md
+++ b/changelog.d/20260814-deployment-dispatch-caller-security.security.md
@@ -1,0 +1,24 @@
+- **`/auto` deployment advance now dispatches under the real operator's identity, not system
+  authority — and confines to that operator's `Execution:Execute` visibility, not just the
+  devices they can see listed.** `DeploymentRoutes::advance_and_render`/`deployment::advance`
+  previously fed the shared dispatch chokepoint a `DispatchCaller{.system = true}` closure for
+  every deploy-advance tick, so `content_dist.stage`/`content_dist.execute_staged` — declared
+  `SoftwareDeployment:Write`/`Execution:Execute` respectively — dispatched unconditionally: the
+  chokepoint's classification/authorization check never ran against the triggering operator's own
+  grants at all. Both now carry the triggering session's real identity (mirroring the same
+  `DispatchCaller`-threading pattern already applied to
+  `RestApiV1`/`WorkflowRoutes`/`BundleOrchestrator`/`McpServer`/`DashboardRoutes`), and the
+  caller's `Execution:Execute` visible set is populated the same way those five surfaces populate
+  it — closing a second gap the caller-threading fix itself introduced: with `exec_visible` left
+  unpopulated, the chokepoint's own per-target intersection was a silent no-op, so
+  `devices_fn(viewer)`-and-cohort's `Infrastructure:Read`/group-membership-based narrowing was
+  standing in for a materially different authorization dimension it was never designed to
+  substitute for.
+
+  **Operator impact:** `content_dist.execute_staged` (the actual execute-on-device dispatch) is
+  itself classified `Execution:Execute`, so a role holding a GLOBAL `Execution:Execute` grant is
+  unaffected. A role holding a management-group-**scoped** `Execution:Execute` grant will now
+  correctly be refused execution on a device outside that scope, where it previously succeeded —
+  the per-device confinement this fix restores was silently a no-op before it. See the upgrade
+  note in `docs/user-manual/server-admin.md` for who this affects and what to check before
+  upgrading.

--- a/docs/authz-model.md
+++ b/docs/authz-model.md
@@ -285,13 +285,13 @@ Three new header-only files under `server/core/src/`, zero `server.cpp` involvem
   `asset_tags.sync`), each `system_reserved = true`. Every other plugin's rows live in separate
   per-group fragment headers owned by other packages; none of them are aggregated here.
 
-**Not yet wired to the live dispatch path.** As of this PR the registry is declarative data with
-its own tests (`test_command_capability.cpp`, `test_capability_catalogue.cpp`, the
-catalogue-completeness gate) — no production dispatch path constructs or consults it yet. The
-follow-up dispatch-chokepoint PR (PR1.9c, next in this stack) constructs a
-`CommandCapabilityRegistry` over all six spans in `ServerImpl` and classifies + authorizes every
-`CommandRequest` through it, at which point this paragraph is rewritten to record the registry as
-load-bearing.
+**Wired to the live dispatch path.** This paragraph previously recorded the registry as
+shipped-incomplete and reachable only from `test_command_capability.cpp`; PR1.9c ended that.
+`ServerImpl::build_classified_command` (`server.cpp`) constructs a `CommandCapabilityRegistry` over
+all six spans — `core_dispatch_capabilities()` plus the five per-group fragment headers — and every
+`CommandRequest` the server builds is classified and authorized through it. An unclassified or
+ambiguous `plugin.action` is refused there, so the registry is now load-bearing rather than
+declarative.
 
 ### Three new securables
 

--- a/docs/enterprise-readiness-soc2-first-customer.md
+++ b/docs/enterprise-readiness-soc2-first-customer.md
@@ -163,8 +163,11 @@ reference is `docs/mcp-server.md` "Revocation." and the upgrade note in
 **Addendum — per-device dispatch confinement, one seam for every operator
 surface (CC6.1/CC6.3, #1788/ADR-0033).** Every operator-facing dispatch path —
 `POST /api/command`, MCP `execute_instruction`/`execute_bundle`, REST
-`POST /api/v1/bundles`, the dashboard execute route, TAR `purge_source`, and
-`POST /api/instructions|workflows/{id}/execute` — now intersects its resolved
+`POST /api/v1/bundles`, the dashboard execute route, TAR `purge_source`,
+`POST /api/instructions|workflows/{id}/execute`, and `/auto` deployment
+staging/execution (`DeploymentRoutes`, joined this release — previously
+dispatched under system authority with no per-device confinement at all) —
+now intersects its resolved
 target set against ONE derived visibility decision (`derive_exec_visible` →
 `dispatch_confined_arms`) before sending, instead of four independently
 hand-rolled arm-classification copies. A service-scoped token is confined to

--- a/docs/user-manual/preflight.md
+++ b/docs/user-manual/preflight.md
@@ -189,6 +189,16 @@ The same engine is designed to be driven headless by an automation worker later.
 | Open the Verify form | `Infrastructure:Read` |
 | Run a Verify comparison / open the per-machine drill | `GuaranteedState:Read` |
 
+The route-level permissions above gate *whether* you can open/advance a deployment at all. Each
+advance additionally dispatches per device through the same chokepoint every other operator
+surface uses, which applies **two further, per-action checks** you don't request directly: staging
+an artifact on a device requires `SoftwareDeployment:Write`, and executing it requires
+`Execution:Execute` — confined to your `Execution:Execute`-**visible** device set, the same
+per-device confinement `Execution:Execute` enforces everywhere else (e.g. running a pre-flight,
+above). A device outside that visible set is skipped, never executed on, regardless of whether
+it's in the go-cohort. A global `Execution:Execute` grant is unaffected; a management-group-scoped
+one confines deployment execution the same way it confines everything else.
+
 Deployments are **owner-scoped** (viewing, advancing, resuming, and deleting all
 require you to be the creator; another operator's deployment reads as not-found).
 The result poll requires `Execute` as well as `Read` because the same request

--- a/docs/user-manual/server-admin.md
+++ b/docs/user-manual/server-admin.md
@@ -227,6 +227,31 @@ HAVING COUNT(*) > 1;
 
 **How to raise a cap.** Edit the table in `server/core/src/body_cap_policy.hpp` (with review) and the matching row in `docs/user-manual/rest-api.md`. Do **not** reach for httplib's global `Server::set_payload_max_length` — that knob is shared by every route on the listener, including the ~70 MiB live-query bundle route and the OTA agent-binary upload, so a single global value can't fit every route class at once. Rejections are visible per class via `yuzu_body_cap_rejected_total{path_class,reason}` — see `docs/user-manual/metrics.md`.
 
+### vNEXT — `/auto` deployment execute now enforces per-device `Execution:Execute` confinement (breaking)
+
+**What changed.** `/auto` deployment advance (staging + executing an installer on a pre-flight
+run's go-cohort) previously dispatched every `content_dist.stage`/`content_dist.execute_staged`
+command under the server's own system authority, bypassing the caller-identity check the
+chokepoint performs for every other operator-facing dispatch surface — the check the route's own
+permission gate depends on to confine *which devices* an operator's `Execution:Execute` grant
+actually reaches. It now dispatches under the triggering operator's real identity and — as of a
+second, related fix landing in the same release — is confined to that operator's
+`Execution:Execute`-visible device set at the point of dispatch, the same per-device confinement
+`RestApiV1`/`WorkflowRoutes`/`BundleOrchestrator`/`McpServer`/`DashboardRoutes` already enforce.
+
+**Who this affects.** Only deployments where a role that can trigger `/auto` deploy
+(`Infrastructure:Read` + `SoftwareDeployment:Execute`, per the permissions table in
+[`preflight.md`](preflight.md#permissions)) holds a **management-group-scoped** `Execution:Execute`
+grant — narrower than the full fleet — rather than a global one. For that role, a deployment whose
+go-cohort includes a device outside the role's `Execution:Execute` scope will now correctly skip
+that device (visible as `skipped` in the deployment's device list) instead of executing on it.
+A role with a global `Execution:Execute` grant sees no change.
+
+**Before upgrading, check for any role combining a scoped `Execution:Execute` grant with
+`SoftwareDeployment:Execute`** — that combination is the only one affected. If none of your
+deployment-triggering roles hold a scoped (rather than global) `Execution:Execute` grant, this
+note does not affect you.
+
 ### vNEXT — an authorization-topology floor now applies regardless of RBAC, and engine-principal reads move off `Security:Read` (#2376) (breaking)
 
 This note has **two independent breaking directions** — read both, they

--- a/scripts/e2e-api-test.sh
+++ b/scripts/e2e-api-test.sh
@@ -258,6 +258,22 @@ http_get_noauth "$SERVER_URL/metrics"
 assert_eq "GET /metrics returns 200" "200" "$HTTP_STATUS"
 assert_contains "GET /metrics body contains 'yuzu_'" "yuzu_" "$HTTP_BODY"
 
+# L9 (wave1 remediation): these deny counters are PRE-REGISTERED at boot
+# (server.cpp) with a concrete zero-value series, deliberately never left to
+# spring into existence on first increment — for a fail-closed check, "absent"
+# (never ran) and "zero" (ran, denied nothing) are different facts, and only
+# pre-registration keeps them distinguishable on a fresh dashboard. This is
+# the one place that boot-time wiring is provable: the counters are set on a
+# private ServerImpl member with no live-Session-free construction path, so a
+# unit test cannot reach them — only a real boot, which this e2e run against a
+# freshly-started stack (no schedule/dispatch/gateway denial has fired yet) is.
+assert_contains "GET /metrics pre-registers yuzu_server_dispatch_denied_total at boot" \
+    "yuzu_server_dispatch_denied_total" "$HTTP_BODY"
+assert_contains "GET /metrics pre-registers yuzu_server_dispatch_tag_invalid_total at boot" \
+    "yuzu_server_dispatch_tag_invalid_total" "$HTTP_BODY"
+assert_contains "GET /metrics pre-registers yuzu_server_gateway_capability_denied_total at boot" \
+    "yuzu_server_gateway_capability_denied_total" "$HTTP_BODY"
+
 log ""
 
 # ══════════════════════════════════════════════════════════════════════

--- a/server/core/src/agent_registry.cpp
+++ b/server/core/src/agent_registry.cpp
@@ -278,15 +278,68 @@ void AgentRegistry::clear_stream_if_session(const std::string& agent_id,
         session->stream = nullptr;
         session->server_context = nullptr;
         session->peer_cert_pem.clear(); // PR3 H-1: stream gone → nothing to sweep
+        // PLAN item 5: a stream that's gone has nothing live to route a
+        // dispatch-tagged command through, gateway or not — clear the
+        // advertised-capability set alongside the other connection-lifetime
+        // fields so a later reconnect starts from a clean slate rather than
+        // inheriting a prior connection's advertisement.
+        session->gateway_wire_capabilities.clear();
     }
 }
 
-void AgentRegistry::set_gateway_node(const std::string& agent_id, const std::string& node) {
-    std::lock_guard lock(mu_);
-    auto it = agents_.find(agent_id);
-    if (it != agents_.end()) {
-        it->second->gateway_node = node;
+void AgentRegistry::set_gateway_route(const std::string& agent_id, const std::string& node,
+                                      std::vector<std::string> capabilities) {
+    std::shared_ptr<AgentSession> session;
+    {
+        std::lock_guard lock(mu_);
+        auto it = agents_.find(agent_id);
+        if (it == agents_.end())
+            return;
+        session = it->second;
     }
+    // M1 (review finding): `gateway_node` and `gateway_wire_capabilities` used
+    // to be TWO setters, TWO lock domains — this one wrote `node` under `mu_`
+    // only, while `send_to`/`send_to_all` read it under `stream_mu` (a data
+    // race), and CONNECTED published the two fields in two separate calls (an
+    // observable intermediate state: node present, capabilities not yet
+    // replaced, which the gateway-capability gate could read as a false
+    // deny). Both fields are published together, under the SAME lock
+    // `send_to`/`send_to_all` already read them under, so there is exactly
+    // one lock domain and no publish step in between for a reader to land in.
+    std::lock_guard slock(session->stream_mu);
+    session->gateway_node = node;
+    // PLAN item 5: a full REPLACE, never a merge — a reconnect behind an
+    // upgraded (or downgraded) gateway build must not keep stacking
+    // capabilities a prior connection advertised but this one does not.
+    session->gateway_wire_capabilities =
+        std::unordered_set<std::string>(capabilities.begin(), capabilities.end());
+}
+
+void AgentRegistry::clear_gateway_wire_capabilities(const std::string& agent_id) {
+    std::shared_ptr<AgentSession> session;
+    {
+        std::lock_guard lock(mu_);
+        auto it = agents_.find(agent_id);
+        if (it == agents_.end())
+            return;
+        session = it->second;
+    }
+    std::lock_guard slock(session->stream_mu);
+    session->gateway_wire_capabilities.clear();
+}
+
+bool AgentRegistry::gateway_has_wire_capability(const std::string& agent_id,
+                                                std::string_view capability) const {
+    std::shared_ptr<AgentSession> session;
+    {
+        std::lock_guard lock(mu_);
+        auto it = agents_.find(agent_id);
+        if (it == agents_.end())
+            return false;
+        session = it->second;
+    }
+    std::lock_guard slock(session->stream_mu);
+    return session->gateway_wire_capabilities.contains(std::string(capability));
 }
 
 void AgentRegistry::sweep_and_publish_trusted_gateway_locked() {
@@ -378,7 +431,80 @@ void AgentRegistry::expire_trusted_gateway_for_test(std::chrono::seconds offset)
         .set(static_cast<double>(trusted_gateway_peer_ips_.size()));
 }
 
-bool AgentRegistry::send_to(const std::string& agent_id, const pb::CommandRequest& cmd) {
+namespace {
+
+/// PLAN item 3 (belt-and-braces): the TYPE invariant (private
+/// `ClassifiedCommand` constructor, `ServerImpl`-only friend) is what
+/// actually stops a hand-built `pb::CommandRequest` from reaching either send
+/// path — this is a SEPARATE, defensive runtime check that the tag a
+/// `ClassifiedCommand` carries still decodes, counted apart from the
+/// gateway-capability denial below so the two failure modes are
+/// distinguishable on a dashboard. Shared by `send_to`/`send_to_all` so the
+/// two cannot drift on what "malformed" means.
+bool tag_is_valid(const pb::CommandRequest& cmd, yuzu::MetricsRegistry& metrics,
+                  const std::string& agent_id) {
+    if (yuzu::server::decode_dispatch_tag(cmd.dispatch_tag()))
+        return true;
+    metrics.counter("yuzu_server_dispatch_tag_invalid_total").increment();
+    spdlog::error("send_to: ClassifiedCommand for agent {} carries an unparseable dispatch_tag "
+                 "'{}' — refusing to send (defensive check)",
+                 agent_id, cmd.dispatch_tag());
+    return false;
+}
+
+/// PLAN item 5 (CC-03): true iff `session` is routed through a gateway that
+/// has NOT proven — via its most recent CONNECTED advertisement — that it
+/// forwards `CommandRequest.dispatch_tag` untouched. Every dispatch reaching
+/// this point already carries a non-empty tag (only `ClassifiedCommand`
+/// reaches `send_to`/`send_to_all`, and `build_classified_command` always
+/// stamps one), so this check applies unconditionally on the gateway-routed
+/// arm — never silently downgraded to "send anyway, tag be damned".
+///
+/// DECISION (CC-03, adversarial review): the `session.gateway_node.empty()`
+/// early-return is DEFENSIVE, not the decision point, and is deliberately
+/// left as an allow. Both callers only enter the gateway arm when
+/// `gateway_node` is non-empty, so an empty node never reaches this check in
+/// production — flipping it to deny would change nothing and would misstate
+/// where the real hazard lives.
+///
+/// The real hazard is upstream and is a DELIVERY problem, not a gate-posture
+/// one. `gateway_node` (and `gateway_wire_capabilities` with it) is written
+/// only by `NotifyStreamStatus`'s CONNECTED arm, which the gateway delivers
+/// as an Erlang `gen_server:cast` (`yuzu_gw_upstream.erl`) that is dropped
+/// with no retry when the circuit is open or ≥10 notifies are in flight. A
+/// proxied agent whose arming notification was dropped therefore sits with
+/// `gateway_node == ""`, `send_to` takes the DIRECT-STREAM branch, and the
+/// command is written into the gateway's proxy Subscribe stream and never
+/// reaches the agent — the #1004 black-hole the `gateway_node`-first
+/// ordering exists to prevent. Hardening this check cannot see that state,
+/// because the state it would need to observe was never delivered.
+///
+/// What ships here instead: the two deny counters are PRE-REGISTERED at boot
+/// (server.cpp's metrics seed block), so "the check ran and passed" (zero)
+/// is distinguishable from "the check never ran" (absent) — which is exactly
+/// the blind state a dropped arming message produces. Making the arming
+/// delivery itself reliable or reconcilable is a gateway-side change with
+/// its own wire implications and is deliberately NOT folded in here.
+bool gateway_capability_missing(const AgentSession& session, yuzu::MetricsRegistry& metrics,
+                                const std::string& agent_id) {
+    if (session.gateway_node.empty())
+        return false; // direct agent — no gateway hop to prove anything about.
+    if (session.gateway_wire_capabilities.contains(
+            std::string(kGatewayWireCapabilityDispatchTagV1)))
+        return false;
+    metrics
+        .counter("yuzu_server_gateway_capability_denied_total",
+                 {{"capability", std::string(kGatewayWireCapabilityDispatchTagV1)}})
+        .increment();
+    spdlog::warn("send_to: refusing to route a dispatch-tagged command to agent {} via gateway "
+                 "node '{}' — gateway has not advertised '{}'",
+                 agent_id, session.gateway_node, kGatewayWireCapabilityDispatchTagV1);
+    return true;
+}
+
+} // namespace
+
+bool AgentRegistry::send_to(const std::string& agent_id, const ClassifiedCommand& cmd) {
     std::shared_ptr<AgentSession> session;
     {
         std::lock_guard lock(mu_);
@@ -387,6 +513,8 @@ bool AgentRegistry::send_to(const std::string& agent_id, const pb::CommandReques
             return false;
         session = it->second;
     }
+    if (!tag_is_valid(cmd.wire(), metrics_, agent_id))
+        return false;
     std::lock_guard slock(session->stream_mu);
     // #1004: prefer the gateway-pending path when `gateway_node` is set.
     // The canonical fanout path for gateway-routed agents is
@@ -398,16 +526,21 @@ bool AgentRegistry::send_to(const std::string& agent_id, const pb::CommandReques
     // black-hole where the command is Write()-en into the gateway's
     // Subscribe stream and never reaches the agent.
     if (!session->gateway_node.empty()) {
+        // PLAN item 5: DENY, counted and logged, never silently downgraded —
+        // checked under stream_mu, which already guards
+        // gateway_wire_capabilities (set/cleared under the same lock).
+        if (gateway_capability_missing(*session, metrics_, agent_id))
+            return false;
         std::lock_guard glock(gw_pending_mu_);
-        gw_pending_.push_back({agent_id, cmd});
+        gw_pending_.push_back({agent_id, cmd.wire()});
         return true;
     }
     if (session->stream)
-        return session->stream->Write(cmd, grpc::WriteOptions());
+        return session->stream->Write(cmd.wire(), grpc::WriteOptions());
     return false;
 }
 
-int AgentRegistry::send_to_all(const pb::CommandRequest& cmd) {
+int AgentRegistry::send_to_all(const ClassifiedCommand& cmd) {
     std::vector<std::shared_ptr<AgentSession>> snapshot;
     {
         std::lock_guard lock(mu_);
@@ -416,16 +549,24 @@ int AgentRegistry::send_to_all(const pb::CommandRequest& cmd) {
             snapshot.push_back(s);
         }
     }
+    if (!tag_is_valid(cmd.wire(), metrics_, "<broadcast>"))
+        return 0;
     int count = 0;
     for (auto& s : snapshot) {
         std::lock_guard slock(s->stream_mu);
         // #1004: mirror send_to() — gateway-pending path wins over any
         // Subscribe stream the gateway may also hold for the agent.
         if (!s->gateway_node.empty()) {
+            // PLAN item 5: an individual recipient's missing advertisement
+            // excludes only that agent from the count — it is not an error
+            // for the rest of the broadcast, mirroring how a dead Subscribe
+            // stream already excludes a direct agent without aborting the loop.
+            if (gateway_capability_missing(*s, metrics_, s->agent_id))
+                continue;
             std::lock_guard glock(gw_pending_mu_);
-            gw_pending_.push_back({s->agent_id, cmd});
+            gw_pending_.push_back({s->agent_id, cmd.wire()});
             ++count;
-        } else if (s->stream && s->stream->Write(cmd, grpc::WriteOptions())) {
+        } else if (s->stream && s->stream->Write(cmd.wire(), grpc::WriteOptions())) {
             ++count;
         }
     }

--- a/server/core/src/agent_registry.hpp
+++ b/server/core/src/agent_registry.hpp
@@ -5,7 +5,10 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdint>
+#include <expected>
 #include <functional>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -22,6 +25,9 @@
 
 #include <yuzu/metrics.hpp>
 #include "agent.grpc.pb.h"
+#include "command_capability.hpp"
+#include "command_capability_parsers.hpp"
+#include "dispatch_caller.hpp"
 #include "event_bus.hpp"
 #include "scope_engine.hpp"
 
@@ -31,11 +37,311 @@ class TagStore;
 class CustomPropertiesStore;
 class ResultSetStore;
 class DeviceTokenStore;
+/// PLAN (p8/PR1.9c): forward-declared so `ClassifiedCommand` below can name
+/// it as the only PRODUCTION friend able to construct one — the full
+/// definition lives entirely in server.cpp (`ServerImpl` has no separate
+/// header; `Server`'s factory is the only public surface).
+class ServerImpl;
 } // namespace yuzu::server
 
 namespace yuzu::server::detail {
 
 namespace pb = ::yuzu::agent::v1;
+
+/// CC-03 (`proto/yuzu/gateway/v1/gateway.proto`'s `StreamStatusNotification.
+/// wire_capabilities` doc comment): the ONE literal a gateway build must
+/// advertise on every CONNECTED notification before the server will route a
+/// dispatch-tagged `CommandRequest` to an agent behind it — proof the
+/// gateway's vendored `agent.proto` carries `CommandRequest.dispatch_tag = 9`
+/// and forwards it untouched. Named here (not re-typed at each call site)
+/// because `gateway_service_impl.cpp` reads it off the wire and this file's
+/// own send path checks for it — a second, independently spelled copy is
+/// exactly the kind of drift this file's #1788 doc comments warn about
+/// elsewhere.
+inline constexpr std::string_view kGatewayWireCapabilityDispatchTagV1{"command_dispatch_tag_v1"};
+
+// ── Dispatch classification + authorization (PR1.9c) ─────────────────────────
+//
+// The chokepoint invariant this section exists to hold: it must be
+// IMPOSSIBLE to put a `CommandRequest` on the wire without BOTH a
+// classification decision (does this `plugin.action` pair exist, and what is
+// it?) AND an authorization decision (may `caller` issue it?). Provenance,
+// not syntax (peer finding PLAN-011): a syntactically valid `dispatch_tag` on
+// a hand-built `pb::CommandRequest` proves nothing on its own, because
+// `encode_dispatch_tag` is a public, pure helper — so the guarantee below is
+// a TYPE invariant (`ClassifiedCommand`'s private constructor), never a
+// string check alone.
+
+/// Why `ServerImpl::build_classified_command` refused a dispatch. Every
+/// value is counted separately by the caller (ADR-0033 §2: "never a
+/// permissive default") — `Unclassified`/`Ambiguous` mirror
+/// `ClassificationError` 1:1; `AnonymousOperator`/`Forbidden` are this
+/// package's own authorization arm.
+enum class DispatchDenialReason : uint8_t {
+    Unclassified,      ///< No `CommandCapability` row matches `plugin.action`.
+    Ambiguous,         ///< Two+ fragments independently declared the same row.
+    AnonymousOperator, ///< `caller.system == false` with an empty `principal`.
+    Forbidden,         ///< Classified, but `caller` may not issue it — either an
+                       ///< operator lacking the resolved securable/operation, or
+                       ///< ANY operator attempting a `system_reserved` row.
+    KillSwitched,      ///< Classified and authorized, but the per-action kill
+                       ///< switch is OFF for this `plugin.action` (or the config
+                       ///< store is degraded, which `action_allowed` reports as
+                       ///< disabled — never as enabled). Deliberately DISTINCT
+                       ///< from `Forbidden`: this is an operator-thrown
+                       ///< emergency stop, not an authorization verdict, and an
+                       ///< incident review needs to tell the two apart.
+};
+
+/// A refused dispatch. `securable`/`operation` are populated only once
+/// classification itself succeeded — `Unclassified`/`Ambiguous` carry no
+/// resolved securable, there is nothing to name yet (a caller
+/// logging/auditing a denial must branch on `reason` before trusting
+/// `securable`). `AnonymousOperator` and `Forbidden` are raised AFTER
+/// classification resolved, so both DO name the securable the caller failed
+/// to satisfy — that is what makes the audit line actionable.
+///
+/// `securable` owns its characters rather than viewing `CommandCapability`'s
+/// static storage: a denial is the exceptional path, and the consumers
+/// concatenate it into operator-facing messages.
+struct DispatchDenial {
+    DispatchDenialReason reason;
+    std::string securable;
+    authz::Operation operation{authz::Operation::Read};
+};
+
+/// The pure classify+authorize DECISION `ServerImpl::build_classified_command`
+/// is built around, extracted so it is directly unit-testable without a live
+/// `ServerImpl`/`RbacStore`/database — the same reasoning
+/// `dispatch_confined_arms.hpp` and `dispatch_target_shape.hpp` give for their
+/// own extractions: a from-scratch copy inside a test is how a shared rule
+/// silently drifts from what production actually enforces.
+///
+/// `has_permission` is injected rather than a live `RbacStore*` so this
+/// function's job stays exactly one question — "is `principal` granted
+/// `operation` on `securable`, right now" — and every HTTP/session-layer
+/// nuance stays OUTSIDE it, owned by whatever binds the callback. Never
+/// memoize the callback's answer across calls (ADR-0012 §4) — this function
+/// itself never does, and neither may a caller.
+///
+/// WHAT THE PRODUCTION BINDER ACTUALLY HANDLES TODAY (server.cpp): legacy-open
+/// (a loaded-and-disabled RbacStore admits, as every other dispatch-adjacent
+/// read here does) and a raw `RbacStore::check_permission`. It does NOT apply
+/// JIT elevation: `auth::effective_role` elevates a cookie session to admin for
+/// its window, and the elevation-aware surface gate (`require_permission`)
+/// admits on that, but this callback receives only a principal STRING and
+/// resolves that principal's BASE grants. So a JIT-elevated operator can clear
+/// the surface gate and then be denied `Forbidden` here for a securable their
+/// base role lacks. That is FAIL-CLOSED — it denies, never over-permits — but
+/// it is a real gap in the elevated-dispatch workflow rather than a design
+/// choice, and whether elevated authority SHOULD reach dispatch is a security
+/// decision that needs its own review. Tracked; do not silently widen this
+/// callback to close it.
+///
+/// System arm (PLAN item 2): `caller.system == true` is trusted BY
+/// CONSTRUCTION — `DispatchCaller::system` is set explicitly only at
+/// background/system call sites, never derived from external input
+/// (`dispatch_caller.hpp`) — so it is routed under an explicit system
+/// identity rather than a caller-attributable RBAC decision, which is
+/// exactly what `system_reserved` rows are FOR
+/// (`capability_decls/core_dispatch_capabilities.hpp`). What a system caller
+/// is NOT excused from is classification itself: an unclassified or
+/// ambiguous `plugin.action` is refused for a system caller exactly as for an
+/// operator one — "route under an identity", never "skip the chokepoint".
+[[nodiscard]] inline std::expected<CommandCapability, DispatchDenial>
+classify_and_authorize_dispatch(
+    const CommandCapabilityRegistry& registry, const DispatchCaller& caller,
+    std::string_view plugin, std::string_view action,
+    const std::function<bool(std::string_view principal, std::string_view securable,
+                             authz::Operation operation)>& has_permission) {
+    auto classified = registry.classify(plugin, action);
+    if (!classified) {
+        return std::unexpected(DispatchDenial{
+            classified.error() == ClassificationError::Ambiguous ? DispatchDenialReason::Ambiguous
+                                                                  : DispatchDenialReason::Unclassified,
+            {}, authz::Operation::Read});
+    }
+    const CommandCapability cap = *classified;
+
+    if (caller.system)
+        return cap;
+
+    // No anonymous operator dispatch (PLAN item 2): an empty principal must
+    // never reach `has_permission`, where a legacy-open store would admit it
+    // by accident — `RbacStore::check_permission` has no notion of "no such
+    // caller", only of "no matching role_permissions row".
+    if (caller.principal.empty())
+        return std::unexpected(
+            DispatchDenial{DispatchDenialReason::AnonymousOperator, std::string(cap.securable),
+                           cap.operation});
+
+    // A `system_reserved` row is dispatchable ONLY under a system caller
+    // (PLAN item 2) — never caller-attributable, so an operator is refused
+    // here regardless of what RBAC says about them; consulting
+    // `has_permission` for a row that by definition names no legitimate
+    // operator grant would be a category error, not a stricter check.
+    if (cap.system_reserved)
+        return std::unexpected(
+            DispatchDenial{DispatchDenialReason::Forbidden, std::string(cap.securable),
+                           cap.operation});
+
+    if (!has_permission(caller.principal, cap.securable, cap.operation))
+        return std::unexpected(
+            DispatchDenial{DispatchDenialReason::Forbidden, std::string(cap.securable),
+                           cap.operation});
+
+    return cap;
+}
+
+/// The frozen v1 dispatch-tag wire grammar (`command_capability_parsers.hpp`),
+/// composed once so `ServerImpl::build_classified_command` and this file's own
+/// tests always stamp/verify a tag the IDENTICAL way — `encode_dispatch_tag` +
+/// `compute_plan_hash` are p1-owned pure helpers; this is the one place p8
+/// composes them, so a test can call this directly rather than re-deriving the
+/// composition from scratch.
+[[nodiscard]] inline std::string
+compute_dispatch_tag(const CommandCapability& cap, std::string_view plugin, std::string_view action,
+                     const std::map<std::string, std::string>& parameters,
+                     std::string_view target_arm, std::string_view execution_id) {
+    return encode_dispatch_tag(
+        cap.dispatch_class, cap.mutability,
+        compute_plan_hash(plugin, action, parameters, target_arm, execution_id));
+}
+
+class ClassifiedCommand; // Forward decl — completed below; needed as an
+                         // incomplete type by the declaration immediately
+                         // following.
+
+/// Forward declaration so `ClassifiedCommand` can friend it below — the
+/// definition (which needs the completed class) follows the class. Default
+/// arguments live here, the one declaration every caller and the friend
+/// grant both see; the out-of-class definition repeats none of them (a
+/// second default-argument set on the same declaration is ill-formed).
+[[nodiscard]] inline std::expected<ClassifiedCommand, DispatchDenial> finalize_classified_command(
+    const CommandCapability& cap,
+    const std::function<bool(std::string_view plugin, std::string_view action)>& action_allowed,
+    std::string_view raw_plugin, std::string_view raw_action, const std::string& command_id,
+    const std::unordered_map<std::string, std::string>& parameters = {},
+    const std::string& payload = {}, int stagger_seconds = 0, int delay_seconds = 0,
+    const std::string& target_arm = {}, const std::string& execution_id = {});
+
+/// PLAN item 3 (PLAN-011, provenance not syntax): the type-level guarantee
+/// that a `pb::CommandRequest` reaching `AgentRegistry::send_to`/`send_to_all`
+/// passed through `ServerImpl::build_classified_command` — a syntactically
+/// valid `dispatch_tag` proves nothing on its own, since `encode_dispatch_tag`
+/// is a public, pure helper any caller could stamp onto a hand-built proto.
+/// The guarantee is therefore a TYPE invariant: PRIVATE constructor, no public
+/// setter, no public conversion that yields a mutable `pb::CommandRequest` —
+/// only `ServerImpl` (production), `finalize_classified_command` (production,
+/// below), and `ClassifiedCommandTestAccess` (tests, mirroring
+/// `EngineLivenessTestAccess` in `engine_principal_store.hpp`) may construct
+/// one. A caller that hand-builds a protobuf cannot reach the registry at
+/// all: there is no overload of `send_to`/`send_to_all` that accepts one.
+class ClassifiedCommand {
+public:
+    /// Read-only view of the wire command. Deliberately a named accessor
+    /// returning `const&`, never a conversion operator — a conversion would
+    /// let a `ClassifiedCommand` silently decay to a mutable
+    /// `pb::CommandRequest` at a call site that forgot which type it held.
+    [[nodiscard]] const pb::CommandRequest& wire() const noexcept { return cmd_; }
+
+private:
+    friend class yuzu::server::ServerImpl;
+    friend struct ClassifiedCommandTestAccess;
+    friend std::expected<ClassifiedCommand, DispatchDenial> finalize_classified_command(
+        const CommandCapability&, const std::function<bool(std::string_view, std::string_view)>&,
+        std::string_view, std::string_view, const std::string&,
+        const std::unordered_map<std::string, std::string>&, const std::string&, int, int,
+        const std::string&, const std::string&);
+
+    explicit ClassifiedCommand(pb::CommandRequest cmd) : cmd_(std::move(cmd)) {}
+
+    pb::CommandRequest cmd_;
+};
+
+/// The composition step `ServerImpl::build_classified_command` runs AFTER
+/// `classify_and_authorize_dispatch` succeeds — extracted for the identical
+/// reason that function was: a from-scratch copy inside a test is how a
+/// shared rule silently drifts from what production actually enforces, and
+/// until this extraction NOTHING unit-tested it directly (M6, wave1
+/// remediation). Two behaviours live here, both revert-survivor-sensitive:
+///
+/// 1. **The per-action kill switch.** `action_allowed` is injected exactly
+///    like `classify_and_authorize_dispatch`'s `has_permission` — the
+///    production binder wraps `PluginConfigStore::action_allowed`, fail-closed
+///    by that store's own contract (a closed store, a lease timeout, or a
+///    query failure all report "not allowed"). An empty/unset callback means
+///    no kill-switch store is wired at all (legacy-open for THIS gate,
+///    mirroring how an absent `plugin_config_store_` behaves in
+///    `server.cpp`) — never call this with a callback that unconditionally
+///    returns `true` "to be safe"; that reintroduces exactly the ZERO-callers
+///    gap this composition exists to close.
+/// 2. **BR-009 canonical wire names.** The wire command is built from `cap`'s
+///    catalogue-resolved spelling (`cap.plugin`/`cap.action`), never the
+///    caller's raw strings — `classify()` is case-insensitive but the agent
+///    matches case-SENSITIVELY, so a caller passing `plugin="TAR"` would
+///    otherwise be authorized here and rejected on the endpoint. `raw_plugin`/
+///    `raw_action` are threaded through ONLY into the dispatch-tag hash
+///    (`compute_dispatch_tag`), unchanged from what `build_classified_command`
+///    always passed there — the hash and the wire fields are deliberately
+///    fed different spellings and this preserves that, rather than "fixing"
+///    it as part of an unrelated extraction.
+[[nodiscard]] inline std::expected<ClassifiedCommand, DispatchDenial> finalize_classified_command(
+    const CommandCapability& cap,
+    const std::function<bool(std::string_view plugin, std::string_view action)>& action_allowed,
+    std::string_view raw_plugin, std::string_view raw_action, const std::string& command_id,
+    const std::unordered_map<std::string, std::string>& parameters,
+    const std::string& payload, int stagger_seconds, int delay_seconds,
+    const std::string& target_arm, const std::string& execution_id) {
+    if (action_allowed && !action_allowed(cap.plugin, cap.action)) {
+        return std::unexpected(
+            DispatchDenial{DispatchDenialReason::KillSwitched, std::string(cap.securable),
+                           cap.operation});
+    }
+
+    pb::CommandRequest cmd;
+    cmd.set_command_id(command_id);
+    cmd.set_plugin(std::string(cap.plugin));
+    cmd.set_action(std::string(cap.action));
+    for (const auto& [k, v] : parameters)
+        (*cmd.mutable_parameters())[k] = v;
+    if (!payload.empty())
+        cmd.set_payload(payload);
+    if (stagger_seconds > 0)
+        cmd.set_stagger_seconds(stagger_seconds);
+    if (delay_seconds > 0)
+        cmd.set_delay_seconds(delay_seconds);
+
+    const std::map<std::string, std::string> ordered_params(parameters.begin(), parameters.end());
+    cmd.set_dispatch_tag(
+        compute_dispatch_tag(cap, raw_plugin, raw_action, ordered_params, target_arm, execution_id));
+
+    return ClassifiedCommand(std::move(cmd));
+}
+
+/// Test-only door to the private constructor above (#2367 pattern — mirrors
+/// `EngineLivenessTestAccess`, `engine_principal_store.hpp`, identical
+/// rationale). Declared here; the definition is deliberately withheld from
+/// every production translation unit and lives ONLY in
+/// `tests/unit/server/classified_command_test_access.cpp`, a TU that links
+/// into the test binary and is never added to server_core's (or any other
+/// production target's) source list. Production code MUST go through
+/// `ServerImpl::build_classified_command` — if a production TU ever
+/// referenced `ClassifiedCommandTestAccess::make`, it would still COMPILE
+/// (the declaration is visible via this header) but FAIL TO LINK, because no
+/// production link line carries the definition. That is what upgrades
+/// "test-only" from a doc-comment convention to a structural,
+/// compile/link-time-enforced control, exactly as #2367 did for
+/// `EngineLivenessTestAccess`. This exists only so a unit test can construct
+/// a `ClassifiedCommand` fixture without a live
+/// `ServerImpl`/`RbacStore`/`CommandCapabilityRegistry`, and so the ONE
+/// pre-existing test that threads a real `pb::CommandRequest` through
+/// `wire_and_dispatch_confined` into a REAL `AgentRegistry`
+/// (`test_dispatch_confined_arms.cpp`'s K-1 case) keeps compiling against
+/// `send_to`'s narrowed signature.
+struct ClassifiedCommandTestAccess {
+    [[nodiscard]] static ClassifiedCommand make(pb::CommandRequest cmd);
+};
 
 // -- Plugin metadata ----------------------------------------------------------
 
@@ -48,12 +354,19 @@ struct PluginMeta {
 
 // -- Agent session (one per connected agent) ----------------------------------
 //
-// IMMUTABILITY CONTRACT: the identity fields (agent_id..scopable_tags,
-// gateway_node) are fully populated BEFORE the session is installed in the
-// registry and are never mutated afterwards — re-registration REPLACES the
-// shared_ptr, it does not edit in place. Lock-free readers (scope evaluation,
-// the DEX perf provider) depend on this. Post-publication writes are confined
-// to stream/server_context/peer_cert_pem (under stream_mu) and the atomic
+// IMMUTABILITY CONTRACT: the identity fields (agent_id..scopable_tags) are
+// fully populated BEFORE the session is installed in the registry and are
+// never mutated afterwards — re-registration REPLACES the shared_ptr, it
+// does not edit in place. Lock-free readers (scope evaluation, the DEX perf
+// provider) depend on this — NONE of them reads `gateway_node` or
+// `gateway_wire_capabilities` (verified: their only readers are
+// send_to/send_to_all, agent_registry.cpp, both under `stream_mu`), which is
+// exactly why those two are NOT in this list. Post-publication writes are
+// confined to stream/server_context/peer_cert_pem, gateway_node +
+// gateway_wire_capabilities (all under stream_mu — the trailing pair
+// published together by set_gateway_route, M1 review fix; an earlier
+// revision wrote gateway_node under the registry mu_ instead, which both
+// raced stream_mu's readers and contradicted this comment) and the atomic
 // last_activity_epoch_ms. (Governance G3 cpp-safety — keep it true.)
 
 struct AgentSession {
@@ -77,6 +390,14 @@ struct AgentSession {
     // the agent presented no client cert. Guarded by stream_mu alongside stream/
     // server_context.
     std::string peer_cert_pem;
+    /// PLAN item 5 (CC-03): the literal wire-capability strings this agent's
+    /// gateway advertised on its most recent CONNECTED
+    /// `StreamStatusNotification` — empty for a direct (non-gateway) agent
+    /// and for a gateway build too old to advertise any. Guarded by
+    /// `stream_mu` alongside the other post-publication, connection-lifetime
+    /// fields above: a reconnect (a fresh CONNECTED) REPLACES this set, it is
+    /// never merged with a prior connection's advertisement (PLAN item 5).
+    std::unordered_set<std::string> gateway_wire_capabilities;
     std::mutex stream_mu;
 
     // Last activity timestamp -- updated on Subscribe reads and Heartbeats.
@@ -133,7 +454,38 @@ public:
     /// Clear stream only if the session_id matches the current session.
     void clear_stream_if_session(const std::string& agent_id, const std::string& session_id);
 
-    void set_gateway_node(const std::string& agent_id, const std::string& node);
+    /// PLAN item 5 (CC-03) / M1 (review finding, post-merge round): record
+    /// the gateway node AND the literal wire-capability strings it
+    /// advertised for `agent_id` on a CONNECTED `StreamStatusNotification` —
+    /// called by `GatewayUpstreamServiceImpl::NotifyStreamStatus`. ONE call,
+    /// not two: both fields are published together under `stream_mu`, the
+    /// SAME lock `send_to`/`send_to_all` read them under (agent_registry.cpp)
+    /// — this used to be two setters in two different lock domains (`node`
+    /// under the registry `mu_` only), which was both a C++ data race on
+    /// `gateway_node` and let a reader observe `node` present with
+    /// capabilities not yet replaced (a false gateway-capability denial).
+    /// `capabilities` is ALWAYS a full replace, never a merge: a reconnect
+    /// (fresh CONNECTED) behind an upgraded — or downgraded — gateway build
+    /// must not keep stacking capabilities the new connection never
+    /// advertised. No-op if `agent_id` is not currently registered.
+    void set_gateway_route(const std::string& agent_id, const std::string& node,
+                           std::vector<std::string> capabilities);
+
+    /// PLAN item 5: drop every advertised wire capability for `agent_id`.
+    /// Called on DISCONNECTED. `clear_stream_if_session` also clears this set
+    /// (a session whose stream is gone has nothing live to route through),
+    /// so a caller that reaches disconnection via that path needs no
+    /// separate call.
+    void clear_gateway_wire_capabilities(const std::string& agent_id);
+
+    /// PLAN item 5: true iff `agent_id` is currently registered AND its most
+    /// recent gateway CONNECTED notification advertised `capability`
+    /// literally. False for an unknown agent, a direct (non-gateway) agent,
+    /// or a gateway build that never advertised it — every one of those is
+    /// "cannot prove this gateway forwards a tagged command", the fail-closed
+    /// direction `send_to`/`send_to_all`'s routed-path check depends on.
+    [[nodiscard]] bool gateway_has_wire_capability(const std::string& agent_id,
+                                                   std::string_view capability) const;
 
     /// #826: record a peer-IP (e.g. `1.2.3.4`, no port, no scheme) as a
     /// trusted gateway. Populated by `GatewayUpstreamServiceImpl` when a
@@ -206,15 +558,32 @@ public:
     /// lock costs nothing and removes a footgun.
     void set_device_token_store(DeviceTokenStore* store);
 
-    // Send a command to a specific agent. Returns false if agent not found or write failed.
-    // For gateway agents (no local stream), adds to gateway_pending and returns true.
-    bool send_to(const std::string& agent_id, const pb::CommandRequest& cmd);
+    // PLAN item 3 (provenance not syntax): only a `ClassifiedCommand` — mintable
+    // ONLY by `ServerImpl::build_classified_command` (or the test-only door) —
+    // can reach either of these. A hand-built `pb::CommandRequest` has no
+    // overload to bind to; this is a compile-time invariant, not a runtime
+    // check (`tests/unit/server/test_dispatch_chokepoint.cpp` pins it).
+    //
+    // Send a command to a specific agent. Returns false if agent not found,
+    // the defensive dispatch_tag check fails, the routed-path gateway-capability
+    // check refuses it (PLAN item 5), or the write itself failed. For gateway
+    // agents (no local stream), adds to gateway_pending and returns true.
+    bool send_to(const std::string& agent_id, const ClassifiedCommand& cmd);
 
-    // Send command to all connected agents. Returns count of agents sent to.
-    int send_to_all(const pb::CommandRequest& cmd);
+    // Send command to all connected agents. Returns count of agents actually
+    // reached — an agent refused by the defensive tag check or the routed-path
+    // gateway-capability check (PLAN item 5) is silently excluded from the count,
+    // never treated as an error for the other recipients.
+    int send_to_all(const ClassifiedCommand& cmd);
 
     struct GatewayPendingCmd {
         std::string agent_id;
+        // Unwrapped to the raw wire type on purpose: by the time a command is
+        // queued here, `send_to`/`send_to_all` have already required a
+        // `ClassifiedCommand` to reach this point — the provenance guarantee
+        // has already done its job, and `forward_gateway_pending` (server.cpp)
+        // only re-wraps this into a `SendCommandRequest`, never re-decides
+        // classification or authorization.
         pb::CommandRequest cmd;
     };
 

--- a/server/core/src/bundle_orchestrator.cpp
+++ b/server/core/src/bundle_orchestrator.cpp
@@ -95,8 +95,17 @@ BundleOrchestrator::dispatch(const std::string& agent_id, const std::vector<Bund
                 // wrapper (REST scoped_perm_fn / MCP in_scope) already confined
                 // `agent_id` against it, so this is a defense-in-depth pass-
                 // through, not a re-decision.
+                //
+                // PR1.9c: the same pass-through reasoning now covers the whole
+                // caller. `principal` is this method's own parameter (the bundle
+                // owner the wrapper authenticated), so the chokepoint sees a real
+                // identity instead of the empty one that made every bundle step
+                // fail `AnonymousOperator`. `principal_role` stays empty: the
+                // chokepoint requires only a non-empty principal, and the
+                // orchestrator has no role to report without re-deriving one.
                 dispatch_(s.plugin, s.action, {agent_id}, /*scope=*/"", params, correlation,
-                          exec_visible);
+                          yuzu::server::DispatchCaller{.principal = principal,
+                                                       .exec_visible = exec_visible});
             ok = sent > 0 && !command_id.empty();
         } catch (const std::exception& e) {
             spdlog::warn("BundleOrchestrator: dispatch threw for step {}.{} ({}): {}", s.plugin,

--- a/server/core/src/bundle_orchestrator.hpp
+++ b/server/core/src/bundle_orchestrator.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "authz_model.hpp"    // #1788: VisibleSet — DispatchFn confinement param
+#include "authz_model.hpp"    // #1788: VisibleSet — dispatch() confinement param
 #include "bundle_service.hpp" // BundleStepSpec, DispatchedStep, BundleAggregate
+#include "dispatch_caller.hpp" // PR1.9c: DispatchCaller — DispatchFn's caller param
 
 #include <cstddef>
 #include <cstdint>
@@ -69,7 +70,14 @@ public:
         // both). The orchestrator never derives or re-decides this set itself
         // (governance UP-8) — it threads through whatever `dispatch()`'s caller
         // supplied unchanged; see that method's doc comment below.
-        const yuzu::server::authz::VisibleSet& exec_visible)>;
+        //
+        // PR1.9c: this carries the whole CALLER, not just the visible set.
+        // `build_classified_command` refuses an empty `DispatchCaller::principal`
+        // as `AnonymousOperator` BEFORE the legacy-open bypass, so a
+        // VisibleSet-only shape made every bundle step undeliverable on both
+        // surfaces. `dispatch()` already receives `principal`, so the caller is
+        // assembled there — no new data crosses this boundary.
+        const yuzu::server::DispatchCaller& caller)>;
 
     /// Per-step audit sink, request-bound by the wrapper (so the core stays
     /// req-free). Called once per step with a transport-agnostic verb.

--- a/server/core/src/dashboard_routes.cpp
+++ b/server/core/src/dashboard_routes.cpp
@@ -162,14 +162,14 @@ void DashboardRoutes::register_routes(httplib::Server& svr,
                                        detail::EventBus* event_bus,
                                        AgentsJsonFn agents_json_fn,
                                        DispatchFn dispatch_fn,
-                                       ExecVisibleFn exec_visible_fn,
+                                       CallerFn caller_fn,
                                        ResolveFn resolve_fn,
                                        yuzu::MetricsRegistry* metrics,
                                        InstructionStore* instruction_store) {
     HttplibRouteSink sink(svr);
     register_routes(sink, std::move(auth_fn), std::move(perm_fn), std::move(audit_fn),
                     response_store, mgmt_group_store, registry, tag_store, event_bus,
-                    std::move(agents_json_fn), std::move(dispatch_fn), std::move(exec_visible_fn),
+                    std::move(agents_json_fn), std::move(dispatch_fn), std::move(caller_fn),
                     std::move(resolve_fn), metrics, instruction_store);
 }
 
@@ -181,7 +181,7 @@ void DashboardRoutes::register_routes(HttpRouteSink& sink,
                                        detail::EventBus* event_bus,
                                        AgentsJsonFn agents_json_fn,
                                        DispatchFn dispatch_fn,
-                                       ExecVisibleFn exec_visible_fn,
+                                       CallerFn caller_fn,
                                        ResolveFn resolve_fn,
                                        yuzu::MetricsRegistry* metrics,
                                        InstructionStore* instruction_store) {
@@ -195,7 +195,7 @@ void DashboardRoutes::register_routes(HttpRouteSink& sink,
     event_bus_ = event_bus;
     agents_json_fn_ = std::move(agents_json_fn);
     dispatch_fn_ = std::move(dispatch_fn);
-    exec_visible_fn_ = std::move(exec_visible_fn);
+    caller_fn_ = std::move(caller_fn);
     resolve_fn_ = std::move(resolve_fn);
     metrics_ = metrics;
     instruction_store_ = instruction_store;
@@ -761,11 +761,12 @@ void DashboardRoutes::register_routes(HttpRouteSink& sink,
                  // dispatch_confined seam (same confinement as /api/command +
                  // MCP). An UNWIRED derivation fails CLOSED (present-empty set →
                  // reaches nobody), never nullopt/unfiltered.
-                 yuzu::server::authz::VisibleSet exec_visible =
-                     exec_visible_fn_ ? exec_visible_fn_(req)
-                                      : yuzu::server::authz::deny_all();
+                 yuzu::server::DispatchCaller caller =
+                     caller_fn_ ? caller_fn_(req)
+                               : yuzu::server::DispatchCaller{
+                                     .exec_visible = yuzu::server::authz::deny_all()};
                  auto [command_id, sent] =
-                     dispatch_fn_(plugin, action, agent_ids, scope_expr, inline_params, exec_visible);
+                     dispatch_fn_(plugin, action, agent_ids, scope_expr, inline_params, caller);
                  if (sent == 0) {
                      res.set_content(
                          "<span id=\"result-context\" hx-swap-oob=\"true\""
@@ -956,11 +957,12 @@ void DashboardRoutes::register_routes(HttpRouteSink& sink,
                  params["sql"] = sql;
                  // CDX-R7-02: same confinement as /api/dashboard/execute — narrow
                  // to the operator's visible set, fail CLOSED if unwired.
-                 yuzu::server::authz::VisibleSet exec_visible =
-                     exec_visible_fn_ ? exec_visible_fn_(req)
-                                      : yuzu::server::authz::deny_all();
+                 yuzu::server::DispatchCaller caller =
+                     caller_fn_ ? caller_fn_(req)
+                               : yuzu::server::DispatchCaller{
+                                     .exec_visible = yuzu::server::authz::deny_all()};
                  auto [command_id, sent] =
-                     dispatch_fn_("tar", "sql", agent_ids, scope_expr, params, exec_visible);
+                     dispatch_fn_("tar", "sql", agent_ids, scope_expr, params, caller);
 
                  if (sent == 0) {
                      res.set_content("<span id=\"result-context\" hx-swap-oob=\"true\""
@@ -1166,11 +1168,12 @@ void DashboardRoutes::register_routes(HttpRouteSink& sink,
                  // dispatch_confined seam, so a service-scoped token cannot scan
                  // an out-of-service device its username visibility would admit.
                  // Fail CLOSED (present-empty) if the derivation is unwired.
-                 yuzu::server::authz::VisibleSet exec_visible =
-                     exec_visible_fn_ ? exec_visible_fn_(req)
-                                      : yuzu::server::authz::deny_all();
+                 yuzu::server::DispatchCaller caller =
+                     caller_fn_ ? caller_fn_(req)
+                               : yuzu::server::DispatchCaller{
+                                     .exec_visible = yuzu::server::authz::deny_all()};
                  auto [command_id, sent] = dispatch_fn_(
-                     "tar", "status", agent_ids, /*scope_expr=*/"", params, exec_visible);
+                     "tar", "status", agent_ids, /*scope_expr=*/"", params, caller);
 
                  {
                      std::lock_guard<std::mutex> lk(tar_scan_mu_);
@@ -1378,12 +1381,13 @@ void DashboardRoutes::register_routes(HttpRouteSink& sink,
                  // arm of dispatch_confined drops an out-of-scope device_id), so
                  // a service-scoped token cannot re-enable capture on a device
                  // outside its service. Fail CLOSED if the derivation is unwired.
-                 yuzu::server::authz::VisibleSet exec_visible =
-                     exec_visible_fn_ ? exec_visible_fn_(req)
-                                      : yuzu::server::authz::deny_all();
+                 yuzu::server::DispatchCaller caller =
+                     caller_fn_ ? caller_fn_(req)
+                               : yuzu::server::DispatchCaller{
+                                     .exec_visible = yuzu::server::authz::deny_all()};
                  auto [command_id, sent] = dispatch_fn_(
                      "tar", "configure", {device_id}, /*scope_expr=*/"",
-                     params, exec_visible);
+                     params, caller);
 
                  if (sent == 0) {
                      audit_fn_(req, "tar.source.reenable", "failure",
@@ -1545,12 +1549,13 @@ void DashboardRoutes::register_routes(HttpRouteSink& sink,
                  // a device outside its service even if username visibility would
                  // admit it. The Ids arm of dispatch_confined drops an
                  // out-of-scope device_id; fail CLOSED if the derivation is unwired.
-                 yuzu::server::authz::VisibleSet exec_visible =
-                     exec_visible_fn_ ? exec_visible_fn_(req)
-                                      : yuzu::server::authz::deny_all();
+                 yuzu::server::DispatchCaller caller =
+                     caller_fn_ ? caller_fn_(req)
+                               : yuzu::server::DispatchCaller{
+                                     .exec_visible = yuzu::server::authz::deny_all()};
                  auto [command_id, sent] =
                      dispatch_fn_("tar", "purge_source", {device_id}, /*scope_expr=*/"", params,
-                                  exec_visible);
+                                  caller);
 
                  if (sent == 0) {
                      audit_fn_(req, "tar.source.purge", "failure", "command", "",

--- a/server/core/src/dashboard_routes.hpp
+++ b/server/core/src/dashboard_routes.hpp
@@ -20,6 +20,7 @@
 #include <yuzu/server/auth.hpp>
 
 #include "authz_model.hpp" // yuzu::server::authz::VisibleSet (#1788 / CDX-R7-02)
+#include "dispatch_caller.hpp" // PLAN-006: DispatchCaller — the principal threaded to dispatch_fn
 
 namespace yuzu::server {
 
@@ -51,24 +52,26 @@ public:
 
     /// Send command callback — dispatches a command and returns (command_id, agents_reached).
     ///
-    /// CDX-R7-02: carries the caller's Execution:Execute visible set as a
-    /// trailing param so the dashboard execute surface narrows to it via the
-    /// shared `dispatch_confined` seam, exactly as /api/command and MCP do.
-    /// nullopt == unfiltered.
+    /// CDX-R7-02 / PLAN-006: carries the caller — identity plus its
+    /// Execution:Execute visible set — as a trailing param so the dashboard
+    /// execute surface narrows to it AND records who asked, via the shared
+    /// `dispatch_confined` seam, exactly as /api/command and MCP do.
+    /// `exec_visible` nullopt == unfiltered.
     using DispatchFn = std::function<std::pair<std::string, int>(
         const std::string& plugin, const std::string& action,
         const std::vector<std::string>& agent_ids, const std::string& scope_expr,
         const std::unordered_map<std::string, std::string>& parameters,
-        const yuzu::server::authz::VisibleSet& exec_visible)>;
+        const yuzu::server::DispatchCaller& caller)>;
 
-    /// CDX-R7-02: resolves the caller's Execution:Execute visible set from the
-    /// request (the dashboard execute handlers gate via `perm_fn_` and hold no
-    /// Session object at the dispatch site). Wired in server.cpp to a closure
-    /// that resolves the session and calls `derive_exec_visible`; an UNWIRED
-    /// callback fails CLOSED (the handler passes a present-EMPTY set — deny all,
-    /// never nullopt).
-    using ExecVisibleFn =
-        std::function<yuzu::server::authz::VisibleSet(const httplib::Request&)>;
+    /// CDX-R7-02 / PLAN-006: resolves the caller's DispatchCaller (identity +
+    /// Execution:Execute visible set) from the request (the dashboard execute
+    /// handlers gate via `perm_fn_` and hold no Session object at the dispatch
+    /// site). Wired in server.cpp to a closure that resolves the session and
+    /// calls `derive_dispatch_caller`; an UNWIRED callback fails CLOSED on
+    /// visibility (the handler passes an empty principal alongside a
+    /// present-EMPTY set — deny all, never nullopt).
+    using CallerFn =
+        std::function<yuzu::server::DispatchCaller(const httplib::Request&)>;
 
     /// Resolve instruction text → (plugin, action). Empty strings on failure.
     using ResolveFn = std::function<std::pair<std::string, std::string>(
@@ -85,7 +88,7 @@ public:
                          detail::EventBus* event_bus,
                          AgentsJsonFn agents_json_fn,
                          DispatchFn dispatch_fn,
-                         ExecVisibleFn exec_visible_fn,
+                         CallerFn caller_fn,
                          ResolveFn resolve_fn,
                          yuzu::MetricsRegistry* metrics = nullptr,
                          InstructionStore* instruction_store = nullptr);
@@ -106,7 +109,7 @@ public:
                          detail::EventBus* event_bus,
                          AgentsJsonFn agents_json_fn,
                          DispatchFn dispatch_fn,
-                         ExecVisibleFn exec_visible_fn,
+                         CallerFn caller_fn,
                          ResolveFn resolve_fn,
                          yuzu::MetricsRegistry* metrics = nullptr,
                          InstructionStore* instruction_store = nullptr);
@@ -137,7 +140,7 @@ private:
     InstructionStore* instruction_store_{nullptr};
     AgentsJsonFn agents_json_fn_;
     DispatchFn dispatch_fn_;
-    ExecVisibleFn exec_visible_fn_;
+    CallerFn caller_fn_;
     ResolveFn resolve_fn_;
     yuzu::MetricsRegistry* metrics_{nullptr};
 

--- a/server/core/src/deployment_engine.cpp
+++ b/server/core/src/deployment_engine.cpp
@@ -117,10 +117,37 @@ void advance(const EngineDeps& deps, const std::string& deployment_id, const Dep
                 authorized.find(d.agent_id) != authorized.end())
                 cand.push_back(d.agent_id);
         auto claimed = deps.store->claim_for_stage(deployment_id, cand);
-        if (!claimed.empty())
-            deps.dispatch_fn("content_dist", "stage", claimed, "",
-                             {{"url", cfg.url}, {"filename", cfg.filename}, {"sha256", cfg.sha256}},
-                             stage_execution_id(deployment_id), caller);
+        if (!claimed.empty()) {
+            const auto [cmd, sent] = deps.dispatch_fn(
+                "content_dist", "stage", claimed, "",
+                {{"url", cfg.url}, {"filename", cfg.filename}, {"sha256", cfg.sha256}},
+                stage_execution_id(deployment_id), caller);
+            // #3133 round-2 review MEDIUM: the claim used to be uncondition-
+            // ally left in 'staging' with the dispatch result discarded — a
+            // chokepoint-denied dispatch (caller lacks the classified
+            // permission for content_dist.stage) or a zero-reach dispatch
+            // left every claimed row stuck in an active step forever, with
+            // no dispatched command and no transition to move it. Settle
+            // them to the terminal 'failed' with an honest error instead —
+            // via the same source-step-GUARDED transitions as every other
+            // mutation here, so a row a concurrent advance already moved is
+            // untouched. NOT 'pending': that would re-claim and re-deny on
+            // every tick forever. The authorization outcome itself is
+            // unchanged — the chokepoint already refused the dispatch; this
+            // only stops the state machine wedging on the refusal.
+            if (sent == 0) {
+                std::vector<DeviceTransition> rollback;
+                rollback.reserve(claimed.size());
+                for (const auto& aid : claimed)
+                    rollback.push_back({.agent_id = aid,
+                                        .from_step = step_token(Step::kStaging),
+                                        .to_step = step_token(Step::kFailed),
+                                        .error = "stage dispatch refused or reached no agents "
+                                                 "(command " +
+                                                 cmd + ", 0 sent)"});
+                deps.store->apply_results(deployment_id, rollback);
+            }
+        }
     }
 
     // ── 6. CAS-claim + dispatch EXECUTE to authorized 'staged' devices ───────
@@ -138,8 +165,26 @@ void advance(const EngineDeps& deps, const std::string& deployment_id, const Dep
                                                                 {"expected_hash", cfg.sha256}};
             if (!cfg.args.empty())
                 params["args"] = cfg.args;
-            deps.dispatch_fn("content_dist", "execute_staged", claimed, "", params,
-                             exec_execution_id(deployment_id), caller);
+            const auto [cmd, sent] =
+                deps.dispatch_fn("content_dist", "execute_staged", claimed, "", params,
+                                 exec_execution_id(deployment_id), caller);
+            // Same settle-on-refusal as the stage claim above. The execute-once
+            // property is PRESERVED, not weakened: claim_for_exec still claims
+            // each row exactly once, and a row settled to 'failed' here was
+            // never dispatched anywhere — there is no second execution to
+            // guard against, only a wedge to release.
+            if (sent == 0) {
+                std::vector<DeviceTransition> rollback;
+                rollback.reserve(claimed.size());
+                for (const auto& aid : claimed)
+                    rollback.push_back({.agent_id = aid,
+                                        .from_step = step_token(Step::kExecuting),
+                                        .to_step = step_token(Step::kFailed),
+                                        .error = "execute dispatch refused or reached no agents "
+                                                 "(command " +
+                                                 cmd + ", 0 sent)"});
+                deps.store->apply_results(deployment_id, rollback);
+            }
         }
     }
 

--- a/server/core/src/deployment_engine.cpp
+++ b/server/core/src/deployment_engine.cpp
@@ -52,7 +52,8 @@ best_response_per_agent(const std::vector<StoredResponse>& rows) {
 }
 
 void advance(const EngineDeps& deps, const std::string& deployment_id, const DeploymentConfig& cfg,
-             const std::unordered_set<std::string>& authorized) {
+             const std::unordered_set<std::string>& authorized,
+             const yuzu::server::DispatchCaller& caller) {
     if (deps.store == nullptr || deployment_id.empty())
         return;
 
@@ -119,7 +120,7 @@ void advance(const EngineDeps& deps, const std::string& deployment_id, const Dep
         if (!claimed.empty())
             deps.dispatch_fn("content_dist", "stage", claimed, "",
                              {{"url", cfg.url}, {"filename", cfg.filename}, {"sha256", cfg.sha256}},
-                             stage_execution_id(deployment_id));
+                             stage_execution_id(deployment_id), caller);
     }
 
     // ── 6. CAS-claim + dispatch EXECUTE to authorized 'staged' devices ───────
@@ -138,7 +139,7 @@ void advance(const EngineDeps& deps, const std::string& deployment_id, const Dep
             if (!cfg.args.empty())
                 params["args"] = cfg.args;
             deps.dispatch_fn("content_dist", "execute_staged", claimed, "", params,
-                             exec_execution_id(deployment_id));
+                             exec_execution_id(deployment_id), caller);
         }
     }
 

--- a/server/core/src/deployment_engine.hpp
+++ b/server/core/src/deployment_engine.hpp
@@ -23,6 +23,7 @@
 /// a lease is NEVER held across a dispatch or a poll.
 
 #include "deployment_parse.hpp" // DeploymentConfig
+#include "dispatch_caller.hpp"  // DispatchCaller
 
 #include <functional>
 #include <string>
@@ -55,12 +56,31 @@ best_response_per_agent(const std::vector<StoredResponse>& rows);
 /// ResponseStore::query_by_execution + latest_per_agent; tests pass a fake).
 using PollFn = std::function<std::unordered_map<std::string, AgentResponse>(const std::string&)>;
 
-/// The shared 6-param command dispatch (execution_id carried for correlation).
+/// The shared command dispatch (execution_id carried for correlation).
+///
+/// The trailing parameter carries the CALLER (identity + visible set), not
+/// merely a visible set — the same PLAN-006 widening `RestApiV1`,
+/// `WorkflowRoutes`, and `BundleOrchestrator` already carry.
+/// `ServerImpl::build_classified_command` is the single chokepoint every
+/// dispatch resolves through, and it authorizes against the CLASSIFIED
+/// capability's declared securable/operation for the CALLER it is given;
+/// `DeploymentRoutes` used to feed it the background-dispatcher closure
+/// (`DispatchCaller{.system = true}`), which the chokepoint's
+/// `caller.system` early-return admits unconditionally — so an
+/// operator-triggered, MUTATING stage dispatch (`content_dist.stage`,
+/// declared `SoftwareDeployment:Write`) never had its RBAC operation
+/// checked at all. The route's own `Infrastructure:Read` +
+/// `SoftwareDeployment:Execute` gate and its per-tick
+/// `devices_fn(viewer)∩cohort` re-authorization are real, but neither is a
+/// substitute for the capability's own declared operation — a role holding
+/// Execute without Write must still be refused before `content_dist.stage`
+/// dispatches, and only a caller-carrying seam lets the chokepoint enforce
+/// that as it does for every other operator surface.
 using DispatchFn = std::function<std::pair<std::string, int>(
     const std::string& plugin, const std::string& action,
     const std::vector<std::string>& agent_ids, const std::string& scope_expr,
     const std::unordered_map<std::string, std::string>& parameters,
-    const std::string& execution_id)>;
+    const std::string& execution_id, const yuzu::server::DispatchCaller& caller)>;
 
 struct EngineDeps {
     DeploymentRunStore* store = nullptr;
@@ -79,11 +99,18 @@ inline std::string exec_execution_id(const std::string& deployment_id) {
 }
 
 /// Advance one deployment one tick. `authorized` = the live caller's
-/// devices_fn(principal) ∩ cohort. Safe to call concurrently / repeatedly: the
-/// store's guarded transitions + the execute CAS make every step idempotent at the
+/// devices_fn(principal) ∩ cohort — the TARGETING confinement. `caller` is the
+/// same live session's DISPATCH identity, threaded to the chokepoint so
+/// `content_dist.stage`/`execute_staged` are authorized against the declared
+/// `SoftwareDeployment:Write` operation rather than dispatched as SYSTEM
+/// (see `DispatchFn`'s doc comment above — targeting and dispatch
+/// authorization are two different questions and neither substitutes for
+/// the other). Safe to call concurrently / repeatedly: the store's guarded
+/// transitions + the execute CAS make every step idempotent at the
 /// state-machine level.
 void advance(const EngineDeps& deps, const std::string& deployment_id, const DeploymentConfig& cfg,
-             const std::unordered_set<std::string>& authorized);
+             const std::unordered_set<std::string>& authorized,
+             const yuzu::server::DispatchCaller& caller);
 
 } // namespace deployment
 } // namespace yuzu::server

--- a/server/core/src/deployment_routes.cpp
+++ b/server/core/src/deployment_routes.cpp
@@ -87,8 +87,19 @@ deployment::DeploymentConfig config_from_row(const DeploymentRow& r) {
 
 } // namespace
 
+yuzu::server::DispatchCaller
+DeploymentRoutes::caller_from_session(const auth::Session& session) const {
+    return yuzu::server::DispatchCaller{
+        .principal = session.username,
+        .principal_role = auth::role_to_string(session.role),
+        .exec_visible = exec_visible_fn_ ? exec_visible_fn_(session)
+                                         : yuzu::server::authz::deny_all()};
+}
+
 std::string DeploymentRoutes::advance_and_render(const std::string& deployment_id,
-                                                 const std::string& viewer, int attempt) {
+                                                 const yuzu::server::DispatchCaller& caller,
+                                                 int attempt) {
+    const std::string& viewer = caller.principal;
     if (!deploy_store_)
         return render_deploy_note("Deployment store is unavailable on this server.");
     // OWNER-SCOPED read at the seam: a not-yours deployment reads as not-found.
@@ -99,14 +110,17 @@ std::string DeploymentRoutes::advance_and_render(const std::string& deployment_i
     // Re-authorization boundary: the engine may dispatch the MUTATING execute step,
     // so it only ever acts on devices the operator CURRENTLY sees. Build the live
     // visible set from devices_fn(viewer); the engine intersects it with the frozen
-    // cohort, skips the rest, and dispatches execute once per device.
+    // cohort, skips the rest, and dispatches execute once per device. This is
+    // TARGETING confinement — a separate question from `caller`, which is the
+    // DISPATCH identity the chokepoint authorizes against (see `DispatchFn`'s
+    // doc comment, deployment_engine.hpp).
     std::unordered_set<std::string> authorized;
     if (devices_fn_)
         for (const auto& d : devices_fn_(viewer))
             authorized.insert(d.agent_id);
 
     const auto cfg = config_from_row(*dep);
-    deployment::advance(engine_, deployment_id, cfg, authorized);
+    deployment::advance(engine_, deployment_id, cfg, authorized, caller);
 
     // Re-read fresh state for the render.
     dep = deploy_store_->get_deployment(deployment_id, viewer);
@@ -124,11 +138,13 @@ std::string DeploymentRoutes::advance_and_render(const std::string& deployment_i
 void DeploymentRoutes::register_routes(httplib::Server& svr, AuthFn auth_fn, PermFn perm_fn,
                                        DevicesFn devices_fn, DispatchFn dispatch_fn, PollFn poll_fn,
                                        AuditFn audit_fn, PreflightRunStore* preflight_store,
-                                       DeploymentRunStore* deploy_store) {
+                                       DeploymentRunStore* deploy_store,
+                                       ExecVisibleFn exec_visible_fn) {
     auth_fn_ = std::move(auth_fn);
     perm_fn_ = std::move(perm_fn);
     devices_fn_ = std::move(devices_fn);
     audit_fn_ = std::move(audit_fn);
+    exec_visible_fn_ = std::move(exec_visible_fn);
     preflight_store_ = preflight_store;
     deploy_store_ = deploy_store;
     engine_.store = deploy_store;
@@ -217,7 +233,8 @@ void DeploymentRoutes::register_routes(httplib::Server& svr, AuthFn auth_fn, Per
             if (audit_fn_)
                 audit_fn_(req, "deployment.create", "resumed", "SoftwareDeployment", *existing,
                           "run=" + run_id);
-            res.set_content(advance_and_render(*existing, session->username, /*attempt=*/0),
+            res.set_content(advance_and_render(*existing, caller_from_session(*session),
+                                                /*attempt=*/0),
                             "text/html; charset=utf-8");
             return;
         }
@@ -270,7 +287,8 @@ void DeploymentRoutes::register_routes(httplib::Server& svr, AuthFn auth_fn, Per
             // A concurrent create won the partial unique index race — resume the
             // winner rather than error (#governance security HIGH-1 backstop).
             if (auto existing = deploy_store_->find_running_for_run(run_id, session->username)) {
-                res.set_content(advance_and_render(*existing, session->username, /*attempt=*/0),
+                res.set_content(advance_and_render(*existing, caller_from_session(*session),
+                                                    /*attempt=*/0),
                                 "text/html; charset=utf-8");
                 return;
             }
@@ -287,8 +305,9 @@ void DeploymentRoutes::register_routes(httplib::Server& svr, AuthFn auth_fn, Per
 
         // First advance (stage dispatch) + render — advance_and_render re-resolves
         // the live authorized set and ticks the engine once.
-        res.set_content(advance_and_render(dep.deployment_id, session->username, /*attempt=*/0),
-                        "text/html; charset=utf-8");
+        res.set_content(
+            advance_and_render(dep.deployment_id, caller_from_session(*session), /*attempt=*/0),
+            "text/html; charset=utf-8");
     });
 
     // ── Result poll: advance one tick, render (owner-scoped) ─────────────────
@@ -317,7 +336,7 @@ void DeploymentRoutes::register_routes(httplib::Server& svr, AuthFn auth_fn, Per
         }
         if (audit_fn_)
             audit_fn_(req, "deployment.advance", "success", "SoftwareDeployment", dep_id, "");
-        res.set_content(advance_and_render(dep_id, session->username, attempt),
+        res.set_content(advance_and_render(dep_id, caller_from_session(*session), attempt),
                         "text/html; charset=utf-8");
     });
 

--- a/server/core/src/deployment_routes.hpp
+++ b/server/core/src/deployment_routes.hpp
@@ -34,6 +34,7 @@
 
 #include <yuzu/server/auth.hpp>
 
+#include "authz_model.hpp"           // authz::VisibleSet
 #include "deployment_engine.hpp"     // deployment::PollFn / DispatchFn / EngineDeps
 #include "deployment_run_store.hpp"  // DeploymentRow / DeploymentDeviceRow
 #include "device_routes.hpp"         // DeviceRow
@@ -82,24 +83,49 @@ public:
     using DispatchFn = deployment::DispatchFn;
     using PollFn = deployment::PollFn;
     using AuditFn = DexRoutes::AuditFn;
+    /// The caller's Execution:Execute visible set (#1788) — same seam every other
+    /// operator-facing dispatch surface (RestApiV1/WorkflowRoutes/BundleOrchestrator/
+    /// McpServer/DashboardRoutes) is wired with. See `caller_from_session`'s doc
+    /// comment for why an unwired callback must fail closed here too.
+    using ExecVisibleFn = std::function<yuzu::server::authz::VisibleSet(const auth::Session&)>;
 
     void register_routes(httplib::Server& svr, AuthFn auth_fn, PermFn perm_fn, DevicesFn devices_fn,
                          DispatchFn dispatch_fn, PollFn poll_fn, AuditFn audit_fn,
-                         PreflightRunStore* preflight_store, DeploymentRunStore* deploy_store);
+                         PreflightRunStore* preflight_store, DeploymentRunStore* deploy_store,
+                         ExecVisibleFn exec_visible_fn = {});
 
 private:
     AuthFn auth_fn_;
     PermFn perm_fn_;
     DevicesFn devices_fn_;
     AuditFn audit_fn_;
+    ExecVisibleFn exec_visible_fn_;
     PreflightRunStore* preflight_store_{nullptr};
     DeploymentRunStore* deploy_store_{nullptr};
     deployment::EngineDeps engine_;
 
+    /// The live session's dispatch identity — never `.system = true`: every
+    /// deployment advance here is operator-triggered, so the chokepoint must
+    /// authorize it against that operator's own grants, not admit it
+    /// unconditionally as a background dispatcher would. `exec_visible` is
+    /// populated from `exec_visible_fn_`, exactly like every sibling
+    /// operator-facing surface — an unwired callback fails closed to
+    /// `authz::deny_all()` (present-empty), NEVER the default-constructed
+    /// `nullopt` (unfiltered): `dispatch_caller.hpp`'s contract reserves
+    /// `nullopt` for a genuine `.system = true` background dispatcher, and
+    /// `devices_fn(viewer)`'s cohort narrowing below is a DIFFERENT
+    /// authorization dimension (`Infrastructure:Read`/flat group-membership)
+    /// from `Execution:Execute`'s ancestor-aware RBAC visibility — it does not
+    /// substitute for this chokepoint-level intersection (#1788 gov finding).
+    yuzu::server::DispatchCaller caller_from_session(const auth::Session& session) const;
+
     /// Advance a deployment one tick (re-auth from the live session) and render its
     /// progress block; self-repolls while in flight + under the page-poll cap.
-    std::string advance_and_render(const std::string& deployment_id, const std::string& viewer,
-                                   int attempt);
+    /// `caller` is the live session's dispatch identity (principal + role);
+    /// `caller.principal` doubles as the owner-scoped `viewer` for the store
+    /// reads below — the two were always the same value, now carried as one.
+    std::string advance_and_render(const std::string& deployment_id,
+                                   const yuzu::server::DispatchCaller& caller, int attempt);
 };
 
 } // namespace yuzu::server

--- a/server/core/src/dispatch_caller.hpp
+++ b/server/core/src/dispatch_caller.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <string>
+
+#include "authz_model.hpp" // yuzu::server::authz::VisibleSet
+
+/// @file dispatch_caller.hpp
+/// PLAN-006 (verified): `ServerImpl::dispatch_confined` and the three
+/// dispatch typedefs that feed it — `McpServer::DispatchFn`,
+/// `DashboardRoutes::DispatchFn`, `WorkflowRoutes::CommandDispatchFn` — used
+/// to carry only the caller's `exec_visible` VISIBILITY filter, never the
+/// caller's IDENTITY. `dispatch_scope_ladder.hpp` can only recover a
+/// principal from `ex->dispatched_by` for owner-scoped `from_result_set`
+/// expressions; every other dispatch reached the seam anonymously even
+/// though the handler had authenticated a real Session moments earlier
+/// (CDX-P1-03/K-3 declined to widen the typedefs for this, judging the
+/// benefit an audit-completeness LOW — see the comment this struct now
+/// answers, at `server.cpp`'s `dispatch_confined`).
+///
+/// `DispatchCaller` is that missing identity, threaded alongside
+/// `exec_visible` through the SAME injection point every surface already
+/// uses (`ExecVisibleFn` → `CallerFn`). This header adds no behaviour: it is
+/// pure plumbing so a later chokepoint wave can authorize on `principal`
+/// instead of merely filtering on `exec_visible`.
+namespace yuzu::server {
+
+/// The caller behind a confined dispatch. `principal`/`principal_role` are
+/// EMPTY for a call site that has no caller at all — see `system` below —
+/// and for one that has a caller but has not yet been wired to identify it
+/// (a defaulted/unwired `CallerFn` fails closed on `exec_visible`, never on
+/// `principal`: an empty principal alongside a deny-all `exec_visible` is
+/// indistinguishable in effect from a wired-but-anonymous caller, and that
+/// is deliberate — the VISIBILITY filter is what does the denying here, not
+/// the identity field).
+struct DispatchCaller {
+    /// STABLE authorization principal — mirrors `auth::Session::username`.
+    /// Empty when unknown (unwired CallerFn) or not applicable (`system`).
+    std::string principal;
+    /// Mirrors `auth::role_to_string(auth::Session::role)`. Empty under the
+    /// same conditions as `principal`.
+    std::string principal_role;
+    /// The caller's Execution:Execute visible set (#1788). `nullopt` means
+    /// unfiltered — reserved for callers that have deliberately opted out of
+    /// confinement (background/system dispatch); every operator-facing
+    /// surface's unwired fallback is a PRESENT-EMPTY set (deny-all), never
+    /// `nullopt`. See each surface's `CallerFn` doc comment for its specific
+    /// fail-closed contract.
+    yuzu::server::authz::VisibleSet exec_visible;
+    /// True ONLY for a background/system dispatcher that has no session at
+    /// all (a policy-engine tick, a scheduled fire with no operator in the
+    /// loop, ...). Set explicitly at each such call site — never a default
+    /// stand-in for "principal happens to be empty" — so a background
+    /// dispatch is a deliberate, greppable statement rather than a value
+    /// that merely looks the same as an unwired one.
+    bool system = false;
+};
+
+} // namespace yuzu::server

--- a/server/core/src/dispatch_caller.hpp
+++ b/server/core/src/dispatch_caller.hpp
@@ -55,4 +55,35 @@ struct DispatchCaller {
     bool system = false;
 };
 
+/// Build the `DispatchCaller` for a STORED username with no live session —
+/// today only `ScheduleRunner`'s fire path, which re-resolves the schedule
+/// creator's authority from a bare string at fire time. Pure so the one
+/// decision that matters is directly testable:
+///
+/// `principal_resolves == false` (the account no longer exists, the auth
+/// store errored, or no auth store is wired) returns an EMPTY-principal,
+/// deny-all caller — which `build_classified_command` refuses as
+/// `AnonymousOperator` BEFORE any permission check runs, independent of the
+/// RBAC on/off toggle. This is the ADR-0033 §1 rule ("an unresolvable,
+/// missing or unparseable input for a filter that applies denies") applied
+/// to the authenticated-actor filter, and it is load-bearing precisely on
+/// the RBAC-off default posture: every OTHER dispatch surface derives its
+/// caller from a live `auth::Session`, which a deleted account cannot
+/// produce, so this resolver is the only place where "the account still
+/// exists" must be enforced explicitly rather than falling out of
+/// authentication. (Round-2 review finding on #3133: an earlier version
+/// returned the bare username with legacy-open visibility here, so a
+/// deleted creator's schedule kept firing unfiltered on a default install.)
+[[nodiscard]] inline DispatchCaller caller_for_stored_username(const std::string& username,
+                                                               bool principal_resolves,
+                                                               std::string principal_role,
+                                                               authz::VisibleSet exec_visible) {
+    if (!principal_resolves)
+        return DispatchCaller{.exec_visible = authz::deny_all()};
+    return DispatchCaller{.principal = username,
+                          .principal_role = std::move(principal_role),
+                          .exec_visible = std::move(exec_visible),
+                          .system = false};
+}
+
 } // namespace yuzu::server

--- a/server/core/src/dispatch_scope_ladder.hpp
+++ b/server/core/src/dispatch_scope_ladder.hpp
@@ -212,7 +212,7 @@ inline std::pair<std::string, int> wire_and_dispatch_confined(
     const std::string& command_id, const std::string& execution_id,
     const std::string& principal_role, const std::vector<std::string>& agent_ids,
     const std::string& scope_expr, const yuzu::server::authz::VisibleSet& exec_visible,
-    bool broadcast_on_none, const yuzu::server::detail::pb::CommandRequest& cmd) {
+    bool broadcast_on_none, const yuzu::server::detail::ClassifiedCommand& cmd) {
     DispatchResolvers resolvers;
     resolvers.group_members_fn = [mgmt_group_store](const std::string& group_id) {
         std::vector<std::string> members;

--- a/server/core/src/gateway_service_impl.cpp
+++ b/server/core/src/gateway_service_impl.cpp
@@ -656,13 +656,39 @@ GatewayUpstreamServiceImpl::NotifyStreamStatus(grpc::ServerContext* context,
     }
 
     switch (request->event()) {
-    case gw::StreamStatusNotification::CONNECTED:
-        registry_.set_gateway_node(agent_id, request->gateway_node());
-        spdlog::info("[gateway] Agent {} stream CONNECTED at gateway node '{}'", agent_id,
-                     request->gateway_node());
+    case gw::StreamStatusNotification::CONNECTED: {
+        // PLAN item 5 (CC-03, peer finding PLAN-007): `wire_capabilities` was
+        // read off the wire and dropped on the floor here — p3's advertised
+        // capability set never reached the registry, so the dispatch
+        // chokepoint's routed-path gateway-capability check (agent_registry.cpp)
+        // had nothing to consult and every gateway session looked
+        // capability-less. Record the FULL set exactly as advertised; a
+        // reconnect (a fresh CONNECTED, which this branch always is —
+        // `wire_capabilities` is sent with EVERY CONNECTED notification, not
+        // only the first) REPLACES it, never merges.
+        //
+        // M1 (review finding, post-merge round): node + capabilities publish
+        // through ONE call, `set_gateway_route` — they used to be two calls,
+        // which both raced `send_to`/`send_to_all`'s reads on `gateway_node`
+        // (a C++ data race: written under a different lock than it was read
+        // under) and exposed an observable intermediate state (node set,
+        // capabilities not yet replaced) that could false-deny a dispatch.
+        std::vector<std::string> wire_capabilities(request->wire_capabilities().begin(),
+                                                    request->wire_capabilities().end());
+        registry_.set_gateway_route(agent_id, request->gateway_node(),
+                                    std::move(wire_capabilities));
+        spdlog::info("[gateway] Agent {} stream CONNECTED at gateway node '{}' ({} wire "
+                     "capabilit{})",
+                     agent_id, request->gateway_node(), request->wire_capabilities_size(),
+                     request->wire_capabilities_size() == 1 ? "y" : "ies");
         break;
+    }
 
     case gw::StreamStatusNotification::DISCONNECTED:
+        // `clear_stream_if_session` also clears the advertised-capability set
+        // (agent_registry.cpp) — a session whose stream is gone has nothing
+        // live to route a dispatch-tagged command through, so no separate
+        // clear call is needed here.
         registry_.clear_stream_if_session(agent_id, session_id);
         registry_.remove_agent_if_session(agent_id, session_id);
         {

--- a/server/core/src/mcp_server.cpp
+++ b/server/core/src/mcp_server.cpp
@@ -2459,7 +2459,7 @@ McpServer::HandlerFn McpServer::build_handler(
     const bool* mcp_streamed_post_enabled,
     std::vector<std::string> allowed_origins, SoftwareLicensingStore* software_licensing_store,
     EnginePrincipalStore* engine_principal_store, AccessReviewStore* access_review_store,
-    AuthDB* auth_db, DirectorySync* directory_sync, ExecVisibleFn exec_visible_fn,
+    AuthDB* auth_db, DirectorySync* directory_sync, CallerFn caller_fn,
     yuzu::server::detail::StreamBudget* stream_budget, StreamRevalidateFn revalidate_fn,
     StreamPrincipalAuditFn principal_audit_fn) {
 
@@ -2498,6 +2498,18 @@ McpServer::HandlerFn McpServer::build_handler(
     // the handler below; outlives every request.
     std::shared_ptr<BundleOrchestrator> bundle_orch;
     if (dispatch_fn && response_store) {
+        // PR1.9c: `BundleOrchestrator::DispatchFn` now carries the whole
+        // `DispatchCaller`, so it is signature-identical to `McpServer::
+        // DispatchFn` and `dispatch_fn` feeds it directly — the adapter that
+        // used to sit here is gone.
+        //
+        // That adapter was the defect, not the boilerplate: it manufactured a
+        // `DispatchCaller{.exec_visible = ...}` with an EMPTY principal, and
+        // `build_classified_command` refuses an empty principal as
+        // `AnonymousOperator` before the legacy-open bypass — so every
+        // `execute_bundle` step was already being denied. The orchestrator
+        // supplies the real principal now (it has always received one; it just
+        // had nowhere to put it).
         bundle_orch = std::make_shared<BundleOrchestrator>(
             dispatch_fn, response_store,
             [] {
@@ -6948,24 +6960,26 @@ McpServer::HandlerFn McpServer::build_handler(
                 // forever AND the JSON-RPC client sees a connection
                 // drop instead of a structured error envelope. Mirrors
                 // the REST sibling at workflow_routes.cpp:1427-1444.
-                // #1788: confine the dispatch to the caller's Execution:Execute
-                // visible device set, mirroring /api/command. Fail closed when
-                // the derivation is unwired (CDX-R6-02, see below).
-                auto exec_visible =
-                    exec_visible_fn ? exec_visible_fn(*session)
-                                    // CDX-R6-02: unwired == FAIL CLOSED. A present EMPTY set
-                                    // (not nullopt) means "no target visible" -> nothing
-                                    // dispatched. ADR-0033 §1 forbids inferring unfiltered
-                                    // authority from an omitted applicable filter (same
-                                    // posture as the tag ScopedPermFn, K-06). Production
-                                    // always wires it (server.cpp); a test wanting unfiltered
-                                    // wires a callback that returns nullopt.
-                                    : yuzu::server::authz::deny_all();
+                // #1788 / PLAN-006: confine the dispatch to the caller's
+                // Execution:Execute visible device set AND identify who asked,
+                // mirroring /api/command. Fail closed on visibility when the
+                // derivation is unwired (CDX-R6-02, see below).
+                auto caller =
+                    caller_fn ? caller_fn(*session)
+                                    // CDX-R6-02: unwired == FAIL CLOSED on exec_visible. A
+                                    // present EMPTY set (not nullopt) means "no target
+                                    // visible" -> nothing dispatched. ADR-0033 §1 forbids
+                                    // inferring unfiltered authority from an omitted
+                                    // applicable filter (same posture as the tag
+                                    // ScopedPermFn, K-06). Production always wires it
+                                    // (server.cpp); a test wanting unfiltered wires a
+                                    // callback whose exec_visible is nullopt.
+                              : DispatchCaller{.exec_visible = yuzu::server::authz::deny_all()};
                 std::string command_id;
                 int agents_reached = 0;
                 try {
                     std::tie(command_id, agents_reached) = dispatch_fn(
-                        plugin, action, agent_ids, scope, params, execution_id, exec_visible);
+                        plugin, action, agent_ids, scope, params, execution_id, caller);
                 } catch (const std::exception& e) {
                     spdlog::error("MCP execute_instruction: dispatch failed: {}", e.what());
                     // 2f PR 3a: unwind the bridge record FIRST (unsubscribe waits
@@ -7844,10 +7858,17 @@ McpServer::HandlerFn McpServer::build_handler(
                         // defense in depth matching the bundle/execute_instruction
                         // dispatch arms (this was the last arm still passing
                         // unfiltered on a single already-authorized target).
+                        // PLAN-006: `session` was authenticated at handler entry and
+                        // is already used for the store write above — identify the
+                        // caller to dispatch_confined too, not just its visible set.
                         std::tie(command_id, agents_reached) = dispatch_fn(
                             "quarantine", "quarantine", {agent_id}, /*scope=*/"", qparams,
                             /*execution_id=*/"",
-                            yuzu::server::authz::VisibleSet{std::unordered_set<std::string>{agent_id}});
+                            DispatchCaller{
+                                .principal = session->username,
+                                .principal_role = auth::role_to_string(session->role),
+                                .exec_visible = yuzu::server::authz::VisibleSet{
+                                    std::unordered_set<std::string>{agent_id}}});
                     } catch (const std::exception& e) {
                         spdlog::error("MCP quarantine_device: isolation dispatch failed: {}",
                                       e.what());
@@ -7884,7 +7905,7 @@ McpServer::HandlerFn McpServer::build_handler(
             // kToolSecurity).
             //
             // governance C4/sec-4: a bundle targets ONE device, so authorization is
-            // the per-target confinement below (exec_visible_fn + in_scope) — NOT
+            // the per-target confinement below (caller_fn + in_scope) — NOT
             // ALSO a targetless global Execution:Execute perm_fn gate. Keeping both
             // (as this handler previously did) is STRICTER than REST's
             // /api/v1/bundles twin (scoped_perm_fn only, no global gate), so a
@@ -7933,17 +7954,21 @@ McpServer::HandlerFn McpServer::build_handler(
                 // #1788: a bundle targets ONE device, so confine it HERE (not in the
                 // orchestrator) — the single target must be in the caller's
                 // Execution:Execute visible set. Fail closed when unwired (CDX-R6-02).
-                auto exec_visible =
-                    exec_visible_fn ? exec_visible_fn(*session)
-                                    // CDX-R6-02: unwired == FAIL CLOSED. A present EMPTY set
-                                    // (not nullopt) means "no target visible" -> nothing
-                                    // dispatched. ADR-0033 §1 forbids inferring unfiltered
-                                    // authority from an omitted applicable filter (same
-                                    // posture as the tag ScopedPermFn, K-06). Production
-                                    // always wires it (server.cpp); a test wanting unfiltered
-                                    // wires a callback that returns nullopt.
-                                    : yuzu::server::authz::deny_all();
-                if (!yuzu::server::authz::in_scope(exec_visible, agent_id)) {
+                // PLAN-006: BundleOrchestrator's own DispatchFn is a separate,
+                // REST-shared typedef with no principal concept (see the adapter
+                // above) — this handler only needs `caller.exec_visible` here.
+                auto caller =
+                    caller_fn ? caller_fn(*session)
+                                    // CDX-R6-02: unwired == FAIL CLOSED on exec_visible. A
+                                    // present EMPTY set (not nullopt) means "no target
+                                    // visible" -> nothing dispatched. ADR-0033 §1 forbids
+                                    // inferring unfiltered authority from an omitted
+                                    // applicable filter (same posture as the tag
+                                    // ScopedPermFn, K-06). Production always wires it
+                                    // (server.cpp); a test wanting unfiltered wires a
+                                    // callback whose exec_visible is nullopt.
+                              : DispatchCaller{.exec_visible = yuzu::server::authz::deny_all()};
+                if (!yuzu::server::authz::in_scope(caller.exec_visible, agent_id)) {
                     mcp_audit("failure", "agent_id=" + agent_id + " out_of_scope");
                     res.set_content(
                         error_response(id, kInvalidParams, "target agent not in your visible scope"),
@@ -7957,7 +7982,7 @@ McpServer::HandlerFn McpServer::build_handler(
                     // default to unfiltered — defense in depth if a future dispatch_fn
                     // starts consulting it itself.
                     r = bundle_orch->dispatch(agent_id, *specs, session->username, bundle_audit,
-                                              exec_visible);
+                                              caller.exec_visible);
                 } catch (const std::exception& e) {
                     spdlog::error("MCP execute_bundle: dispatch failed: {}", e.what());
                     mcp_audit("failure", std::string("dispatch_exception: ") + e.what());
@@ -10834,7 +10859,7 @@ void McpServer::register_routes(httplib::Server& svr, AuthFn auth_fn, PermFn per
                                 StreamRevalidateFn revalidate_fn,
                                 std::size_t mcp_max_streams_per_principal,
                                 StreamPrincipalAuditFn principal_audit_fn,
-                                ExecVisibleFn exec_visible_fn) {
+                                CallerFn caller_fn) {
     // GET + DELETE first: they COPY auth_fn / audit_fn / allowed_origins, which
     // build_handler std::move()s below. &mcp_disabled is a live pointer into the
     // cfg_ member (outlives the handlers).
@@ -10860,7 +10885,7 @@ void McpServer::register_routes(httplib::Server& svr, AuthFn auth_fn, PermFn per
                            sessions, mcp_streaming_disabled, mcp_streamed_post_enabled,
                            std::move(allowed_origins),
                            software_licensing_store, engine_principal_store, access_review_store,
-                           auth_db, directory_sync, std::move(exec_visible_fn),
+                           auth_db, directory_sync, std::move(caller_fn),
                            // 2f PR 3b: the streamed-POST arm leases from the SAME
                            // budget as the GET channel above (which COPIED these, so
                            // moving here is safe) - one arithmetic for every

--- a/server/core/src/mcp_server.hpp
+++ b/server/core/src/mcp_server.hpp
@@ -7,6 +7,7 @@
 #include "audit_store.hpp"
 #include "authz_model.hpp" // #1788: VisibleSet — MCP dispatch confinement (in_scope/filter_to_scope)
 #include "ca_store.hpp"
+#include "dispatch_caller.hpp" // PLAN-006: DispatchCaller — the principal threaded to dispatch_fn
 #include "dex_app_perf_model.hpp"
 #include "dex_perf_model.hpp"
 #include "network_perf_model.hpp"
@@ -201,24 +202,33 @@ public:
     /// `WorkflowRoutes::CommandDispatchFn` (the REST sibling). Added for
     /// issue #1088 so MCP `execute_instruction` can return `execution_id`
     /// in its response and let agentic workers bridge to `/api/v1/events`.
+    ///
+    /// PLAN-006: the trailing param carries the caller's IDENTITY as well as
+    /// its `exec_visible` filter (`yuzu::server::DispatchCaller`, formerly a
+    /// bare `VisibleSet`) so the shared `dispatch_confined` seam has a
+    /// principal to work with, not only a visibility filter.
     using DispatchFn = std::function<std::pair<std::string, int>(
         const std::string& plugin, const std::string& action,
         const std::vector<std::string>& agent_ids, const std::string& scope_expr,
         const std::unordered_map<std::string, std::string>& parameters,
         const std::string& execution_id,
-        // #1788: the caller's Execution:Execute visible set (nullopt == unfiltered).
-        // Every dispatch arm intersects against it, mirroring /api/command.
-        const yuzu::server::authz::VisibleSet& exec_visible)>;
+        // #1788 / PLAN-006: every dispatch arm intersects `caller.exec_visible`
+        // against its targets, mirroring /api/command; `caller.principal`
+        // identifies who asked.
+        const yuzu::server::DispatchCaller& caller)>;
 
-    /// #1788: derives the per-request Execution:Execute visible set the DispatchFn
-    /// intersects against. Injected because the handler has the session but the
-    /// dispatch lambda (server.cpp) does not. When this std::function is UNSET,
-    /// the execute_instruction / execute_bundle handlers substitute a PRESENT-EMPTY
-    /// VisibleSet (deny-all), NOT nullopt — an unwired derivation fails CLOSED
-    /// (ADR-0033 §1: a missing applicable filter denies; CDX-R6-02). A caller that
-    /// genuinely wants full-fleet dispatch must wire a callback returning
-    /// std::nullopt; production wires server.cpp's derive_exec_visible.
-    using ExecVisibleFn = std::function<yuzu::server::authz::VisibleSet(const auth::Session&)>;
+    /// #1788 / PLAN-006: derives the per-request DispatchCaller (identity +
+    /// Execution:Execute visible set) the DispatchFn consults. Injected because
+    /// the handler has the session but the dispatch lambda (server.cpp) does
+    /// not. When this std::function is UNSET, the execute_instruction /
+    /// execute_bundle handlers substitute an EMPTY principal alongside a
+    /// PRESENT-EMPTY `exec_visible` (deny-all), NOT nullopt — an unwired
+    /// derivation fails CLOSED on visibility exactly as before this struct
+    /// existed (ADR-0033 §1: a missing applicable filter denies; CDX-R6-02). A
+    /// caller that genuinely wants full-fleet dispatch must wire a callback
+    /// whose `exec_visible` is std::nullopt; production wires server.cpp's
+    /// derive_dispatch_caller (which wraps derive_exec_visible).
+    using CallerFn = std::function<yuzu::server::DispatchCaller(const auth::Session&)>;
 
     /// Owner-FK existence check for engine-principal create/transfer-owner
     /// (design doc `docs/auth-engine-principals-design.md` §3.1:
@@ -356,13 +366,20 @@ public:
                             // whole access-review tool family answering "unavailable".
                             AccessReviewStore* access_review_store = nullptr,
                             AuthDB* auth_db = nullptr, DirectorySync* directory_sync = nullptr,
-                            // #1788: derives the per-request Execution:Execute visible
-                            // set for the execute_instruction / execute_bundle dispatch
-                            // confinement. Trailing optional, but UNSET fails CLOSED —
-                            // the handlers substitute a present-empty (deny-all) VisibleSet,
-                            // not unfiltered (CDX-R6-02); a test seam wanting full fleet
-                            // wires a callback returning std::nullopt.
-                            ExecVisibleFn exec_visible_fn = {},
+                            // #1788 / PLAN-006: derives the per-request DispatchCaller
+                            // (identity + Execution:Execute visible set) for the
+                            // execute_instruction / execute_bundle dispatch confinement.
+                            // Trailing optional, but UNSET fails CLOSED on exec_visible —
+                            // the handlers substitute an empty principal alongside a
+                            // present-empty (deny-all) VisibleSet, not unfiltered
+                            // (CDX-R6-02); a test seam wanting full fleet wires a callback
+                            // whose exec_visible is std::nullopt.
+                            //
+                            // ORDER (merge with 2f PR 3b): this parameter occupies the
+                            // slot #2689's positional call sites use — it REPLACES the
+                            // former ExecVisibleFn, whose visible set DispatchCaller now
+                            // carries — so the streaming trio still appends after it.
+                            CallerFn caller_fn = {},
                             // 2f PR 3b (streamed POST): the SAME shared held-open
                             // budget the GET channel leases from - a streamed POST
                             // pins an HTTP worker exactly as a GET SSE stream does,
@@ -377,10 +394,6 @@ public:
                             // already be gone. Absent any of them the POST simply
                             // never streams - it answers plain JSON, byte-identical
                             // to today, which is the correct degradation.
-                            //
-                            // ORDER: exec_visible_fn stays FIRST so #2689's positional
-                            // call sites are untouched by this branch; the streaming
-                            // trio is appended after it.
                             yuzu::server::detail::StreamBudget* stream_budget = nullptr,
                             StreamRevalidateFn revalidate_fn = {},
                             StreamPrincipalAuditFn principal_audit_fn = {});
@@ -467,9 +480,9 @@ public:
                          // Explicit-principal audit sink for mcp.stream.close (see
                          // StreamPrincipalAuditFn). Empty falls back to the generic sink.
                          StreamPrincipalAuditFn principal_audit_fn = {},
-                         // #1788: per-request Execution:Execute visible-set deriver,
+                         // #1788 / PLAN-006: per-request DispatchCaller deriver,
                          // forwarded to build_handler for MCP dispatch confinement.
-                         ExecVisibleFn exec_visible_fn = {});
+                         CallerFn caller_fn = {});
 
 private:
     // ── Engine-principal lifecycle wiring (ADR-1005 item 2b, plan PR 4.3) ──

--- a/server/core/src/rest_api_v1.cpp
+++ b/server/core/src/rest_api_v1.cpp
@@ -1351,6 +1351,38 @@ void RestApiV1::register_routes(
         return yuzu::server::authz::deny_all();
     };
 
+    // PR1.9c: the caller-carrying sibling of the above. Same resolution, same
+    // fail-closed posture — it just stops throwing the identity away.
+    // `build_classified_command` refuses an empty `DispatchCaller::principal`
+    // as `AnonymousOperator` before the legacy-open bypass, so the routes that
+    // dispatch MUST supply one; the visible-set-only resolver resolved a full
+    // `auth::Session` and discarded everything but the set six lines before
+    // that dispatch, which is what made every REST dispatch undeliverable.
+    //
+    // The unwired-`auth_fn` arm deliberately keeps an EMPTY principal: with no
+    // authenticator there is no identity to claim, and `AnonymousOperator` is
+    // the correct fail-closed answer rather than a fabricated one. It pairs
+    // with `deny_all()` (present-empty), never a defaulted VisibleSet — that
+    // default is nullopt, which reads as UNFILTERED.
+    auto resolve_secondary_caller =
+        [auth_fn, exec_visible_fn](const httplib::Request& req, httplib::Response& res)
+        -> std::optional<yuzu::server::DispatchCaller> {
+        std::optional<auth::Session> sess;
+        if (auth_fn) {
+            sess = auth_fn(req, res);
+            if (!sess)
+                return std::nullopt;
+        }
+        yuzu::server::DispatchCaller caller;
+        if (sess) {
+            caller.principal = sess->username;
+            caller.principal_role = auth::role_to_string(sess->role);
+        }
+        caller.exec_visible = (exec_visible_fn && sess) ? exec_visible_fn(*sess)
+                                                        : yuzu::server::authz::deny_all();
+        return caller;
+    };
+
     // ── CORS preflight handler for /api/v1/* ─────────────────────────────
     // Actual CORS headers are added by the post-routing handler in server.cpp
     // with origin allowlist validation.
@@ -1430,14 +1462,14 @@ void RestApiV1::register_routes(
                                   const std::string& scope,
                                   const std::unordered_map<std::string, std::string>& params,
                                   const std::string& correlation_id,
-                                  const yuzu::server::authz::VisibleSet& exec_visible)
+                                  const yuzu::server::DispatchCaller& caller)
                 -> std::pair<std::string, int> {
                 for (const auto& id : agent_ids) {
-                    if (!yuzu::server::authz::in_scope(exec_visible, id))
+                    if (!yuzu::server::authz::in_scope(caller.exec_visible, id))
                         return {correlation_id, 0};
                 }
                 return command_dispatch_fn(plugin, action, agent_ids, scope, params,
-                                           correlation_id, exec_visible);
+                                           correlation_id, caller);
             },
             response_store,
             [] {
@@ -1588,7 +1620,7 @@ void RestApiV1::register_routes(
     sink.Post(
         "/api/v1/tar/retention-paused/purge",
         [scoped_perm_fn, command_dispatch_fn, audit_fn, metrics_registry,
-         resolve_secondary_exec_visible](const httplib::Request& req, httplib::Response& res) {
+         resolve_secondary_caller](const httplib::Request& req, httplib::Response& res) {
             const auto cid = detail::make_correlation_id();
             res.set_header("X-Correlation-Id", cid);
             auto bump = [&](const char* result) {
@@ -1663,14 +1695,14 @@ void RestApiV1::register_routes(
             // and has already authorized this exact device_id, so the seam's
             // intersection is a second, independent check rather than the thing
             // standing between this caller and the fleet.
-            const auto exec_visible = resolve_secondary_exec_visible(req, res);
-            if (!exec_visible) {
+            const auto caller = resolve_secondary_caller(req, res);
+            if (!caller) {
                 bump("denied");
                 return;
             }
             const auto [command_id, sent] =
                 command_dispatch_fn("tar", "purge_source", {device_id}, "", {{"source", source}},
-                                    /*execution_id=*/"", *exec_visible);
+                                    /*execution_id=*/"", *caller);
             if (sent == 0) {
                 // NOTE: a confinement drop also lands here and is reported as
                 // "offline" + counted as agent_not_connected. The RESPONSE
@@ -6711,6 +6743,12 @@ void RestApiV1::register_routes(
                 return;
             }
             const yuzu::server::authz::VisibleSet exec_visible = exec_visible_fn(session);
+            // PR1.9c: the chokepoint needs the identity too, and `session` is
+            // this lambda's own parameter — no extra resolution required.
+            const yuzu::server::DispatchCaller caller{
+                .principal = session.username,
+                .principal_role = auth::role_to_string(session.role),
+                .exec_visible = exec_visible};
             // Resolve the parent scope. parent_id present → dispatch is scoped
             // to that set's CURRENT members via the `from_result_set:` scope
             // kind; absent → broadcast to all connected agents (__all__).
@@ -6818,7 +6856,7 @@ void RestApiV1::register_routes(
                 // lives in the server's AgentRegistry, and a second copy of the
                 // intersection is the drift that seam exists to prevent.
                 std::tie(command_id, sent) = command_dispatch_fn(plugin, action, {}, dispatch_scope,
-                                                                 params, exec_id, exec_visible);
+                                                                 params, exec_id, caller);
             } catch (const std::exception& e) {
                 spdlog::error("result-set async producer dispatch failed: {}", e.what());
                 execution_tracker->mark_cancelled(exec_id, owner);
@@ -8929,7 +8967,7 @@ void RestApiV1::register_routes(
     sink.Post(
         R"(/api/v1/dex/devices/([^/]+)/live)",
         [scoped_perm_fn, response_store, command_dispatch_fn, audit_fn, metrics_registry,
-         resolve_secondary_exec_visible](const httplib::Request& req, httplib::Response& res) {
+         resolve_secondary_caller](const httplib::Request& req, httplib::Response& res) {
             const std::string agent_id = req.matches[1].str();
             const auto cid = detail::make_correlation_id();
             // Echo the correlation id on EVERY response path (A3), parity with the
@@ -8994,8 +9032,8 @@ void RestApiV1::register_routes(
             // audit was the original shape and is the ordering defect this
             // moves; the scope gate above has already answered 401, so this
             // still cannot fail in practice and no status ordering shifts.)
-            const auto exec_visible = resolve_secondary_exec_visible(req, res);
-            if (!exec_visible)
+            const auto caller = resolve_secondary_caller(req, res);
+            if (!caller)
                 return;
             // Concurrency cap (UP-1/2/3): acquire an in-flight slot BEFORE dispatch so
             // an over-budget caller gets 429 without orphaning a command. RAII releases
@@ -9038,7 +9076,7 @@ void RestApiV1::register_routes(
                 return;
             }
             const auto [command_id, sent] = command_dispatch_fn(plugin, action, {agent_id}, "", {},
-                                                                /*execution_id=*/"", *exec_visible);
+                                                                /*execution_id=*/"", *caller);
             if (sent == 0) {
                 res.status = 503;
                 res.set_content(detail::error_json_a4(

--- a/server/core/src/rest_api_v1.hpp
+++ b/server/core/src/rest_api_v1.hpp
@@ -9,6 +9,7 @@
 #include "approval_manager.hpp"
 #include "audit_store.hpp"
 #include "authz_model.hpp"
+#include "dispatch_caller.hpp"
 #include "device_token_store.hpp"
 #include "dex_app_perf_model.hpp"
 #include "dex_perf_model.hpp"
@@ -270,8 +271,8 @@ public:
     /// Command dispatch callback — sends a CommandRequest to agents via gRPC
     /// and returns (command_id, agents_reached). Identical signature to
     /// `WorkflowRoutes::CommandDispatchFn`; the server threads the SAME hoisted
-    /// CONFINED closure (`command_dispatch_confined_fn`) into both, so every
-    /// REST dispatch surface narrows to the caller's reach through the one
+    /// caller-carrying closure (`command_dispatch_caller_fn`) into both, so
+    /// every REST dispatch surface narrows to the caller's reach through the one
     /// `dispatch_confined_arms` seam. The trailing `execution_id` is registered
     /// command_id→execution_id BEFORE any RPC so FAST loopback agents can't
     /// reply before the mapping lands (UP2-4). Empty callback leaves the async
@@ -292,11 +293,20 @@ public:
     /// header's docstring on why a second copy is the drift class). Broadcast
     /// and scope arms could not be confined route-locally in any case: the
     /// candidate set lives in the server's AgentRegistry, not in this file.
+    /// PR1.9c: the trailing parameter carries the CALLER (identity + visible
+    /// set), not the visible set alone. It has to:
+    /// `ServerImpl::build_classified_command` refuses an empty
+    /// `DispatchCaller::principal` as `AnonymousOperator` BEFORE the
+    /// legacy-open/RBAC-off bypass, so a VisibleSet-only signature left every
+    /// REST dispatch here undeliverable — reported as `503 "device offline"` on
+    /// a healthy connected agent. The other three dispatch surfaces (MCP,
+    /// dashboard, workflow) were widened by PR1.9b′; this one was deferred at
+    /// the time, and that deferral WAS the defect rather than a boundary.
     using CommandDispatchFn = std::function<std::pair<std::string, int>(
         const std::string& plugin, const std::string& action,
         const std::vector<std::string>& agent_ids, const std::string& scope_expr,
         const std::unordered_map<std::string, std::string>& parameters,
-        const std::string& execution_id, const yuzu::server::authz::VisibleSet& exec_visible)>;
+        const std::string& execution_id, const yuzu::server::DispatchCaller& caller)>;
 
     /// Production overload — constructs an HttplibRouteSink and delegates
     /// to the sink-based overload below.

--- a/server/core/src/schedule_runner.cpp
+++ b/server/core/src/schedule_runner.cpp
@@ -217,9 +217,16 @@ int ScheduleRunner::dispatch_tracked(const InstructionSchedule& s, const std::st
                                            ? std::string(yuzu::server::kBroadcastScope)
                                            : s.scope_expression;
     try {
+        // Review finding (#3133): re-resolve the creator's CURRENT
+        // permissions at fire time rather than dispatching as `system` —
+        // an operator who could create this schedule but does not (or no
+        // longer) holds the classified permission for `plugin.action`
+        // must be refused by the SAME chokepoint every operator-initiated
+        // dispatch goes through, not silently bypass it.
+        const auto caller = d_.resolve_caller(s.created_by);
         std::tie(command_id, sent) = d_.dispatch_fn(plugin, action, /*agent_ids=*/{},
                                                     dispatch_scope,
-                                                    /*parameters=*/{}, exec_id);
+                                                    /*parameters=*/{}, exec_id, caller);
     } catch (const std::exception& e) {
         count("yuzu_schedule_fire_failures_total");
         spdlog::error("schedule_runner: dispatch failed for schedule '{}' (id={}): {}", s.name,

--- a/server/core/src/schedule_runner.hpp
+++ b/server/core/src/schedule_runner.hpp
@@ -37,6 +37,8 @@
 /// never retried into a backlog). Only a pending approval holds a schedule
 /// at its due time.
 
+#include "dispatch_caller.hpp"
+
 #include <functional>
 #include <string>
 #include <unordered_map>
@@ -61,12 +63,30 @@ class ScheduleRunner {
 public:
     /// Same shape as WorkflowRoutes::CommandDispatchFn — the server hands the
     /// runner the one shared dispatch lambda so scheduled fires travel the
-    /// exact same path as operator-initiated commands.
+    /// exact same path as operator-initiated commands. Review finding
+    /// (external PR review, #3133): this used to be narrower than its
+    /// sibling — no `caller` parameter at all — so every fire went through
+    /// `command_dispatch_fn`'s hardcoded `DispatchCaller{.system = true}`,
+    /// bypassing the classify+authorize chokepoint's per-action check
+    /// entirely. Widened to actually match the shape this comment always
+    /// claimed.
     using CommandDispatchFn = std::function<std::pair<std::string, int>(
         const std::string& plugin, const std::string& action,
         const std::vector<std::string>& agent_ids, const std::string& scope_expr,
         const std::unordered_map<std::string, std::string>& parameters,
-        const std::string& execution_id)>;
+        const std::string& execution_id, const yuzu::server::DispatchCaller& caller)>;
+
+    /// Resolves the CURRENT `DispatchCaller` for a stored username at fire
+    /// time — re-resolving live permissions, never trusting a stale
+    /// creation-time snapshot (a schedule's creator may have gained or lost
+    /// grants since `s.created_by` was recorded). A schedule fire has no
+    /// live HTTP session to derive from, unlike every other dispatch
+    /// surface's `CallerFn` — server.cpp wires this to a lookup against the
+    /// current auth/RBAC state. REQUIRED: an unwired resolver would
+    /// reproduce exactly the system-caller bypass this field exists to
+    /// close, so `dispatch_tracked` calls it unconditionally rather than
+    /// falling back to an unfiltered default.
+    using ResolveCallerFn = std::function<yuzu::server::DispatchCaller(const std::string& username)>;
 
     struct Deps {
         ScheduleEngine* schedule_engine{nullptr};       // required
@@ -76,6 +96,7 @@ public:
         AuditStore* audit_store{nullptr};               // optional forensic sink
         yuzu::MetricsRegistry* metrics{nullptr};        // optional observability sink
         CommandDispatchFn dispatch_fn;                  // required
+        ResolveCallerFn resolve_caller;                 // required
     };
 
     explicit ScheduleRunner(Deps deps);

--- a/server/core/src/server.cpp
+++ b/server/core/src/server.cpp
@@ -98,10 +98,21 @@
 #include "scope_yaml.hpp"
 #include "rbac_store.hpp"
 #include "response_store.hpp"
+#include "dispatch_caller.hpp" // PLAN-006: DispatchCaller — the principal threaded to dispatch_confined
 #include "dispatch_target_shape.hpp" // check_targeting_shape / targeting_supplied (#2500)
 #include "authz_model.hpp" // #1788: per-arm visibility intersection (in_scope/filter_to_scope)
 #include "dispatch_confined_arms.hpp" // the ONE per-arm intersection, shared with /api/command
 #include "dispatch_scope_ladder.hpp" // A-3/QE-2: the shared scope-resolution ladder + caller wiring
+#include "command_capability.hpp" // PR1.9c: CommandCapabilityRegistry — the dispatch classification vocabulary
+#include "command_capability_parsers.hpp" // PR1.9c: encode_dispatch_tag / compute_plan_hash
+// PR1.9c: the six capability spans build_classified_command's registry composes over — declared
+// by other packages (p1/p7/p10-p13), included (never authored) here at the composition site.
+#include "capability_decls/core_dispatch_capabilities.hpp"
+#include "capability_decls/plugin_action_catalogue_a.hpp"
+#include "capability_decls/plugin_action_catalogue_b.hpp"
+#include "capability_decls/plugin_action_catalogue_c.hpp"
+#include "capability_decls/plugin_action_catalogue_d.hpp"
+#include "capability_decls/plugin_action_catalogue_content_dist.hpp"
 #include "mcp_input_bounds.hpp" // kExecInstrBoundReasons — the boot pre-seed iterates it (#2437)
 #include "mcp_jsonrpc.hpp"
 #include "auth_routes.hpp"
@@ -1050,6 +1061,46 @@ public:
         metrics_.counter("yuzu_server_dispatch_target_rejected_total",
                          {{"route", "dispatch_closure"},
                           {"reason", std::string(yuzu::server::kReasonClosureNoTarget)}});
+        // ── Dispatch chokepoint + gateway wire-capability denials ─────────
+        //
+        // These three series answer "did the gate run and refuse?" — a question
+        // that has no answer at all while the counter is created lazily inside
+        // its own denial branch. Absent-vs-zero is exactly the distinction that
+        // matters here: an unseeded gateway-capability counter reads identically
+        // whether the gateway is advertising the capability correctly or the
+        // check never executed because the arming message was silently dropped
+        // (CC-03 — the gateway's CONNECTED advertisement is a `gen_server:cast`
+        // that `yuzu_gw_upstream.erl` drops on an open circuit or a full notify
+        // queue, with no retry). Seeding them makes the blind state visible.
+        //
+        // Both label sets are closed: `reason` is every `DispatchDenialReason`
+        // enumerator, `capability` is the one wire capability the server gates
+        // on today.
+        metrics_.describe("yuzu_server_dispatch_denied_total",
+                          "Dispatches refused by the classification/authorization chokepoint "
+                          "(`build_classified_command`), labelled by which gate refused. "
+                          "`kill_switched` is an operator-thrown emergency stop, deliberately "
+                          "distinct from the `forbidden` authorization verdict.",
+                          "counter");
+        for (auto reason : {"unclassified", "ambiguous", "anonymous_operator", "forbidden",
+                            "kill_switched"}) {
+            metrics_.counter("yuzu_server_dispatch_denied_total", {{"reason", reason}});
+        }
+        metrics_.describe("yuzu_server_dispatch_tag_invalid_total",
+                          "ClassifiedCommands whose dispatch_tag failed to decode at the send "
+                          "path — a defensive check behind the type invariant, so any non-zero "
+                          "value is a server-side defect.",
+                          "counter");
+        metrics_.counter("yuzu_server_dispatch_tag_invalid_total");
+        metrics_.describe("yuzu_server_gateway_capability_denied_total",
+                          "Dispatches refused because the routing gateway has not advertised the "
+                          "named wire capability in its most recent CONNECTED notification. Zero "
+                          "means the check ran and passed; absent would mean it never ran.",
+                          "counter");
+        metrics_.counter(
+            "yuzu_server_gateway_capability_denied_total",
+            {{"capability", std::string(yuzu::server::detail::kGatewayWireCapabilityDispatchTagV1)}});
+
         // #2437 transport-layer body rejection (pre-routing, pre-auth). No
         // `tool` label: the body is never read, so nothing is known about the
         // call beyond its path — a tool label here would be a fabrication.
@@ -3512,17 +3563,22 @@ public:
                 const auto command_id =
                     "tar-" + auth::AuthManager::bytes_to_hex(auth::AuthManager::random_bytes(8));
 
-                detail::pb::CommandRequest cmd;
-                cmd.set_command_id(command_id);
-                cmd.set_plugin("tar");
-                cmd.set_action("fleet_snapshot");
+                // PR1.9c: the ONE builder, under an explicit system caller —
+                // `tar.fleet_snapshot` is `system_reserved` (never a
+                // caller-attributable RBAC decision, capdecls::
+                // core_dispatch_capabilities.hpp).
+                auto classified = build_classified_command(
+                    yuzu::server::DispatchCaller{.system = true}, "tar", "fleet_snapshot",
+                    command_id);
+                if (!classified)
+                    return out; // denied/unclassified — already counted + logged
 
                 agent_service_.record_send_time(command_id);
 
                 std::unordered_set<std::string> dispatched;
                 dispatched.reserve(agent_ids.size());
                 for (const auto& aid : agent_ids) {
-                    if (registry_.send_to(aid, cmd))
+                    if (registry_.send_to(aid, *classified))
                         dispatched.insert(aid);
                 }
                 forward_gateway_pending();
@@ -4071,16 +4127,17 @@ public:
                             return member;
                         },
                         /*full_sync=*/true, current);
-                    ::yuzu::agent::v1::CommandRequest cmd;
                     // Unique per re-push (random suffix) so a same-generation reconcile
                     // can't collide with the agent's replay-dedup set (hp-F2/cons-S1).
-                    cmd.set_command_id(
+                    const auto command_id =
                         "__guard__-reconcile-" + std::to_string(current) + "-" +
-                        auth::AuthManager::bytes_to_hex(auth::AuthManager::random_bytes(8)));
-                    cmd.set_plugin("__guard__");
-                    cmd.set_action("push_rules");
-                    cmd.set_payload(push.SerializeAsString());
-                    if (registry_.send_to(agent_id, cmd)) {
+                        auth::AuthManager::bytes_to_hex(auth::AuthManager::random_bytes(8));
+                    // PR1.9c: system caller — __guard__.push_rules is
+                    // `system_reserved` (capdecls::core_dispatch_capabilities.hpp).
+                    auto classified = build_classified_command(
+                        yuzu::server::DispatchCaller{.system = true}, "__guard__", "push_rules",
+                        command_id, /*parameters=*/{}, push.SerializeAsString());
+                    if (classified && registry_.send_to(agent_id, *classified)) {
                         forward_gateway_pending();
                         metrics_
                             .counter("yuzu_server_guardian_reconciles_total",
@@ -8044,13 +8101,168 @@ private:
         return yuzu::server::authz::compose_exec_visible(facts);
     }
 
+    /// PLAN-006: wraps `derive_exec_visible` with the caller's IDENTITY, so a
+    /// dispatch surface with a live Session can hand `dispatch_confined` a
+    /// principal to work with, not only a visibility filter. Pure plumbing —
+    /// composes `derive_exec_visible` verbatim and adds no new decision.
+    /// `principal_role` mirrors the `role` audited on scope-evaluation rows
+    /// (see `dispatch_confined`'s own `principal_role` param below).
+    yuzu::server::DispatchCaller derive_dispatch_caller(const auth::Session& sess) {
+        return yuzu::server::DispatchCaller{
+            .principal = sess.username,
+            .principal_role = auth::role_to_string(sess.role),
+            .exec_visible = derive_exec_visible(sess),
+            .system = false,
+        };
+    }
+
+    /// PR1.9c: a stable string label for `DispatchArm`, fed into
+    /// `build_classified_command`'s `target_arm` (→ `compute_plan_hash`) so
+    /// two dispatches of the same `plugin.action` differing only in HOW
+    /// targets were selected (an explicit id list vs. a scope match that
+    /// happens to resolve to the same set) mint distinct plan identities.
+    /// Local to this translation unit, not the wire — never parsed back,
+    /// only hashed, so the exact spelling is a private implementation detail.
+    static std::string_view dispatch_arm_label(DispatchArm arm) {
+        switch (arm) {
+        case DispatchArm::Group: return "group";
+        case DispatchArm::Scope: return "scope";
+        case DispatchArm::Ids: return "ids";
+        case DispatchArm::Broadcast: return "broadcast";
+        case DispatchArm::None: return "none";
+        }
+        return "none";
+    }
+
+    /// PR1.9c (spec item 1): the ONE place a `detail::pb::CommandRequest` is
+    /// constructed — every former direct-construction site now calls this
+    /// instead. Classifies `plugin.action` via `capability_registry_`,
+    /// authorizes the result against `caller` (via
+    /// `classify_and_authorize_dispatch`, agent_registry.hpp — the pure,
+    /// independently-unit-tested decision this method wraps with the one live
+    /// dependency it needs: `rbac_store_`), and — ONLY on success — stamps
+    /// `dispatch_tag` and mints the `ClassifiedCommand` that alone can reach
+    /// `AgentRegistry::send_to`/`send_to_all`.
+    ///
+    /// `target_arm`/`execution_id` feed `compute_plan_hash` (via
+    /// `detail::compute_dispatch_tag`) so two dispatches that differ only in
+    /// HOW targets were selected, or which execution they belong to, mint
+    /// distinct plan identities; callers with no such concept (the system
+    /// dispatchers, the legacy sink) pass `{}` for both. `payload`/
+    /// `stagger_seconds`/`delay_seconds` are optional CommandRequest fields
+    /// only some call sites need — set post-classification, since a
+    /// classification/authorization DENIAL must never construct any part of
+    /// the wire command.
+    ///
+    /// Denial is reported, never thrown: every caller — background loops with
+    /// no `res` to answer on included — must handle
+    /// `std::unexpected` explicitly. Every denial is counted (one family,
+    /// `reason` label) and logged; no path returns a permissive default
+    /// (ADR-0033 §2).
+    std::expected<detail::ClassifiedCommand, detail::DispatchDenial> build_classified_command(
+        const yuzu::server::DispatchCaller& caller, const std::string& plugin,
+        const std::string& action, const std::string& command_id,
+        const std::unordered_map<std::string, std::string>& parameters = {},
+        const std::string& payload = {}, int stagger_seconds = 0, int delay_seconds = 0,
+        const std::string& target_arm = {}, const std::string& execution_id = {}) {
+        auto decision = yuzu::server::detail::classify_and_authorize_dispatch(
+            capability_registry_, caller, plugin, action,
+            [this](std::string_view principal, std::string_view securable,
+                   yuzu::server::authz::Operation op) {
+                // Mirrors every other dispatch-adjacent RBAC read in this file
+                // (e.g. derive_exec_visible's own `legacy_open` composition):
+                // a loaded-and-explicitly-disabled store is legacy-open, and
+                // legacy-open means "RBAC off, everyone may do everything" —
+                // the SAME bypass every other securable already grants here,
+                // not a new one minted for this chokepoint.
+                if (!rbac_enforcement_in_effect(rbac_store_.get()))
+                    return true;
+                return rbac_store_ != nullptr &&
+                       rbac_store_->check_permission(std::string(principal),
+                                                     std::string(securable),
+                                                     std::string(yuzu::server::authz::to_string(op)));
+            });
+
+        if (!decision) {
+            const auto& denial = decision.error();
+            std::string_view reason_label;
+            switch (denial.reason) {
+            case yuzu::server::detail::DispatchDenialReason::Unclassified:
+                reason_label = "unclassified";
+                break;
+            case yuzu::server::detail::DispatchDenialReason::Ambiguous:
+                reason_label = "ambiguous";
+                break;
+            case yuzu::server::detail::DispatchDenialReason::AnonymousOperator:
+                reason_label = "anonymous_operator";
+                break;
+            case yuzu::server::detail::DispatchDenialReason::Forbidden:
+                reason_label = "forbidden";
+                break;
+            case yuzu::server::detail::DispatchDenialReason::KillSwitched:
+                reason_label = "kill_switched";
+                break;
+            }
+            metrics_
+                .counter("yuzu_server_dispatch_denied_total",
+                         {{"reason", std::string(reason_label)}})
+                .increment();
+            spdlog::warn(
+                "dispatch denied: {}:{} reason={} securable={} caller={}", plugin, action,
+                reason_label, denial.securable.empty() ? "(none)" : denial.securable,
+                caller.system ? std::string("system")
+                             : (caller.principal.empty() ? std::string("(anonymous)")
+                                                          : caller.principal));
+            return std::unexpected(denial);
+        }
+
+        const auto& cap = *decision;
+
+        // PER-ACTION KILL SWITCH SEAM + BR-009 canonical wire names. Both
+        // behaviours are composed by `finalize_classified_command`
+        // (agent_registry.hpp) rather than inlined here, so the composition
+        // itself — not just its two pieces in isolation — is directly
+        // unit-testable without a live `ServerImpl`.
+        //
+        // The kill-switch callback is UNWIRED in this PR (empty std::function =
+        // legacy-open for this one gate, mirroring how an absent config store
+        // behaves) — the plugin-config plane that supplies the real
+        // `action_allowed` predicate lands later in this stack and replaces the
+        // `{}` below with a fail-closed store-backed callback. The seam is
+        // injected (rather than the store being reached for directly) precisely
+        // so this PR's chokepoint is complete and testable without that store.
+        //
+        // Placed AFTER classification+authorization deliberately: an unclassified
+        // or forbidden dispatch should report that, not be masked by a kill
+        // switch, and the switch is keyed on a plugin.action we have confirmed
+        // exists.
+        auto finalized = yuzu::server::detail::finalize_classified_command(
+            cap, /*action_allowed=*/{}, plugin, action, command_id, parameters, payload,
+            stagger_seconds, delay_seconds, target_arm, execution_id);
+
+        if (!finalized) {
+            // The only denial `finalize_classified_command` can produce is
+            // KillSwitched — classification/authorization already succeeded
+            // above.
+            metrics_.counter("yuzu_server_dispatch_denied_total", {{"reason", "kill_switched"}})
+                .increment();
+            spdlog::warn("dispatch denied: {}:{} reason=kill_switched caller={}", plugin, action,
+                         caller.system ? std::string("system")
+                                       : (caller.principal.empty() ? std::string("(anonymous)")
+                                                                   : caller.principal));
+            return std::unexpected(finalized.error());
+        }
+
+        return *finalized;
+    }
+
     /// A-3: the `ConfinedDispatchSink` literal both `dispatch_confined` and
     /// `/api/command` built by hand — byte-identical apart from the local
     /// name (`sink` vs `confined_sink`) — is the same sink because the two
     /// callers dispatch through the SAME registry_. `cmd` is captured by
     /// reference: the returned sink must not outlive it.
     yuzu::server::ConfinedDispatchSink
-    make_confined_dispatch_sink(const detail::pb::CommandRequest& cmd) {
+    make_confined_dispatch_sink(const detail::ClassifiedCommand& cmd) {
         return yuzu::server::ConfinedDispatchSink{
             [this, &cmd](const std::string& aid) { return registry_.send_to(aid, cmd); },
             [this, &cmd] { return registry_.send_to_all(cmd); },
@@ -8080,31 +8292,42 @@ private:
     /// empty selection into a deliberate fleet broadcast (dashboard + MCP —
     /// `true`). This is the seam #1714/#1715's core chokepoint will EXTEND, not
     /// a per-route copy to be forked.
-    /// `principal_role` (C5): carried alongside `principal` on the
-    /// scope-evaluation audit rows this seam emits. Defaulted so the four
-    /// existing callers (all wired through Deps/DispatchFn shapes owned by
-    /// other files — dashboard_routes.hpp, mcp_server.hpp, PolicyEvaluator —
-    /// this wave does not touch) keep compiling unchanged and keep emitting
-    /// role="" exactly as before; a caller updated in a later wave to thread
-    /// its live session's role through can now do so without a second seam.
+    /// `caller.principal_role` (C5): carried alongside `caller.principal` on
+    /// the scope-evaluation audit rows this seam emits.
     ///
-    /// CDX-P1-03/K-3 (adv-fix11): attempted widening McpServer::DispatchFn by
-    /// one param for exactly this — the session is already in scope at both
-    /// MCP call sites (execute_instruction, quarantine_device) via
-    /// ExecVisibleFn. Reverted: the typedef is reused verbatim by 18+ fake
-    /// DispatchFn lambdas in test_mcp_server.cpp alone (each would need
-    /// updating for a signature-only change), plus BundleOrchestrator::
-    /// DispatchFn (execute_bundle) is a SEPARATE, REST-shared typedef with no
-    /// role concept on its REST side — disproportionate blast radius for an
+    /// PLAN-006 (verified; supersedes CDX-P1-03/K-3 below): the calculus that
+    /// declined this widening no longer holds once a principal is the actual
+    /// FEATURE a chokepoint wave needs, not merely audit completeness. The
+    /// widening happened: `DispatchCaller` (dispatch_caller.hpp) replaces the
+    /// bare `exec_visible`/`principal_role` pair on this signature AND on the
+    /// three DispatchFn/CommandDispatchFn typedefs that feed it
+    /// (McpServer::DispatchFn, DashboardRoutes::DispatchFn,
+    /// WorkflowRoutes::CommandDispatchFn); every fake dispatch lambda in
+    /// test_mcp_server.cpp / test_dashboard_tar_fragments.cpp /
+    /// test_workflow_routes.cpp was updated for the signature-only change.
+    /// `BundleOrchestrator::DispatchFn` (execute_bundle) is left as the
+    /// original CDX-P1-03/K-3 comment found it — a SEPARATE, REST-shared
+    /// typedef with no role concept on its REST side; mcp_server.cpp now
+    /// adapts the widened DispatchFn down to it at construction rather than
+    /// touch that shared type. `principal`/`principal_role` are empty for a
+    /// caller not yet wired to identify itself (present-empty `exec_visible`
+    /// still denies); `DispatchCaller::system` marks a genuine
+    /// background/system dispatcher (no Session at all) explicitly.
+    ///
+    /// Original CDX-P1-03/K-3 (adv-fix11) rationale, preserved for context: a
+    /// prior wave attempted widening McpServer::DispatchFn by one param for
+    /// exactly this — the session is already in scope at both MCP call sites
+    /// (execute_instruction, quarantine_device) via ExecVisibleFn — and
+    /// reverted, judging the blast radius (18+ fake DispatchFn lambdas plus
+    /// the BundleOrchestrator coupling above) disproportionate for an
     /// audit-completeness LOW both external reviewers graded non-blocking.
-    /// Still open for a future wave willing to touch those call sites.
     std::pair<std::string, int> dispatch_confined(
         const std::string& plugin, const std::string& action,
         const std::vector<std::string>& agent_ids, const std::string& scope_expr,
         const std::unordered_map<std::string, std::string>& parameters,
         const std::string& execution_id,
-        const yuzu::server::authz::VisibleSet& exec_visible,
-        bool broadcast_on_none, const std::string& principal_role = {}) {
+        const yuzu::server::DispatchCaller& caller,
+        bool broadcast_on_none) {
         // Normalize action to lowercase — agent plugins register actions in
         // lowercase and match case-sensitively (was implicit on the MCP path
         // via upstream lowercasing; a safe superset here).
@@ -8115,26 +8338,35 @@ private:
         auto command_id =
             plugin + "-" + auth::AuthManager::bytes_to_hex(auth::AuthManager::random_bytes(8));
 
-        detail::pb::CommandRequest cmd;
-        cmd.set_command_id(command_id);
-        cmd.set_plugin(plugin);
-        cmd.set_action(norm_action);
-        for (const auto& [k, v] : parameters)
-            (*cmd.mutable_parameters())[k] = v;
+        // Same classifier as the /api/command handler (#2500): an explicit
+        // agent_ids list ALWAYS wins over a broadcast request; `__all__` is
+        // treated as "no scope expression", never a first-wins broadcast.
+        // Computed here (in addition to inside resolve_and_dispatch_confined,
+        // which is pure and cheap to call twice) for TWO reasons now: the
+        // None-arm observability below (specific to this seam, not something
+        // dispatch_confined_arms itself emits), AND — PR1.9c — to feed
+        // build_classified_command's plan-hash `target_arm` below.
+        const auto arm = classify_dispatch_arm(!agent_ids.empty(), scope_expr);
+
+        // PR1.9c (spec item 1): the ONE builder. Classification/authorization
+        // gates BEFORE any targeting decision — a denial (unclassified,
+        // ambiguous, or `caller` not authorized for the resolved
+        // securable/operation) reaches nobody, exactly like the None-arm
+        // no-target case below. Already counted + logged by
+        // build_classified_command; nothing further to do here on refusal.
+        auto classified =
+            build_classified_command(caller, plugin, norm_action, command_id, parameters,
+                                     /*payload=*/{}, /*stagger_seconds=*/0, /*delay_seconds=*/0,
+                                     std::string(dispatch_arm_label(arm)), execution_id);
+        if (!classified)
+            return {command_id, 0};
+
         agent_service_.record_send_time(command_id);
         // PR 2 / UP2-4: register command_id -> execution_id BEFORE any RPC.
         if (!execution_id.empty()) {
             agent_service_.record_execution_id(command_id, execution_id);
         }
 
-        // Same classifier as the /api/command handler (#2500): an explicit
-        // agent_ids list ALWAYS wins over a broadcast request; `__all__` is
-        // treated as "no scope expression", never a first-wins broadcast.
-        // Computed here (in addition to inside resolve_and_dispatch_confined,
-        // which is pure and cheap to call twice) ONLY to decide the
-        // None-arm observability below, which is specific to this seam and
-        // not something dispatch_confined_arms itself emits.
-        const auto arm = classify_dispatch_arm(!agent_ids.empty(), scope_expr);
         if (arm == DispatchArm::None && !broadcast_on_none) {
             // Shared closure: NO TARGET NAMED AT ALL — reach NOBODY, not
             // everybody (#2500). COUNTED, not just logged: this branch is
@@ -8174,8 +8406,8 @@ private:
                    const std::string& cmd_id, const std::string& reason) {
                 audit_scope_evaluation_aborted(principal, role, cmd_id, reason);
             },
-            command_id, execution_id, principal_role, agent_ids, scope_expr, exec_visible,
-            broadcast_on_none, cmd);
+            command_id, execution_id, caller.principal_role, agent_ids, scope_expr,
+            caller.exec_visible, broadcast_on_none, *classified);
         (void)ignored_command_id; // always == command_id, minted above
 
         forward_gateway_pending();
@@ -8347,22 +8579,22 @@ private:
             return;
 
         // Build the sync command with all 4 structured category values
-        ::yuzu::agent::v1::CommandRequest cmd;
-        cmd.set_command_id("asset-tag-sync-" +
-                           std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(
-                                              std::chrono::system_clock::now().time_since_epoch())
-                                              .count()));
-        cmd.set_plugin("asset_tags");
-        cmd.set_action("sync");
-
-        auto* params = cmd.mutable_parameters();
+        std::unordered_map<std::string, std::string> parameters;
         for (auto cat_key : kCategoryKeys) {
             std::string key_str{cat_key};
-            auto val = tag_store_->get_tag(agent_id, key_str);
-            (*params)[key_str] = val;
+            parameters[key_str] = tag_store_->get_tag(agent_id, key_str);
         }
 
-        if (registry_.send_to(agent_id, cmd)) {
+        const auto command_id =
+            "asset-tag-sync-" +
+            std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(
+                               std::chrono::system_clock::now().time_since_epoch())
+                               .count());
+        // PR1.9c: system caller — asset_tags.sync is `system_reserved`
+        // (capdecls::core_dispatch_capabilities.hpp).
+        auto classified = build_classified_command(yuzu::server::DispatchCaller{.system = true},
+                                                    "asset_tags", "sync", command_id, parameters);
+        if (classified && registry_.send_to(agent_id, *classified)) {
             spdlog::debug("Pushed asset tag sync to agent {}", agent_id);
             forward_gateway_pending();
         }
@@ -11286,6 +11518,19 @@ private:
             }
             const bool named_target = yuzu::server::targeting_supplied(body);
 
+            // Resolved ONCE for the whole handler (was resolved a second time,
+            // redundantly, inside the destructive-action block below, and a
+            // third time implicitly via derive_exec_visible's need for a
+            // Session — PR1.9c consolidates to the one call every other path
+            // in this file already treats as the rule: "require_auth writes an
+            // error response on failure, so calling it twice could emit two"
+            // (forward_legacy_command's own comment, same file). Placed AFTER
+            // require_permission(Execution,Execute) so a bare-unauthenticated
+            // caller was already turned away by that coarser gate first.
+            auto sess = require_auth(req, res);
+            if (!sess)
+                return; // require_auth already wrote the response
+
             // Per-action securable elevation + scope confinement for DESTRUCTIVE
             // generic-dispatch actions (governance HIGH #2). /api/command otherwise
             // base-gates only Execution:Execute and applies NO per-device visibility to
@@ -11299,18 +11544,24 @@ private:
             // purge via /api/command audits under the generic `command.dispatch` verb +
             // yuzu_commands_dispatched_total, not tar.source.purge / the domain metric —
             // domain-verb emission on this path is tracked in Tr3kkR/Yuzu#1787.)
+            //
+            // PR1.9c (spec item 4): PRESERVES this behaviour exactly for
+            // `tar.purge_source` — same securable (`Infrastructure`), same
+            // operation (`Delete`), same 400/404 shapes, same visible-agents
+            // confinement — but sources the securable/operation from
+            // `capability_registry_` instead of a hand-maintained one-row map,
+            // so it generalizes automatically to every OTHER row the registry
+            // classifies `Destructive` (e.g. `filesystem.delete_lines`,
+            // `registry.delete_key`) rather than silently exempting them from
+            // the same targeting-safety treatment `tar.purge_source` alone used
+            // to get.
             {
-                static const std::unordered_map<std::string,
-                                                std::pair<std::string, std::string>>
-                    kDestructiveActionSecurable = {
-                        {"tar.purge_source", {"Infrastructure", "Delete"}},
-                    };
-                std::string dkey = plugin + "." + action;
-                std::transform(dkey.begin(), dkey.end(), dkey.begin(),
-                               [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-                if (auto it = kDestructiveActionSecurable.find(dkey);
-                    it != kDestructiveActionSecurable.end()) {
-                    if (!require_permission(req, res, it->second.first, it->second.second))
+                const auto classified_for_gate = capability_registry_.classify(plugin, action);
+                if (classified_for_gate &&
+                    classified_for_gate->dispatch_class == yuzu::server::DispatchClass::Destructive) {
+                    const auto& cap = *classified_for_gate;
+                    if (!require_permission(req, res, std::string(cap.securable),
+                                            std::string(yuzu::server::authz::to_string(cap.operation))))
                         return;
                     // Destructive dispatch must be explicitly targeted + in scope.
                     if (agent_ids.empty() || !extract_json_string(body, "scope").empty()) {
@@ -11325,10 +11576,8 @@ private:
                     // dashboard fragment). Out-of-scope ids are silently dropped.
                     std::vector<std::string> filtered;
                     if (mgmt_group_store_) {
-                        auto s = require_auth(req, res);
-                        if (!s) return;
                         // ADR-0042: nullopt (store degraded) → empty visible set → 404.
-                        auto vis = mgmt_group_store_->get_visible_agents(s->username);
+                        auto vis = mgmt_group_store_->get_visible_agents(sess->username);
                         std::unordered_set<std::string> visible;
                         if (vis)
                             visible.insert(vis->begin(), vis->end());
@@ -11372,11 +11621,11 @@ private:
             // emptied out below. Fail-closed: any store error narrows to
             // "nothing visible", never "everything" — never re-decides the
             // frozen #1715/INV-7 precedence those RbacStore calls already
-            // resolve, only composes on top of it.
-            auto sess = require_auth(req, res);
-            if (!sess)
-                return; // require_auth already wrote the response
-
+            // resolve, only composes on top of it. `sess` was already
+            // resolved once, above the destructive-action block (PR1.9c
+            // consolidation) — re-authenticating here would risk a second
+            // written response on failure for no benefit.
+            //
             // D3: the no-agent 503 short-circuit sits BEFORE deriving
             // exec_visible — that derivation runs an RBAC/tag-store lookup
             // that is wasted work on the (common, cheap-to-detect) no-agent
@@ -11389,39 +11638,74 @@ private:
                 return;
             }
 
-            yuzu::server::authz::VisibleSet exec_visible = derive_exec_visible(*sess);
+            // PLAN-006: the caller's IDENTITY, not merely their visibility
+            // filter — `caller.exec_visible` is byte-identical to the
+            // `exec_visible` this handler derived directly before PR1.9c
+            // (`derive_dispatch_caller` composes `derive_exec_visible`
+            // verbatim), kept as a reference alias so every arm-dispatch use
+            // of `exec_visible` below is unchanged.
+            const auto caller = derive_dispatch_caller(*sess);
+            const auto& exec_visible = caller.exec_visible;
 
             auto command_id =
                 plugin + "-" + auth::AuthManager::bytes_to_hex(auth::AuthManager::random_bytes(8));
 
-            detail::pb::CommandRequest cmd;
-            cmd.set_command_id(command_id);
-            cmd.set_plugin(plugin);
-            cmd.set_action(action);
+            // Parameters: pass-through key-value pairs to the agent plugin.
+            auto parameters = extract_json_string_map(body, "params");
 
-            // Parameters: pass-through key-value pairs to the agent plugin
-            {
-                auto params_map = extract_json_string_map(body, "params");
-                for (const auto& [k, v] : params_map) {
-                    (*cmd.mutable_parameters())[k] = v;
-                }
-            }
-
-            // Stagger/delay: prevent thundering herd on large-fleet dispatch
+            // Stagger/delay: prevent thundering herd on large-fleet dispatch.
             auto stagger = extract_json_int(body, "stagger", 0);
             auto delay = extract_json_int(body, "delay", 0);
-            if (stagger > 0)
-                cmd.set_stagger_seconds(stagger);
-            if (delay > 0)
-                cmd.set_delay_seconds(delay);
-
-            agent_service_.record_send_time(command_id);
 
             // Check for scope-based targeting. Reuses the parsed body like the
             // other post-auth reads; this site was missed when the rest were
             // converted and re-parsed the whole body to read a key the handler
-            // already had (governance).
+            // already had (governance). Computed here (moved up from just
+            // before the arm dispatch below) because PR1.9c's builder needs
+            // `arm` for its plan-hash `target_arm` before any dispatch
+            // decision is made.
             auto scope_expr = extract_json_string(body, "scope");
+            const auto arm = yuzu::server::classify_dispatch_arm(!agent_ids.empty(), scope_expr);
+
+            // PR1.9c (spec item 1): the ONE builder — the only place a
+            // `detail::pb::CommandRequest` is constructed. A denial (unknown/
+            // ambiguous plugin.action, or `caller` not authorized for the
+            // resolved securable/operation) is answered here — unlike the
+            // background dispatch seams, this route has a `res` to write to.
+            // Already counted (`yuzu_server_dispatch_denied_total{reason=}`)
+            // and logged by build_classified_command; this block only shapes
+            // the HTTP response and the route-local audit row.
+            auto classified = build_classified_command(
+                caller, plugin, action, command_id, parameters, /*payload=*/{}, stagger, delay,
+                std::string(dispatch_arm_label(arm)), /*execution_id=*/{});
+            if (!classified) {
+                const auto& denial = classified.error();
+                const bool is_classification_error =
+                    denial.reason == yuzu::server::detail::DispatchDenialReason::Unclassified ||
+                    denial.reason == yuzu::server::detail::DispatchDenialReason::Ambiguous;
+                const int status = is_classification_error ? 400 : 403;
+                const std::string message =
+                    is_classification_error
+                        ? std::string{"unknown or ambiguous plugin.action"}
+                        : "permission denied: " + denial.securable + ":" +
+                              std::string(yuzu::server::authz::to_string(denial.operation));
+                const bool audit_ok =
+                    audit_log(req, "command.dispatch", "denied", "command", "",
+                             std::string("reason=dispatch_denied ") +
+                                 onbehalf::sanitize_for_log(plugin, 128) + ":" +
+                                 onbehalf::sanitize_for_log(action, 128));
+                if (!audit_ok)
+                    res.set_header("Sec-Audit-Failed", "true");
+                res.status = status;
+                nlohmann::json err{{"error", {{"code", status}, {"message", message}}},
+                                   {"meta", {{"api_version", "v1"}}}};
+                if (audit_store_)
+                    err["audit_emitted"] = audit_ok;
+                res.set_content(err.dump(), "application/json");
+                return;
+            }
+
+            agent_service_.record_send_time(command_id);
 
             int sent = 0;
             // `__all__` is the PUBLISHED ground scope kind (/discover/scope-kinds,
@@ -11439,14 +11723,13 @@ private:
             // shaping — which is why it is not simply absorbed by that seam —
             // but the DECISION OF WHO IS REACHED is the shared one, so the two
             // can no longer drift.
-            const auto confined_sink = make_confined_dispatch_sink(cmd);
+            const auto confined_sink = make_confined_dispatch_sink(*classified);
             const auto dispatch_broadcast = [&]() -> int {
                 return yuzu::server::dispatch_confined_arms(
                     yuzu::server::DispatchArm::Broadcast, {}, exec_visible,
                     /*broadcast_on_none=*/true, confined_sink);
             };
 
-            const auto arm = yuzu::server::classify_dispatch_arm(!agent_ids.empty(), scope_expr);
             if (arm == yuzu::server::DispatchArm::Group) {
                 // Group-based dispatch — resolve group members here, then let the
                 // shared seam intersect (#1788): a management group is a targeting
@@ -14306,35 +14589,50 @@ private:
         // Shared command-dispatch closure — sends a CommandRequest to agents via
         // gRPC. Hoisted here (was inline in the WorkflowRoutes block) so the
         // PolicyEvaluator and WorkflowRoutes drive the EXACT same dispatch path.
+        //
+        // PLAN-006: this is a genuine background/system dispatcher — its ONLY
+        // production caller is PolicyEvaluator (a compliance-check tick with no
+        // Session in the loop) — so it constructs `DispatchCaller{.system =
+        // true}` explicitly rather than leaving `principal` merely empty by
+        // default: a background dispatch is a deliberate, greppable statement.
         auto command_dispatch_fn =
             [this](const std::string& plugin, const std::string& action,
                    const std::vector<std::string>& agent_ids, const std::string& scope_expr,
                    const std::unordered_map<std::string, std::string>& parameters,
                    const std::string& execution_id) -> std::pair<std::string, int> {
             // Background engines + legacy callers dispatch as SYSTEM (unfiltered):
-            // exec_visible = nullopt. Operator surfaces that must confine call the
-            // 7-param command_dispatch_confined_fn (below) instead. Both funnel
-            // through the ONE dispatch_confined seam. broadcast_on_none=false: an
-            // unnamed target here reaches nobody (#2500), never the fleet.
+            // exec_visible = nullopt (DispatchCaller's default). Operator surfaces
+            // that must confine call command_dispatch_caller_fn / the caller-typed
+            // sibling below instead. Both funnel through the ONE dispatch_confined
+            // seam. broadcast_on_none=false: an unnamed target here reaches nobody
+            // (#2500), never the fleet.
             return dispatch_confined(plugin, action, agent_ids, scope_expr, parameters,
-                                     execution_id, /*exec_visible=*/std::nullopt,
+                                     execution_id, yuzu::server::DispatchCaller{.system = true},
                                      /*broadcast_on_none=*/false);
         };
 
         // #1788 / CDX-R7-02 / K-R7-02: the operator-facing confined entry.
-        // Identical to command_dispatch_fn but carries the caller's
-        // Execution:Execute visible set so dashboard + workflow dispatch narrow
-        // to it, exactly as /api/command and MCP do. Same seam
-        // (dispatch_confined), one extra parameter.
-        auto command_dispatch_confined_fn =
+        // Identical to command_dispatch_fn but carries the caller (identity +
+        // Execution:Execute visible set) so every operator dispatch surface —
+        // REST v1, dashboard, workflow, MCP — narrows to it, exactly as
+        // /api/command does. Same seam (dispatch_confined), one extra parameter.
+        //
+        // PR1.9c: there used to be a second, bare-VisibleSet sibling here
+        // (`command_dispatch_confined_fn`) kept only because
+        // `RestApiV1::CommandDispatchFn` had not been widened. It built a
+        // `DispatchCaller` with an EMPTY principal, which
+        // `build_classified_command` refuses as `AnonymousOperator` before the
+        // legacy-open bypass — so every REST v1 dispatch was undeliverable.
+        // REST now takes the caller like everyone else and that closure is
+        // deleted; there is deliberately only ONE confined entry point again.
+        auto command_dispatch_caller_fn =
             [this](const std::string& plugin, const std::string& action,
                    const std::vector<std::string>& agent_ids, const std::string& scope_expr,
                    const std::unordered_map<std::string, std::string>& parameters,
                    const std::string& execution_id,
-                   const yuzu::server::authz::VisibleSet& exec_visible)
-            -> std::pair<std::string, int> {
+                   const yuzu::server::DispatchCaller& caller) -> std::pair<std::string, int> {
             return dispatch_confined(plugin, action, agent_ids, scope_expr, parameters,
-                                     execution_id, exec_visible, /*broadcast_on_none=*/false);
+                                     execution_id, caller, /*broadcast_on_none=*/false);
         };
 
         // PolicyEvaluator — drives the compliance check -> verdict pipeline.
@@ -15575,13 +15873,22 @@ private:
         // installer (content_dist) on the cleared-so-far devices, tracking the
         // per-device stage→execute state machine. Reuses the scoped
         // device provider (devices_fn) for the live re-authorization the MUTATING
-        // execute step requires, the SAME 6-param untracked dispatch (execution_id
+        // execute step requires, the SAME untracked dispatch (execution_id
         // "deployment-<id>-{stage,exec}" → skipped by notify_exec_tracker, like
         // preflight-), and a narrow ResponseStore poll seam (query_by_execution +
         // latest_per_agent). The cohort is read from preflight_run_store_.
+        //
+        // command_dispatch_CALLER_fn, not the bare system closure: every deploy
+        // advance is operator-triggered (a page load, poll, or create), never a
+        // background dispatcher, and the chokepoint must authorize
+        // content_dist.stage/execute_staged against the live caller's own
+        // SoftwareDeployment:Write grant rather than admit them unconditionally
+        // as a `.system = true` caller would (governance finding, review round
+        // following the origin/dev merge — the caller-carrying seam did not
+        // exist on dev when this route was written).
         deployment_routes_ = std::make_unique<DeploymentRoutes>();
         deployment_routes_->register_routes(
-            *web_server_, auth_fn, perm_fn, devices_fn, command_dispatch_fn,
+            *web_server_, auth_fn, perm_fn, devices_fn, command_dispatch_caller_fn,
             // Poll seam: execution_id → best (status, output) per agent. Same
             // scoring as the pre-flight collect (terminal beats running, then
             // non-empty output, then later arrival).
@@ -15597,7 +15904,17 @@ private:
                     response_store_->query_by_execution(execution_id, q)
                         .value_or(std::vector<StoredResponse>{}));
             },
-            audit_fn, preflight_run_store_.get(), deployment_run_store_.get());
+            audit_fn, preflight_run_store_.get(), deployment_run_store_.get(),
+            // #1788 gov finding: the SAME chokepoint-level Execution:Execute
+            // visible-set derivation every other operator-facing dispatch surface
+            // carries — devices_fn(viewer)∩cohort above is TARGETING confinement
+            // (Infrastructure:Read/flat group-membership), a different dimension
+            // from this. Without it, caller.exec_visible defaulted to nullopt
+            // (unfiltered), so the chokepoint's own per-target intersection
+            // (dispatch_confined_arms.hpp) was a no-op for every deployment
+            // dispatch — the exact failure shape dispatch_caller.hpp's contract
+            // reserves for a genuine `.system = true` background dispatcher only.
+            [this](const auth::Session& sess) { return derive_exec_visible(sess); });
 
         // TarTreeRoutes — /tar Frame 3 process tree viewer. Reuses DeviceRoutes'
         // scoped device picker (devices_fn) + identity lookup (lookup_fn) + the SAME
@@ -15651,24 +15968,25 @@ private:
             // DispatchFn — the dashboard execute surface, now routed through the
             // shared dispatch_confined seam exactly as /api/command and MCP are.
             //
-            // CDX-R7-02: carries the operator's Execution:Execute visible set
-            // (`exec_visible`, derived per-request by the ExecVisibleFn below)
-            // and narrows every arm to it — a management group / scope / id-list
-            // / broadcast is a targeting mechanism, never an authz exemption
-            // (#1788). execution_id is empty (dashboard is the legacy untracked
-            // UI path). broadcast_on_none=true preserves the legacy UI contract
-            // that an OMITTED `scope` means the whole fleet. It is NOT about
-            // `__all__`: dashboard_routes passes that through by name (the
-            // Broadcast arm), and refuses a supplied-but-empty `scope=`, so None
-            // reaches here only when no targeting argument was supplied at all.
+            // CDX-R7-02 / PLAN-006: carries the operator's identity + its
+            // Execution:Execute visible set (`caller`, derived per-request by
+            // the CallerFn below) and narrows every arm to it — a management
+            // group / scope / id-list / broadcast is a targeting mechanism,
+            // never an authz exemption (#1788). execution_id is empty (dashboard
+            // is the legacy untracked UI path). broadcast_on_none=true preserves
+            // the legacy UI contract that an OMITTED `scope` means the whole
+            // fleet. It is NOT about `__all__`: dashboard_routes passes that
+            // through by name (the Broadcast arm), and refuses a
+            // supplied-but-empty `scope=`, so None reaches here only when no
+            // targeting argument was supplied at all.
             [this](const std::string& plugin, const std::string& action,
                    const std::vector<std::string>& agent_ids, const std::string& scope_expr,
                    const std::unordered_map<std::string, std::string>& parameters,
-                   const yuzu::server::authz::VisibleSet& exec_visible)
+                   const yuzu::server::DispatchCaller& caller)
                 -> std::pair<std::string, int> {
                 auto [command_id, sent] = dispatch_confined(plugin, action, agent_ids, scope_expr,
                                                             parameters, /*execution_id=*/std::string{},
-                                                            exec_visible, /*broadcast_on_none=*/true);
+                                                            caller, /*broadcast_on_none=*/true);
 
                 if (sent > 0) {
                     // Publish RUNNING status + clear results via SSE.
@@ -15696,17 +16014,19 @@ private:
                 }
                 return {command_id, sent};
             },
-            // ExecVisibleFn — CDX-R7-02: resolve the caller's Execution:Execute
-            // visible set from the request. The dashboard execute handlers gate
-            // via perm_fn and hold no Session at the dispatch site, so resolve it
-            // here from a throwaway Response (never written back). A session that
-            // cannot be resolved yields a present-EMPTY set — fail CLOSED, deny
-            // all — never nullopt.
-            [this](const httplib::Request& req) -> yuzu::server::authz::VisibleSet {
+            // CallerFn — CDX-R7-02 / PLAN-006: resolve the caller's identity +
+            // Execution:Execute visible set from the request. The dashboard
+            // execute handlers gate via perm_fn and hold no Session at the
+            // dispatch site, so resolve it here from a throwaway Response
+            // (never written back). A session that cannot be resolved yields an
+            // empty principal alongside a present-EMPTY set — fail CLOSED on
+            // visibility, deny all — never nullopt.
+            [this](const httplib::Request& req) -> yuzu::server::DispatchCaller {
                 httplib::Response throwaway;
                 if (auto s = require_auth(req, throwaway))
-                    return derive_exec_visible(*s);
-                return std::unordered_set<std::string>{};
+                    return derive_dispatch_caller(*s);
+                return yuzu::server::DispatchCaller{
+                    .exec_visible = yuzu::server::authz::deny_all()};
             },
             // ResolveFn — resolve instruction text → (plugin, action)
             [this](const std::string& text) -> std::pair<std::string, std::string> {
@@ -15775,19 +16095,22 @@ private:
         wf_deps.product_pack_store = product_pack_store_.get();
         wf_deps.instruction_store = instruction_store_.get();
         wf_deps.policy_store = policy_store_.get();
-        // K-R7-02: workflow + instruction dispatch is an OPERATOR surface, so it
-        // routes through the CONFINED 7-param sibling (carries the caller's
-        // Execution:Execute visible set), not the system 6-param command_dispatch_fn.
-        // Both funnel through the ONE dispatch_confined seam.
-        wf_deps.command_dispatch_fn = command_dispatch_confined_fn;
-        wf_deps.exec_visible_fn =
-            [this](const httplib::Request& req) -> yuzu::server::authz::VisibleSet {
+        // K-R7-02 / PLAN-006: workflow + instruction dispatch is an OPERATOR
+        // surface, so it routes through the caller-carrying sibling (carries
+        // the caller's identity + Execution:Execute visible set), not the
+        // system command_dispatch_fn. Both funnel through the ONE
+        // dispatch_confined seam.
+        wf_deps.command_dispatch_fn = command_dispatch_caller_fn;
+        wf_deps.caller_fn =
+            [this](const httplib::Request& req) -> yuzu::server::DispatchCaller {
             // Resolve the session from a throwaway Response (never written back);
-            // an unresolved session yields a present-EMPTY set (fail CLOSED).
+            // an unresolved session yields an empty principal alongside a
+            // present-EMPTY set (fail CLOSED on visibility).
             httplib::Response throwaway;
             if (auto s = require_auth(req, throwaway))
-                return derive_exec_visible(*s);
-            return std::unordered_set<std::string>{};
+                return derive_dispatch_caller(*s);
+            return yuzu::server::DispatchCaller{
+                .exec_visible = yuzu::server::authz::deny_all()};
         };
         wf_deps.approval_manager = approval_manager_.get();
         wf_deps.response_store = response_store_.get();
@@ -16533,7 +16856,7 @@ private:
             // longer type-compatible with this parameter at all: the wrong
             // choice stopped being available rather than merely being avoided.
             // Empty closure would 503 those routes.
-            command_dispatch_confined_fn,
+            command_dispatch_caller_fn,
             // PR2 MFA step-up gate for the high-risk REST handlers; empty
             // closure disables the gate (preserves pre-PR2 behaviour).
             step_up_fn,
@@ -16645,19 +16968,20 @@ private:
                         [&](const std::string& expr) { return agent_in_scope(aid, expr); },
                         full_sync, generation);
 
-                    ::yuzu::agent::v1::CommandRequest cmd;
                     // Unique per push (random suffix) so two pushes in the same second
                     // can't collide on the agent's replay-dedup set (hp-F2/cons-S1).
-                    cmd.set_command_id(
+                    const auto push_command_id =
                         "__guard__-push-" + std::to_string(now_s) + "-" +
-                        auth::AuthManager::bytes_to_hex(auth::AuthManager::random_bytes(8)));
-                    cmd.set_plugin("__guard__");
-                    cmd.set_action("push_rules");
+                        auth::AuthManager::bytes_to_hex(auth::AuthManager::random_bytes(8));
                     // Binary serialized proto rides in the `payload` bytes field, not the
                     // `parameters` string map: proto3 string values must be valid UTF-8, and
                     // raw GuaranteedStatePush bytes are not. See agent.proto CommandRequest.payload.
-                    cmd.set_payload(push.SerializeAsString());
-                    if (registry_.send_to(aid, cmd)) {
+                    // PR1.9c: system caller — __guard__.push_rules is
+                    // `system_reserved` (capdecls::core_dispatch_capabilities.hpp).
+                    auto classified = build_classified_command(
+                        yuzu::server::DispatchCaller{.system = true}, "__guard__", "push_rules",
+                        push_command_id, /*parameters=*/{}, push.SerializeAsString());
+                    if (classified && registry_.send_to(aid, *classified)) {
                         ++sent;
                         metrics_
                             .counter("yuzu_server_guardian_pushes_dispatched_total",
@@ -16861,14 +17185,14 @@ private:
                        const std::vector<std::string>& agent_ids, const std::string& scope_expr,
                        const std::unordered_map<std::string, std::string>& parameters,
                        const std::string& execution_id,
-                       const yuzu::server::authz::VisibleSet& exec_visible)
+                       const yuzu::server::DispatchCaller& caller)
                     -> std::pair<std::string, int> {
                     // MCP normalises an omitted target to kBroadcastScope upstream
                     // (mcp_server.cpp), so broadcast_on_none=true states its
                     // deliberate broadcast-on-empty contract. Same seam as the
                     // shared closure and the dashboard — one confined arm logic.
                     auto r = dispatch_confined(plugin, action, agent_ids, scope_expr, parameters,
-                                               execution_id, exec_visible,
+                                               execution_id, caller,
                                                /*broadcast_on_none=*/true);
                     spdlog::info("MCP execute_instruction: {}:{} → {} agent(s)", plugin, action,
                                  r.second);
@@ -16991,11 +17315,12 @@ private:
                                                                  principal.role, target_type,
                                                                  target_id, detail, principal.cls);
                 },
-                // #1788: per-request Execution:Execute visible-set deriver, so the MCP
-                // execute_instruction / execute_bundle dispatch confines to the caller's
-                // visible device set — the SAME derivation /api/command uses.
-                [this](const auth::Session& s) -> yuzu::server::authz::VisibleSet {
-                    return derive_exec_visible(s);
+                // #1788 / PLAN-006: per-request DispatchCaller deriver, so the MCP
+                // execute_instruction / execute_bundle / quarantine_device dispatch
+                // confines to AND identifies the caller — the SAME derivation
+                // /api/command's visible-set half uses, now carrying identity too.
+                [this](const auth::Session& s) -> yuzu::server::DispatchCaller {
+                    return derive_dispatch_caller(s);
                 });
         }
 
@@ -17101,24 +17426,35 @@ private:
         auto command_id =
             plugin + "-" + auth::AuthManager::bytes_to_hex(auth::AuthManager::random_bytes(8));
 
-        detail::pb::CommandRequest cmd;
-        cmd.set_command_id(command_id);
-        cmd.set_plugin(plugin);
-        cmd.set_action(action);
-
-        agent_service_.record_send_time(command_id);
         // Resolve the session ONCE — require_auth writes an error response on
         // failure, so calling it twice could emit two. Fail CLOSED to a
-        // present-empty set (reaches nobody), never nullopt (unfiltered);
-        // the permission gate above has already admitted the caller, so this
-        // only bites if the session vanished between the two.
+        // present-empty visible set AND an empty principal, never nullopt
+        // (unfiltered); the permission gate above has already admitted the
+        // caller, so this only bites if the session vanished between the two.
         auto sess = require_auth(req, res);
-        const yuzu::server::authz::VisibleSet exec_visible =
-            sess ? derive_exec_visible(*sess)
-                 : yuzu::server::authz::deny_all();
+        const yuzu::server::DispatchCaller caller =
+            sess ? derive_dispatch_caller(*sess)
+                 : yuzu::server::DispatchCaller{.exec_visible = yuzu::server::authz::deny_all()};
+        const yuzu::server::authz::VisibleSet& exec_visible = caller.exec_visible;
+
+        // PR1.9c (spec item 1): the ONE builder. A vanished session denies
+        // here (empty principal, non-system caller) — reaching nobody exactly
+        // as the pre-existing deny_all() fallback did, just at the chokepoint
+        // rather than after resolving targets. Already counted + logged by
+        // build_classified_command.
+        auto classified = build_classified_command(caller, plugin, action, command_id);
+        if (!classified) {
+            res.status = 403;
+            res.set_content(
+                R"({"error":{"code":403,"message":"command denied"},"meta":{"api_version":"v1"}})",
+                "application/json");
+            return;
+        }
+
+        agent_service_.record_send_time(command_id);
         const yuzu::server::ConfinedDispatchSink sink{
-            [&](const std::string& aid) { return registry_.send_to(aid, cmd); },
-            [&] { return registry_.send_to_all(cmd); },
+            [&](const std::string& aid) { return registry_.send_to(aid, *classified); },
+            [&] { return registry_.send_to_all(*classified); },
             [&] { return registry_.all_ids(); }};
         int sent = yuzu::server::dispatch_confined_arms(
             yuzu::server::DispatchArm::Broadcast, {}, exec_visible,
@@ -17236,6 +17572,22 @@ private:
     auth::AuthManager& auth_mgr_;
     auth::AutoApproveEngine auto_approve_;
     yuzu::MetricsRegistry metrics_;
+    /// PR1.9c: the composed classification ruleset `build_classified_command`
+    /// consults on every dispatch — core (this package) plus the five
+    /// per-group plugin catalogues (p7/p10-p13). A STATIC ruleset, constructed
+    /// once: composing it is not itself a cached DECISION (ADR-0012 §4) —
+    /// `classify_and_authorize_dispatch` still re-classifies and re-authorizes
+    /// on every call; nothing about a dispatch OUTCOME is memoized here. No
+    /// dependency on any other member, so declaration order carries no
+    /// constraint.
+    yuzu::server::CommandCapabilityRegistry capability_registry_{
+        yuzu::server::capdecls::core_dispatch_capabilities(),
+        yuzu::server::capdecls::plugin_action_catalogue_a(),
+        yuzu::server::capdecls::plugin_action_catalogue_b(),
+        yuzu::server::capdecls::plugin_action_catalogue_c(),
+        yuzu::server::capdecls::plugin_action_catalogue_d(),
+        yuzu::server::capdecls::plugin_action_catalogue_content_dist(),
+    };
     /// Shared Postgres connection pool — the server storage substrate (ADR-0006/
     /// 0007). Constructed in the ctor BEFORE any Postgres-backed store (fail
     /// closed if the DSN is empty or unreachable), reset in stop() AFTER the

--- a/server/core/src/server.cpp
+++ b/server/core/src/server.cpp
@@ -8116,6 +8116,51 @@ private:
         };
     }
 
+    /// Review finding (external PR review, #3133): ScheduleRunner has no live
+    /// Session to derive a caller from at fire time — it only has the stored
+    /// creator username. This is the headless analogue of derive_dispatch_caller
+    /// (which mirrors derive_exec_visible verbatim), NOT a synthesized Session:
+    /// `elevated` is unconditionally false (JIT admin elevation is a
+    /// recent-authentication-event property, auth::is_elevated's own doc
+    /// comment — a background fire has no session to re-establish one) and
+    /// `service_scoped` never applies (no API token on a scheduled fire). What
+    /// DOES get re-resolved is exactly what a live re-check needs:
+    /// `check_permission`/`visible_agents_for_permission` are username-keyed
+    /// RBAC lookups, independent of any session, so this re-derives the
+    /// creator's CURRENT grants rather than trusting a stale creation-time
+    /// snapshot. Fail-closed throughout: an unknown/deleted user or a
+    /// degraded RbacStore never resolves to unfiltered — same present-EMPTY
+    /// (deny-all) posture every other unwired/degraded caller path in this
+    /// file takes.
+    yuzu::server::DispatchCaller derive_dispatch_caller_for_username(const std::string& username) {
+        yuzu::server::authz::ExecVisibleFacts facts;
+        facts.legacy_open = !rbac_enforcement_in_effect(rbac_store_.get());
+        facts.global_grant =
+            rbac_store_ && rbac_store_->check_permission(username, "Execution", "Execute");
+        if (rbac_store_) {
+            if (auto v = rbac_store_->visible_agents_for_permission(username, "Execution",
+                                                                     "Execute",
+                                                                     mgmt_group_store_.get()))
+                facts.scoped_visible = std::unordered_set<std::string>(v->begin(), v->end());
+            // else: store error -> scoped_visible stays nullopt -> fail closed.
+        }
+
+        std::string role_label;
+        if (auth_db_) {
+            if (auto user = auth_db_->get_user(username))
+                role_label = auth::role_to_string(user->role);
+            // else: unknown/deleted user -> role_label stays empty; exec_visible
+            // above is still correctly fail-closed independent of this label.
+        }
+
+        return yuzu::server::DispatchCaller{
+            .principal = username,
+            .principal_role = role_label,
+            .exec_visible = yuzu::server::authz::compose_exec_visible(facts),
+            .system = false,
+        };
+    }
+
     /// PR1.9c: a stable string label for `DispatchArm`, fed into
     /// `build_classified_command`'s `target_arm` (→ `compute_plan_hash`) so
     /// two dispatches of the same `plugin.action` differing only in HOW
@@ -14797,7 +14842,17 @@ private:
             .approval_manager = approval_manager_.get(),
             .audit_store = audit_store_.get(),
             .metrics = &metrics_,
-            .dispatch_fn = command_dispatch_fn,
+            // Review finding (#3133): was command_dispatch_fn (hardcoded
+            // system=true, unfiltered) — every scheduled fire bypassed the
+            // classify+authorize chokepoint's per-action check regardless of
+            // the creator's actual permissions. Now carries the caller
+            // resolve_caller derives, exactly like every other operator
+            // dispatch surface.
+            .dispatch_fn = command_dispatch_caller_fn,
+            .resolve_caller =
+                [this](const std::string& username) {
+                return derive_dispatch_caller_for_username(username);
+            },
         });
         schedule_tick_thread_ = std::thread([this]() {
             spdlog::info("Schedule runner thread started (cadence=30s)");
@@ -15926,13 +15981,20 @@ private:
         tar_tree_routes_ = std::make_unique<TarTreeRoutes>();
         tar_tree_routes_->register_routes(
             *web_server_, auth_fn, perm_fn, scoped_perm_fn, devices_fn, lookup_fn,
-            [command_dispatch_fn](const std::string& plugin, const std::string& action,
-                                  const std::vector<std::string>& agent_ids,
-                                  const std::string& scope_expr,
-                                  const std::unordered_map<std::string, std::string>& parameters)
-                -> std::pair<std::string, int> {
-                return command_dispatch_fn(plugin, action, agent_ids, scope_expr, parameters,
-                                           /*execution_id=*/"");
+            // Review finding (#3133): was command_dispatch_fn (hardcoded
+            // system=true, unfiltered) — the capture-source push dispatches
+            // the mutating, Infrastructure:Write-classified tar.configure
+            // action, and this route only ever gated Infrastructure:Read.
+            // Now forwards through command_dispatch_caller_fn with the real
+            // caller TarTreeRoutes derives via caller_fn below, so the
+            // chokepoint's own classify+authorize check actually runs.
+            [command_dispatch_caller_fn](
+                const std::string& plugin, const std::string& action,
+                const std::vector<std::string>& agent_ids, const std::string& scope_expr,
+                const std::unordered_map<std::string, std::string>& parameters,
+                const yuzu::server::DispatchCaller& caller) -> std::pair<std::string, int> {
+                return command_dispatch_caller_fn(plugin, action, agent_ids, scope_expr,
+                                                  parameters, /*execution_id=*/"", caller);
             },
             [this](const std::string& command_id,
                    const std::string& agent_id) -> std::vector<DexAgentResponse> {
@@ -15945,7 +16007,18 @@ private:
                     out.push_back({r.agent_id, r.status, r.output, r.error_detail});
                 return out;
             },
-            audit_fn);
+            audit_fn,
+            [this](const httplib::Request& req) -> yuzu::server::DispatchCaller {
+                // Resolve the session from a throwaway Response (never written back);
+                // an unresolved session yields an empty principal alongside a
+                // present-EMPTY set (fail CLOSED on visibility) — same idiom as
+                // WorkflowRoutes' caller_fn above.
+                httplib::Response throwaway;
+                if (auto s = require_auth(req, throwaway))
+                    return derive_dispatch_caller(*s);
+                return yuzu::server::DispatchCaller{
+                    .exec_visible = yuzu::server::authz::deny_all()};
+            });
 
         // VizRoutes — /api/v1/viz/fleet/topology + /fragments/viz/fleet/topology
         // (PR 3 of feat/viz-engine ladder)

--- a/server/core/src/server.cpp
+++ b/server/core/src/server.cpp
@@ -8128,11 +8128,44 @@ private:
     /// `check_permission`/`visible_agents_for_permission` are username-keyed
     /// RBAC lookups, independent of any session, so this re-derives the
     /// creator's CURRENT grants rather than trusting a stale creation-time
-    /// snapshot. Fail-closed throughout: an unknown/deleted user or a
-    /// degraded RbacStore never resolves to unfiltered — same present-EMPTY
-    /// (deny-all) posture every other unwired/degraded caller path in this
-    /// file takes.
+    /// snapshot.
+    ///
+    /// EXISTENCE IS THE GATE (round-2 review HIGH): every other dispatch
+    /// surface gets "the account still exists" for free from authentication —
+    /// a deleted account cannot mint a Session. Here the username is a bare
+    /// stored string, so existence must be enforced explicitly, and it is the
+    /// one input whose failure must deny INDEPENDENT of RBAC mode: on the
+    /// RBAC-off default posture the permission callback admits everyone and
+    /// legacy-open visibility is unfiltered, so an unresolvable creator that
+    /// kept its bare username as `principal` would fire with full authority
+    /// forever (ADR-0033 §7: a departed scheduler's schedule STOPS). The
+    /// decision lives in `caller_for_stored_username` (dispatch_caller.hpp,
+    /// pure, directly tested): unresolvable — deleted/unknown user, an auth
+    /// store error, or no auth store at all — yields an EMPTY-principal,
+    /// deny-all caller, which `build_classified_command` refuses as
+    /// `AnonymousOperator` before any permission check runs.
     yuzu::server::DispatchCaller derive_dispatch_caller_for_username(const std::string& username) {
+        bool principal_resolves = false;
+        std::string role_label;
+        if (auth_db_ && !username.empty()) {
+            if (auto user = auth_db_->get_user(username)) {
+                principal_resolves = true;
+                role_label = auth::role_to_string(user->role);
+            } else {
+                spdlog::warn("schedule fire: creator '{}' no longer resolves ({}); denying "
+                             "fail-closed rather than firing on a stale identity",
+                             username,
+                             user.error() == AuthDBError::UserNotFound ? "account deleted/unknown"
+                                                                       : "auth store error");
+            }
+        } else if (!username.empty()) {
+            spdlog::warn("schedule fire: no auth store wired to verify creator '{}' exists; "
+                         "denying fail-closed",
+                         username);
+        }
+        if (!principal_resolves)
+            return yuzu::server::caller_for_stored_username(username, false, {}, {});
+
         yuzu::server::authz::ExecVisibleFacts facts;
         facts.legacy_open = !rbac_enforcement_in_effect(rbac_store_.get());
         facts.global_grant =
@@ -8144,21 +8177,9 @@ private:
                 facts.scoped_visible = std::unordered_set<std::string>(v->begin(), v->end());
             // else: store error -> scoped_visible stays nullopt -> fail closed.
         }
-
-        std::string role_label;
-        if (auth_db_) {
-            if (auto user = auth_db_->get_user(username))
-                role_label = auth::role_to_string(user->role);
-            // else: unknown/deleted user -> role_label stays empty; exec_visible
-            // above is still correctly fail-closed independent of this label.
-        }
-
-        return yuzu::server::DispatchCaller{
-            .principal = username,
-            .principal_role = role_label,
-            .exec_visible = yuzu::server::authz::compose_exec_visible(facts),
-            .system = false,
-        };
+        return yuzu::server::caller_for_stored_username(
+            username, true, std::move(role_label),
+            yuzu::server::authz::compose_exec_visible(facts));
     }
 
     /// PR1.9c: a stable string label for `DispatchArm`, fed into
@@ -14632,14 +14653,21 @@ private:
         };
 
         // Shared command-dispatch closure — sends a CommandRequest to agents via
-        // gRPC. Hoisted here (was inline in the WorkflowRoutes block) so the
-        // PolicyEvaluator and WorkflowRoutes drive the EXACT same dispatch path.
+        // gRPC. Hoisted here (was inline in the WorkflowRoutes block) so every
+        // background consumer drives the EXACT same dispatch path.
         //
-        // PLAN-006: this is a genuine background/system dispatcher — its ONLY
-        // production caller is PolicyEvaluator (a compliance-check tick with no
-        // Session in the loop) — so it constructs `DispatchCaller{.system =
-        // true}` explicitly rather than leaving `principal` merely empty by
-        // default: a background dispatch is a deliberate, greppable statement.
+        // PLAN-006 (caller list corrected per #3133 round-2 review — it used to
+        // claim PolicyEvaluator was the only caller): the production consumers
+        // are PolicyEvaluator (compliance-check tick), PreflightRunner +
+        // PreflightRoutes (read-only preflight dispatch/re-dispatch), and the
+        // DexRoutes / DeviceRoutes live-info panels' canned read-only queries.
+        // All are either genuine background engines with no Session in the
+        // loop, or pre-existing read-only surfaces behind their own scoped
+        // gates (the latter tracked for caller-widening as a follow-up — see
+        // the #3133 round-1/2 review minors). It constructs
+        // `DispatchCaller{.system = true}` explicitly rather than leaving
+        // `principal` merely empty by default: a background dispatch is a
+        // deliberate, greppable statement.
         auto command_dispatch_fn =
             [this](const std::string& plugin, const std::string& action,
                    const std::vector<std::string>& agent_ids, const std::string& scope_expr,

--- a/server/core/src/tar_tree_routes.cpp
+++ b/server/core/src/tar_tree_routes.cpp
@@ -789,6 +789,7 @@ void TarTreeRoutes::register_routes(HttpRouteSink& sink, AuthFn auth_fn, PermFn 
         // build_classified_command exactly like every other Write-classified action.
         const auto caller = caller_fn_(req);
         int applied = 0;
+        int refused_or_unreached = 0;
         std::size_t pos = 0;
         while (pos < changes.size()) {
             const auto comma = changes.find(',', pos);
@@ -816,6 +817,27 @@ void TarTreeRoutes::register_routes(HttpRouteSink& sink, AuthFn auth_fn, PermFn 
             // not claim it was pushed (ADR-0015 review LOW-D).
             if (sent > 0)
                 ++applied;
+            else
+                ++refused_or_unreached;
+        }
+        // #3133 round-2 review minor: a chokepoint denial (the operator lacks
+        // the Infrastructure:Write that tar.configure is classified as) used
+        // to render the same "0 change(s) pushed" as an offline agent. The
+        // dispatch return can't distinguish the two ({command_id, 0} either
+        // way), so when nothing landed, probe scoped Write the same soft way
+        // can_execute probes Execute — for the MESSAGE only. The probe
+        // approximates the chokepoint's decision for display; the chokepoint
+        // itself remains the enforcement authority either way.
+        if (applied == 0 && refused_or_unreached > 0) {
+            httplib::Response probe;
+            const bool likely_authorized =
+                scoped_perm_fn_ && scoped_perm_fn_(req, probe, "Infrastructure", "Write", device);
+            if (!likely_authorized) {
+                note(res, "No changes pushed: modifying capture sources dispatches "
+                          "<code>tar.configure</code>, which needs the <b>Infrastructure "
+                          "Write</b> permission.");
+                return;
+            }
         }
         res.set_content(std::format("<span data-applied=\"{}\">{} change(s) pushed</span>", applied,
                                     applied),

--- a/server/core/src/tar_tree_routes.cpp
+++ b/server/core/src/tar_tree_routes.cpp
@@ -294,17 +294,19 @@ std::optional<std::string> TarTreeRoutes::cache_render_detail(const std::string&
 void TarTreeRoutes::register_routes(httplib::Server& svr, AuthFn auth_fn, PermFn perm_fn,
                                     ScopedPermFn scoped_perm_fn, DevicesFn devices_fn,
                                     LookupFn lookup_fn, DispatchFn dispatch_fn,
-                                    ResponsesFn responses_fn, AuditFn audit_fn) {
+                                    ResponsesFn responses_fn, AuditFn audit_fn,
+                                    CallerFn caller_fn) {
     HttplibRouteSink sink(svr);
     register_routes(sink, std::move(auth_fn), std::move(perm_fn), std::move(scoped_perm_fn),
                     std::move(devices_fn), std::move(lookup_fn), std::move(dispatch_fn),
-                    std::move(responses_fn), std::move(audit_fn));
+                    std::move(responses_fn), std::move(audit_fn), std::move(caller_fn));
 }
 
 void TarTreeRoutes::register_routes(HttpRouteSink& sink, AuthFn auth_fn, PermFn perm_fn,
                                     ScopedPermFn scoped_perm_fn, DevicesFn devices_fn,
                                     LookupFn lookup_fn, DispatchFn dispatch_fn,
-                                    ResponsesFn responses_fn, AuditFn audit_fn) {
+                                    ResponsesFn responses_fn, AuditFn audit_fn,
+                                    CallerFn caller_fn) {
     auth_fn_ = std::move(auth_fn);
     perm_fn_ = std::move(perm_fn);
     scoped_perm_fn_ = std::move(scoped_perm_fn);
@@ -313,6 +315,7 @@ void TarTreeRoutes::register_routes(HttpRouteSink& sink, AuthFn auth_fn, PermFn 
     dispatch_fn_ = std::move(dispatch_fn);
     responses_fn_ = std::move(responses_fn);
     audit_fn_ = std::move(audit_fn);
+    caller_fn_ = std::move(caller_fn);
 
     // Soft Execute probe (htmx swallows a raw 403 → render an in-panel note instead).
     auto can_execute = [this](const httplib::Request& req, const std::string& id) {
@@ -379,8 +382,9 @@ void TarTreeRoutes::register_routes(HttpRouteSink& sink, AuthFn auth_fn, PermFn 
             "SELECT pid, process_name, proto, local_port, remote_addr, remote_port, state, ts, "
             "action FROM $TCP_Live" +
             where + " ORDER BY ts DESC LIMIT 5000";
-        const auto [pcmd, psent] = dispatch_fn_("tar", "sql", {device}, "", {{"sql", psql}});
-        const auto [tcmd, tsent] = dispatch_fn_("tar", "sql", {device}, "", {{"sql", tsql}});
+        const auto caller = caller_fn_(req);
+        const auto [pcmd, psent] = dispatch_fn_("tar", "sql", {device}, "", {{"sql", psql}}, caller);
+        const auto [tcmd, tsent] = dispatch_fn_("tar", "sql", {device}, "", {{"sql", tsql}}, caller);
         // Audit at DISPATCH (parity with device-live-info / DEX-perf): the live query
         // hitting the endpoint is the access event and must be recorded even when it
         // reaches no agent or the later poll never completes. Shared #1647 chokepoint:
@@ -577,8 +581,9 @@ void TarTreeRoutes::register_routes(HttpRouteSink& sink, AuthFn auth_fn, PermFn 
             const std::string asql =
                 "SELECT interface, ip_address, mac_address, entry_type, ts, action "
                 "FROM $ARP_Live ORDER BY ts DESC LIMIT 20000";
-            const auto [dc, dsent] = dispatch_fn_("tar", "sql", {device}, "", {{"sql", dsql}});
-            const auto [ac, asent] = dispatch_fn_("tar", "sql", {device}, "", {{"sql", asql}});
+            const auto caller = caller_fn_(req);
+            const auto [dc, dsent] = dispatch_fn_("tar", "sql", {device}, "", {{"sql", dsql}}, caller);
+            const auto [ac, asent] = dispatch_fn_("tar", "sql", {device}, "", {{"sql", asql}}, caller);
             // Shared #1647 chokepoint: catch-arm parity + Sec-Audit-Failed per verb
             // (DNS is usage-class PII, kept separately countable). Dispatch posture
             // unchanged; if either evidence row drops, the header is set.
@@ -686,8 +691,9 @@ void TarTreeRoutes::register_routes(HttpRouteSink& sink, AuthFn auth_fn, PermFn 
         std::string scmd = get_param(req, "scmd");
         std::string ccmd = get_param(req, "ccmd");
         if (scmd.empty() || ccmd.empty()) {
-            const auto [sc, ssent] = dispatch_fn_("tar", "status", {device}, "", {});
-            const auto [cc, csent] = dispatch_fn_("tar", "compatibility", {device}, "", {});
+            const auto caller = caller_fn_(req);
+            const auto [sc, ssent] = dispatch_fn_("tar", "status", {device}, "", {}, caller);
+            const auto [cc, csent] = dispatch_fn_("tar", "compatibility", {device}, "", {}, caller);
             (void)detail::emit_behavioral_audit(
                 audit_fn_, req, res, "tar.sources.read", ssent > 0 ? "dispatched" : "no_agents",
                 "Agent", device,
@@ -775,6 +781,13 @@ void TarTreeRoutes::register_routes(HttpRouteSink& sink, AuthFn auth_fn, PermFn 
             "process", "tcp", "service", "user",   "perf",
             "procperf", "netqual", "module", "arp", "dns"};
         const std::string changes = get_param(req, "changes");
+        // Review finding (#3133): this route gates only Infrastructure:Read above,
+        // but `tar.configure` is classified Infrastructure:Write — the route relied
+        // on the chokepoint to enforce Write, and the chokepoint only does that when
+        // handed a real, non-system caller. Deriving it here (not a bare Read-only
+        // gate) is the complete fix: an operator who lacks Write is refused by
+        // build_classified_command exactly like every other Write-classified action.
+        const auto caller = caller_fn_(req);
         int applied = 0;
         std::size_t pos = 0;
         while (pos < changes.size()) {
@@ -792,8 +805,8 @@ void TarTreeRoutes::register_routes(HttpRouteSink& sink, AuthFn auth_fn, PermFn 
             if (val != "on" && val != "off")
                 continue;
             const std::string enabled = (val == "on") ? "true" : "false";
-            const auto [cmd, sent] =
-                dispatch_fn_("tar", "configure", {device}, "", {{src + "_enabled", enabled}});
+            const auto [cmd, sent] = dispatch_fn_("tar", "configure", {device}, "",
+                                                  {{src + "_enabled", enabled}}, caller);
             (void)detail::emit_behavioral_audit(
                 audit_fn_, req, res, "tar.sources.configure", sent > 0 ? "dispatched" : "no_agents",
                 "Agent", device,

--- a/server/core/src/tar_tree_routes.hpp
+++ b/server/core/src/tar_tree_routes.hpp
@@ -24,8 +24,9 @@
 
 #include <yuzu/server/auth.hpp>
 
-#include "dex_routes.hpp"    // DexRoutes::DispatchFn/ResponsesFn/AuditFn + DexAgentResponse
-#include "device_routes.hpp" // DeviceRow
+#include "dex_routes.hpp"      // DexRoutes::ResponsesFn/AuditFn + DexAgentResponse
+#include "device_routes.hpp"   // DeviceRow
+#include "dispatch_caller.hpp" // DispatchCaller
 #include "tar_process_tree.hpp"
 
 #include <httplib.h>
@@ -68,18 +69,37 @@ public:
     /// Unscoped single-device identity lookup (for the device's OS — the Windows
     /// names-only caption). Authz is the scoped gate the routes run first.
     using LookupFn = std::function<std::optional<DeviceRow>(const std::string& agent_id)>;
-    using DispatchFn = DexRoutes::DispatchFn;
+    /// Review finding (external PR review, #3133): every dispatch in this class used
+    /// to go through `DexRoutes::DispatchFn` (no caller parameter), which server.cpp
+    /// wired to the unfiltered `command_dispatch_fn` — so a mutating action
+    /// (`tar.configure`, the capture-source push) dispatched as `system`, bypassing
+    /// the catalogue's `Infrastructure:Write` requirement even though the route
+    /// itself only ever checked `Infrastructure:Read`. TarTreeRoutes now has its own
+    /// caller-aware signature — deliberately NOT sharing `DexRoutes::DispatchFn` with
+    /// `DeviceRoutes` (the device-live-info panel), whose read-only, pre-existing
+    /// system dispatch is a separate, non-blocking finding from the same review.
+    using DispatchFn = std::function<std::pair<std::string, int>(
+        const std::string& plugin, const std::string& action,
+        const std::vector<std::string>& agent_ids, const std::string& scope_expr,
+        const std::unordered_map<std::string, std::string>& parameters,
+        const yuzu::server::DispatchCaller& caller)>;
     using ResponsesFn = DexRoutes::ResponsesFn;
     using AuditFn = DexRoutes::AuditFn;
+    /// Resolves the caller's identity + Execution:Execute visible set from the
+    /// request — same contract as WorkflowRoutes::CallerFn: an UNWIRED callback
+    /// fails CLOSED (empty principal, present-EMPTY exec_visible), never nullopt.
+    using CallerFn = std::function<yuzu::server::DispatchCaller(const httplib::Request&)>;
 
     void register_routes(httplib::Server& svr, AuthFn auth_fn, PermFn perm_fn,
                          ScopedPermFn scoped_perm_fn, DevicesFn devices_fn, LookupFn lookup_fn,
-                         DispatchFn dispatch_fn, ResponsesFn responses_fn, AuditFn audit_fn);
+                         DispatchFn dispatch_fn, ResponsesFn responses_fn, AuditFn audit_fn,
+                         CallerFn caller_fn);
 
     /// HttpRouteSink overload — in-process testable (no httplib acceptor; #438).
     void register_routes(HttpRouteSink& sink, AuthFn auth_fn, PermFn perm_fn,
                          ScopedPermFn scoped_perm_fn, DevicesFn devices_fn, LookupFn lookup_fn,
-                         DispatchFn dispatch_fn, ResponsesFn responses_fn, AuditFn audit_fn);
+                         DispatchFn dispatch_fn, ResponsesFn responses_fn, AuditFn audit_fn,
+                         CallerFn caller_fn);
 
 private:
     /// One cached reconstruction. Holds the rendered tree (node-id addressable by the
@@ -120,6 +140,7 @@ private:
     DispatchFn dispatch_fn_;
     ResponsesFn responses_fn_;
     AuditFn audit_fn_;
+    CallerFn caller_fn_;
 
     std::mutex cache_mu_;
     std::unordered_map<std::string, ReconEntry> cache_;

--- a/server/core/src/workflow_routes.cpp
+++ b/server/core/src/workflow_routes.cpp
@@ -65,9 +65,10 @@ void WorkflowRoutes::register_routes(HttpRouteSink& sink, Deps deps) {
     auto* execution_event_bus = deps.execution_event_bus;
     auto* metrics = deps.metrics;
     auto cmd_dispatch = std::move(deps.command_dispatch_fn);
-    // K-R7-02: per-request Execution:Execute visible-set derivation. A missing
-    // callback fails CLOSED at each dispatch site (present-empty set, deny all).
-    auto exec_visible_fn = std::move(deps.exec_visible_fn);
+    // K-R7-02 / PLAN-006: per-request DispatchCaller derivation. A missing
+    // callback fails CLOSED on visibility at each dispatch site (empty
+    // principal, present-empty set, deny all).
+    auto caller_fn = std::move(deps.caller_fn);
 
     // -- HTMX fragments --------------------------------------------------------
 
@@ -1158,7 +1159,7 @@ void WorkflowRoutes::register_routes(HttpRouteSink& sink, Deps deps) {
     // POST /api/workflows/:id/execute -- execute workflow against agents
     sink.Post(R"(/api/workflows/([^/]+)/execute)", [auth_fn, perm_fn, audit_fn, emit_fn,
                                                     workflow_engine, instruction_store,
-                                                    cmd_dispatch, exec_visible_fn,
+                                                    cmd_dispatch, caller_fn,
                                                     approval_manager](const httplib::Request& req,
                                                                       httplib::Response& res) {
         if (!perm_fn(req, res, "Workflow", "Execute"))
@@ -1197,13 +1198,15 @@ void WorkflowRoutes::register_routes(HttpRouteSink& sink, Deps deps) {
             return;
         }
 
-        // K-R7-02: derive the operator's Execution:Execute visible set ONCE for
-        // this request and thread it into every step dispatch below, so a
-        // workflow step is confined exactly as /api/command and MCP are. An
-        // UNWIRED derivation fails CLOSED (present-empty set → reaches nobody).
-        const yuzu::server::authz::VisibleSet exec_visible =
-            exec_visible_fn ? exec_visible_fn(req)
-                            : yuzu::server::authz::deny_all();
+        // K-R7-02 / PLAN-006: derive the operator's DispatchCaller ONCE for this
+        // request and thread it into every step dispatch below, so a workflow
+        // step is confined AND identified exactly as /api/command and MCP are.
+        // An UNWIRED derivation fails CLOSED on visibility (present-empty set →
+        // reaches nobody).
+        const yuzu::server::DispatchCaller caller =
+            caller_fn ? caller_fn(req)
+                      : yuzu::server::DispatchCaller{
+                            .exec_visible = yuzu::server::authz::deny_all()};
 
         // --- Pre-validate approval gates on all workflow steps ---------------
         // If any instruction in the workflow requires approval, reject the
@@ -1262,11 +1265,11 @@ void WorkflowRoutes::register_routes(HttpRouteSink& sink, Deps deps) {
         }
 
         // Create a dispatch function that uses the real command dispatch.
-        // exec_visible is captured by value (workflow_engine->execute invokes
-        // this synchronously below, but a value capture is lifetime-safe
-        // regardless) so every step narrows to the operator's visible set.
+        // caller is captured by value (workflow_engine->execute invokes this
+        // synchronously below, but a value capture is lifetime-safe
+        // regardless) so every step narrows to AND identifies the operator.
         auto dispatch_fn =
-            [instruction_store, &cmd_dispatch, exec_visible](
+            [instruction_store, &cmd_dispatch, caller](
                 const std::string& instruction_id, const std::string& agent_ids_json,
                 const std::string& parameters_json) -> std::expected<std::string, std::string> {
             // Look up the instruction definition to get plugin + action
@@ -1325,7 +1328,7 @@ void WorkflowRoutes::register_routes(HttpRouteSink& sink, Deps deps) {
             // the legacy sentinel (legacy fallback in detail handler
             // covers the rendering).
             auto [command_id, sent] = cmd_dispatch(def->plugin, def->action, target_ids, "", params,
-                                                   /*execution_id=*/"", exec_visible);
+                                                   /*execution_id=*/"", caller);
 
             if (sent == 0)
                 return std::unexpected<std::string>("no agents reached for " + instruction_id);
@@ -1413,7 +1416,7 @@ void WorkflowRoutes::register_routes(HttpRouteSink& sink, Deps deps) {
     // POST /api/instructions/:id/execute — dispatch a single instruction definition
     sink.Post(R"(/api/instructions/([^/]+)/execute)", [auth_fn, perm_fn, audit_fn, emit_fn,
                                                        instruction_store, cmd_dispatch,
-                                                       exec_visible_fn, execution_tracker,
+                                                       caller_fn, execution_tracker,
                                                        approval_manager,
                                                        metrics](const httplib::Request& req,
                                                                 httplib::Response& res) {
@@ -1646,16 +1649,17 @@ void WorkflowRoutes::register_routes(HttpRouteSink& sink, Deps deps) {
             const std::string dispatch_scope = (agent_ids.empty() && scope_expr.empty())
                                                    ? std::string(kBroadcastScope)
                                                    : scope_expr;
-            // K-R7-02: confine to the operator's Execution:Execute visible set
-            // via the shared dispatch_confined seam. `session` is already
-            // resolved above; re-derive from the request (fail CLOSED if the
-            // callback is unwired — present-empty set → reaches nobody).
-            const yuzu::server::authz::VisibleSet exec_visible =
-                exec_visible_fn ? exec_visible_fn(req)
-                                : yuzu::server::authz::deny_all();
+            // K-R7-02 / PLAN-006: confine to AND identify the operator via the
+            // shared dispatch_confined seam. `session` is already resolved
+            // above; re-derive from the request (fail CLOSED on visibility if
+            // the callback is unwired — present-empty set → reaches nobody).
+            const yuzu::server::DispatchCaller caller =
+                caller_fn ? caller_fn(req)
+                          : yuzu::server::DispatchCaller{
+                                .exec_visible = yuzu::server::authz::deny_all()};
             std::tie(command_id, sent) = cmd_dispatch(def->plugin, def->action, agent_ids,
                                                       dispatch_scope, params, execution_id,
-                                                      exec_visible);
+                                                      caller);
         } catch (const std::exception& e) {
             spdlog::error("instruction dispatch failed: {}", e.what());
             // Pattern C / hardening regression close: the pre-created

--- a/server/core/src/workflow_routes.hpp
+++ b/server/core/src/workflow_routes.hpp
@@ -8,6 +8,7 @@
 #include "approval_manager.hpp"
 #include "authz_model.hpp" // yuzu::server::authz::VisibleSet (K-R7-02 / #1788)
 #include "custom_properties_store.hpp"
+#include "dispatch_caller.hpp" // PLAN-006: DispatchCaller — the principal threaded to dispatch_fn
 #include "execution_tracker.hpp"
 #include "instruction_store.hpp"
 #include "policy_store.hpp"
@@ -59,22 +60,24 @@ public:
     /// register-mapping call). Empty `execution_id` skips registration
     /// (callers that don't track executions, e.g. raw command path).
     ///
-    /// K-R7-02: the trailing `exec_visible` carries the caller's
-    /// Execution:Execute visible set so workflow/instruction dispatch narrows to
-    /// it via the shared `dispatch_confined` seam, exactly as /api/command and
-    /// MCP do. nullopt == unfiltered (background/system callers only).
+    /// K-R7-02 / PLAN-006: the trailing `caller` carries the caller's identity
+    /// alongside its Execution:Execute visible set so workflow/instruction
+    /// dispatch narrows to it AND records who asked, via the shared
+    /// `dispatch_confined` seam, exactly as /api/command and MCP do.
+    /// `exec_visible` nullopt == unfiltered (background/system callers only).
     using CommandDispatchFn = std::function<std::pair<std::string, int>(
         const std::string& plugin, const std::string& action,
         const std::vector<std::string>& agent_ids, const std::string& scope_expr,
         const std::unordered_map<std::string, std::string>& parameters,
-        const std::string& execution_id, const yuzu::server::authz::VisibleSet& exec_visible)>;
+        const std::string& execution_id, const yuzu::server::DispatchCaller& caller)>;
 
-    /// K-R7-02: resolves the caller's Execution:Execute visible set from the
-    /// request. Wired in server.cpp to a closure that resolves the session and
-    /// calls `derive_exec_visible`; an UNWIRED callback fails CLOSED (the handler
-    /// passes a present-EMPTY set — deny all, never nullopt).
-    using ExecVisibleFn =
-        std::function<yuzu::server::authz::VisibleSet(const httplib::Request&)>;
+    /// K-R7-02 / PLAN-006: resolves the caller's DispatchCaller (identity +
+    /// Execution:Execute visible set) from the request. Wired in server.cpp to
+    /// a closure that resolves the session and calls `derive_dispatch_caller`;
+    /// an UNWIRED callback fails CLOSED on visibility (the handler passes an
+    /// empty principal alongside a present-EMPTY set — deny all, never nullopt).
+    using CallerFn =
+        std::function<yuzu::server::DispatchCaller(const httplib::Request&)>;
 
     /// PR 2.5 — deps-struct refactor (#670).
     ///
@@ -104,10 +107,11 @@ public:
         InstructionStore* instruction_store{nullptr};
         PolicyStore* policy_store{nullptr};
         CommandDispatchFn command_dispatch_fn;
-        /// K-R7-02: per-request Execution:Execute visible-set derivation for the
-        /// execute handlers. nullptr → the handlers fail CLOSED (present-empty
-        /// visible set, deny all) rather than dispatching unfiltered.
-        ExecVisibleFn exec_visible_fn;
+        /// K-R7-02 / PLAN-006: per-request DispatchCaller derivation for the
+        /// execute handlers. nullptr → the handlers fail CLOSED on visibility
+        /// (empty principal, present-empty visible set, deny all) rather than
+        /// dispatching unfiltered.
+        CallerFn caller_fn;
         ApprovalManager* approval_manager{nullptr};
         ResponseStore* response_store{nullptr};
         /// PR 3 — per-execution SSE event bus for `/sse/executions/{id}`.

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -546,6 +546,11 @@ if build_server
       # kept OFF the production link line so the private cached path has no
       # public trampoline in server_core.
       'unit/server/engine_liveness_test_access.cpp',
+      # PR1.9c: same #2367 pattern for ClassifiedCommandTestAccess::make — the
+      # ONLY definition, deliberately off the production link line so a
+      # production caller that tries to forge a ClassifiedCommand (bypassing
+      # classification and authorization) fails to LINK rather than compiling.
+      'unit/server/classified_command_test_access.cpp',
       'unit/server/test_rest_engine_principal_roles.cpp',
       'unit/server/test_mcp_engine_principal_roles.cpp',
       'unit/server/test_engine_principal_lifecycle.cpp',
@@ -553,6 +558,7 @@ if build_server
       'unit/server/test_rotation_confirm_state.cpp',
       'unit/server/test_access_review_model.cpp',
       'unit/server/test_access_review_store.cpp',
+      'unit/server/test_dispatch_chokepoint.cpp',
       'unit/server/test_capability_catalogue.cpp',
       'unit/server/test_command_capability.cpp',
       'unit/server/test_rest_access_review.cpp',

--- a/tests/unit/server/classified_command_test_access.cpp
+++ b/tests/unit/server/classified_command_test_access.cpp
@@ -1,0 +1,26 @@
+// Test-only definition of ClassifiedCommandTestAccess::make (#2367 pattern).
+//
+// ClassifiedCommand's constructor is private; the private ctor has no public
+// trampoline in server_core — production reaches it ONLY through the friend
+// ServerImpl::build_classified_command (the one dispatch-chokepoint builder,
+// server.cpp). Tests need to construct fixture ClassifiedCommand values
+// directly, so the header declares a friend `struct ClassifiedCommandTestAccess`
+// with a static forwarder -- but the forwarder is DEFINED here, in a TU that
+// links only into the test binary, not into server_core. A production caller
+// that references it therefore fails to LINK, which is what upgrades the
+// production/test split from a doc-comment convention to a structural,
+// compile/link-time-enforced control (mirrors #2367's EngineLivenessTestAccess,
+// engine_principal_store.cpp — identical rationale).
+//
+// Keep this file minimal: it exists solely to host that one definition off the
+// production link line.
+
+#include "agent_registry.hpp"
+
+namespace yuzu::server::detail {
+
+ClassifiedCommand ClassifiedCommandTestAccess::make(pb::CommandRequest cmd) {
+    return ClassifiedCommand(std::move(cmd));
+}
+
+} // namespace yuzu::server::detail

--- a/tests/unit/server/test_bundle_orchestrator.cpp
+++ b/tests/unit/server/test_bundle_orchestrator.cpp
@@ -41,6 +41,7 @@ struct FakeDispatch {
         std::string plugin, action, correlation;
         std::vector<std::string> agent_ids;
         yuzu::server::authz::VisibleSet exec_visible; // governance UP-8: what the caller threaded
+        std::string principal; // M11: the IDENTITY half — see the test below
     };
     std::vector<Call> calls;
     int sent = 1; // agents_reached returned for every step
@@ -50,8 +51,9 @@ struct FakeDispatch {
                       const std::vector<std::string>& agent_ids, const std::string& /*scope*/,
                       const std::unordered_map<std::string, std::string>& /*params*/,
                       const std::string& correlation,
-                      const yuzu::server::authz::VisibleSet& exec_visible) -> std::pair<std::string, int> {
-            calls.push_back(Call{plugin, action, correlation, agent_ids, exec_visible});
+                      const yuzu::server::DispatchCaller& caller) -> std::pair<std::string, int> {
+            calls.push_back(
+                Call{plugin, action, correlation, agent_ids, caller.exec_visible, caller.principal});
             return {"cmd-" + plugin + "-" + action, sent};
         };
     }
@@ -141,6 +143,12 @@ TEST_CASE("orchestrator threads the caller's exec_visible into DispatchFn unchan
         REQUIRE(call.exec_visible.has_value()); // NOT nullopt/unfiltered
         CHECK(call.exec_visible->size() == 1);
         CHECK(call.exec_visible->count("agent-1") == 1);
+        // M11 (review finding, post-merge round): this suite proved the
+        // VISIBILITY half of DispatchCaller reaches dispatch_fn but ignored
+        // the IDENTITY half — the same asymmetry the original CRITICAL fix
+        // was about. `dispatch()`'s third positional argument ("alice"
+        // above) is exactly `caller.principal`.
+        CHECK(call.principal == "alice");
     }
 }
 
@@ -288,7 +296,7 @@ TEST_CASE("orchestrator: a throwing dispatch step is isolated, manifest still st
     BundleOrchestrator::DispatchFn throwing =
         [&n](const std::string& plugin, const std::string& action, const std::vector<std::string>&,
              const std::string&, const std::unordered_map<std::string, std::string>&,
-             const std::string&, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+             const std::string&, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         if (++n == 2)
             throw std::runtime_error("gRPC write failed");
         return {"cmd-" + plugin + "-" + action, 1};

--- a/tests/unit/server/test_chrome_ir_chain.cpp
+++ b/tests/unit/server/test_chrome_ir_chain.cpp
@@ -137,7 +137,7 @@ struct ChromeIrHarness {
                    const std::vector<std::string>& agent_ids, const std::string& scope_expr,
                    const std::unordered_map<std::string, std::string>& params,
                    const std::string& exec_id,
-                   const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                   const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
             calls.push_back({plugin, action, scope_expr, agent_ids, params, exec_id});
             return {"cmd-" + std::to_string(calls.size()), dispatch_sent};
         };

--- a/tests/unit/server/test_dashboard_tar_fragments.cpp
+++ b/tests/unit/server/test_dashboard_tar_fragments.cpp
@@ -70,6 +70,9 @@ struct DispatchCall {
     std::unordered_map<std::string, std::string> params;
     // CDX-R7-02: the exec_visible set the handler threaded into dispatch.
     yuzu::server::authz::VisibleSet exec_visible;
+    // PLAN-006: the full DispatchCaller (identity + exec_visible) the handler
+    // threaded into dispatch, so a test can assert the principal half too.
+    yuzu::server::DispatchCaller caller;
 };
 struct AuditRow {
     std::string action, result, target_type, target_id, detail;
@@ -123,13 +126,15 @@ struct FragmentHarness {
     bool auth_ok{true};    ///< auth_fn verdict (false → handler returns early)
     int dispatch_sent{1};  ///< agents reached per dispatch (0 → offline 404)
 
-    /// CDX-R7-02: the per-request exec-visible derivation the handlers consult
-    /// for /api/dashboard/execute + tar-execute. Default returns nullopt
-    /// (UNFILTERED) so pre-existing fragment tests keep the full-fleet path; a
-    /// confinement test overrides it with a specific set; a fail-closed test
-    /// sets it to `{}` (genuinely unwired → the production handler denies all).
-    DashboardRoutes::ExecVisibleFn exec_visible_fn{
-        [](const httplib::Request&) { return yuzu::server::authz::VisibleSet{}; }};
+    /// CDX-R7-02 / PLAN-006: the per-request DispatchCaller derivation the
+    /// handlers consult for /api/dashboard/execute + tar-execute. Default
+    /// returns a DispatchCaller whose exec_visible is nullopt (UNFILTERED) so
+    /// pre-existing fragment tests keep the full-fleet path; a confinement
+    /// test overrides it with a specific set; a fail-closed test sets it to
+    /// `{}` (genuinely unwired → the production handler denies all).
+    DashboardRoutes::CallerFn caller_fn{[](const httplib::Request&) -> yuzu::server::DispatchCaller {
+        return yuzu::server::DispatchCaller{.exec_visible = yuzu::server::authz::VisibleSet{}};
+    }};
 
     /// CDX-R7-02: what the harness resolve_fn returns for /api/dashboard/execute
     /// (empty → "unknown command", so the dispatch path is unreachable). A
@@ -138,7 +143,7 @@ struct FragmentHarness {
 
     /// @param with_dispatch false → register with an empty DispatchFn so the
     ///        "dispatch unavailable" 503 branch is reachable.
-    /// @param wire_exec_visible false → register with an EMPTY ExecVisibleFn so
+    /// @param wire_exec_visible false → register with an EMPTY CallerFn so
     ///        the production handler's own fail-closed branch (unwired → present-
     ///        empty deny-all) is exercised (CDX-R7-02).
     explicit FragmentHarness(bool with_dispatch = true, bool wire_exec_visible = true) {
@@ -174,9 +179,9 @@ struct FragmentHarness {
             [this](const std::string& plugin, const std::string& action,
                    const std::vector<std::string>& ids, const std::string& scope,
                    const std::unordered_map<std::string, std::string>& params,
-                   const yuzu::server::authz::VisibleSet& exec_visible)
+                   const yuzu::server::DispatchCaller& caller)
             -> std::pair<std::string, int> {
-            calls.push_back({plugin, action, scope, ids, params, exec_visible});
+            calls.push_back({plugin, action, scope, ids, params, caller.exec_visible, caller});
             return {"cmd-" + std::to_string(calls.size()), dispatch_sent};
         };
 
@@ -185,18 +190,17 @@ struct FragmentHarness {
                                /*tag_store=*/nullptr, /*event_bus=*/nullptr,
                                /*agents_json_fn=*/[] { return std::string{"[]"}; },
                                with_dispatch ? dispatch : DashboardRoutes::DispatchFn{},
-                               /*exec_visible_fn=*/
+                               /*caller_fn=*/
                                wire_exec_visible
-                                   ? DashboardRoutes::ExecVisibleFn{
-                                         [this](const httplib::Request& req) {
+                                   ? DashboardRoutes::CallerFn{
+                                         [this](const httplib::Request& req) -> yuzu::server::DispatchCaller {
                                              // Delegate to the reassignable member so
                                              // a test can override it after
                                              // construction (live read).
-                                             return exec_visible_fn
-                                                        ? exec_visible_fn(req)
-                                                        : yuzu::server::authz::VisibleSet{};
+                                             return caller_fn ? caller_fn(req)
+                                                              : yuzu::server::DispatchCaller{};
                                          }}
-                                   : DashboardRoutes::ExecVisibleFn{},
+                                   : DashboardRoutes::CallerFn{},
                                /*resolve_fn=*/
                                [this](const std::string&) { return resolve_to; },
                                &metrics, /*instruction_store=*/nullptr);
@@ -596,8 +600,9 @@ TEST_CASE("dashboard execute threads the caller's exec_visible into dispatch (CD
     h.resolve_to = {"os_info", "version"};
     h.dispatch_sent = 0; // stop before the result-render path (registry_ is null here)
     // Service-scoped confinement: the caller can see only dev-A.
-    h.exec_visible_fn = [](const httplib::Request&) {
-        return yuzu::server::authz::VisibleSet{std::unordered_set<std::string>{"dev-A"}};
+    h.caller_fn = [](const httplib::Request&) -> yuzu::server::DispatchCaller {
+        return yuzu::server::DispatchCaller{
+            .exec_visible = yuzu::server::authz::VisibleSet{std::unordered_set<std::string>{"dev-A"}}};
     };
     // Target dev-B (an id-list arm), which is OUTSIDE the caller's visible set.
     auto res = h.post("/api/dashboard/execute", "instruction=run&scope=dev-B");
@@ -616,8 +621,9 @@ TEST_CASE("dashboard execute broadcast still carries the caller's exec_visible (
     FragmentHarness h;
     h.resolve_to = {"os_info", "version"};
     h.dispatch_sent = 0;
-    h.exec_visible_fn = [](const httplib::Request&) {
-        return yuzu::server::authz::VisibleSet{std::unordered_set<std::string>{"dev-A"}};
+    h.caller_fn = [](const httplib::Request&) -> yuzu::server::DispatchCaller {
+        return yuzu::server::DispatchCaller{
+            .exec_visible = yuzu::server::authz::VisibleSet{std::unordered_set<std::string>{"dev-A"}}};
     };
     // CDX-R8-01: `__all__` is now passed THROUGH by name (the Broadcast arm),
     // not stripped to empty+empty (the None arm). Broadcast is named, never
@@ -665,7 +671,7 @@ TEST_CASE("dashboard execute still broadcasts when scope is OMITTED entirely (CD
 
 TEST_CASE("dashboard execute FAILS CLOSED when the exec-visible derivation is unwired (CDX-R7-02)",
           "[server][dashboard][execute][scope]") {
-    // Genuinely UNWIRED ExecVisibleFn: the production handler must hand dispatch
+    // Genuinely UNWIRED CallerFn: the production handler must hand dispatch
     // a PRESENT EMPTY visible set (deny all), never nullopt (unfiltered).
     FragmentHarness h(/*with_dispatch=*/true, /*wire_exec_visible=*/false);
     h.resolve_to = {"os_info", "version"};
@@ -675,6 +681,41 @@ TEST_CASE("dashboard execute FAILS CLOSED when the exec-visible derivation is un
     REQUIRE(h.calls.size() == 1);
     REQUIRE(h.calls[0].exec_visible.has_value()); // PRESENT (deny), not nullopt
     CHECK(h.calls[0].exec_visible->empty());       // EMPTY → production sink reaches no one
+}
+
+// PLAN-006: the identity sibling of the fail-closed test above — an unwired
+// CallerFn must hand dispatch an EMPTY principal too, not merely a deny-all
+// exec_visible.
+TEST_CASE("dashboard execute hands dispatch an EMPTY principal when the CallerFn is unwired "
+          "(PLAN-006)",
+          "[server][dashboard][execute][scope]") {
+    FragmentHarness h(/*with_dispatch=*/true, /*wire_exec_visible=*/false);
+    h.resolve_to = {"os_info", "version"};
+    h.dispatch_sent = 0;
+    auto res = h.post("/api/dashboard/execute", "instruction=run&scope=dev-A");
+    REQUIRE(res->status == 200);
+    REQUIRE(h.calls.size() == 1);
+    CHECK(h.calls[0].caller.principal.empty());
+}
+
+// PLAN-006: the sibling of the confinement handoff test above, asserting the
+// IDENTITY half of DispatchCaller — a wired CallerFn's principal must reach
+// the dispatch seam, not just its exec_visible.
+TEST_CASE("dashboard execute threads the caller's principal into dispatch (PLAN-006)",
+          "[server][dashboard][execute][scope]") {
+    FragmentHarness h;
+    h.resolve_to = {"os_info", "version"};
+    h.dispatch_sent = 0;
+    h.caller_fn = [](const httplib::Request&) -> yuzu::server::DispatchCaller {
+        return yuzu::server::DispatchCaller{.principal = "dash-operator",
+                                            .principal_role = "admin"};
+    };
+    auto res = h.post("/api/dashboard/execute", "instruction=run&scope=dev-A");
+    REQUIRE(res->status == 200);
+    REQUIRE(h.calls.size() == 1);
+    CHECK(h.calls[0].caller.principal == "dash-operator");
+    CHECK(h.calls[0].caller.principal_role == "admin");
+    CHECK_FALSE(h.calls[0].caller.system);
 }
 
 TEST_CASE("dashboard execute REFUSES a PERCENT-ENCODED supplied-but-empty scope "

--- a/tests/unit/server/test_deployment_engine.cpp
+++ b/tests/unit/server/test_deployment_engine.cpp
@@ -76,10 +76,17 @@ struct Harness {
             -> std::pair<std::string, int> {
             dispatched.push_back({action, agents});
             dispatch_callers.push_back(caller);
-            return {"cmd", static_cast<int>(agents.size())};
+            // deny_dispatch mirrors a chokepoint refusal: dispatch_confined
+            // returns {command_id, 0} on a denial (the command_id is minted
+            // before classification), so a denied and a zero-reach dispatch
+            // are indistinguishable to the engine — which is exactly why the
+            // engine must settle the claim on ANY zero-sent outcome.
+            return {"cmd", deny_dispatch ? 0 : static_cast<int>(agents.size())};
         };
         return d;
     }
+
+    bool deny_dispatch{false};
 
     int dispatch_count(const std::string& action, const std::string& agent) const {
         int n = 0;
@@ -188,6 +195,54 @@ TEST_CASE("deployment engine drives stage→execute, skips out-of-scope, runs on
     advance(deps, id, cfg, authorized, test_caller());
     advance(deps, id, cfg, authorized, test_caller());
     CHECK(h.dispatch_count("execute_staged", "a1") == 1); // still exactly one
+}
+
+// #3133 round-2 review MEDIUM (falsifier): a caller the chokepoint refuses —
+// e.g. holding SoftwareDeployment:Execute but not the Write that
+// content_dist.stage is classified as — used to leave every claimed device
+// stuck in 'staging' forever: the CAS claim ran BEFORE the dispatch outcome
+// was known and the {command_id, 0} refusal was discarded. The rows must
+// settle to a terminal step instead of wedging in an active one, and the
+// engine must not livelock re-claiming and re-denying on every tick.
+TEST_CASE("deployment engine settles a claim to failed when the dispatch is refused, "
+          "instead of wedging it in staging",
+          "[pg][deployment][engine]") {
+    YUZU_REQUIRE_PG_DB_TPL(db, deprun_tpl);
+    PgPool pool{{.conninfo = db.dsn(), .size = 4}};
+    REQUIRE(pool.valid());
+    DeploymentRunStore store{pool};
+    REQUIRE(store.is_open());
+
+    const std::string id = "e-denied";
+    REQUIRE(store.create_deployment(make_dep(id), {tgt("a1"), tgt("a2")}));
+
+    Harness h{store};
+    h.deny_dispatch = true; // every dispatch answers {command_id, 0} — a refusal
+    auto deps = h.deps();
+    DeploymentConfig cfg{"https://repo.lan/pkg.msi", "pkg.msi", std::string(64, 'a'), ""};
+    const std::unordered_set<std::string> authorized{"a1", "a2"};
+
+    // Tick 1: both devices are claimed, the dispatch is refused, and the rows
+    // settle to terminal 'failed' — never left in 'staging'.
+    advance(deps, id, cfg, authorized, test_caller());
+    CHECK(h.dispatch_count("stage", "a1") == 1);
+    CHECK(step_of(store, id, "a1") == "failed");
+    CHECK(step_of(store, id, "a2") == "failed");
+
+    // The error names the refusal, so an operator reading the grid sees why
+    // nothing ran rather than a bare failure.
+    for (const auto& d : store.get_devices(id))
+        CHECK(d.error.find("refused or reached no agents") != std::string::npos);
+
+    // Ticks 2-3: terminal rows are never re-claimed or re-dispatched — no
+    // deny-livelock, and the deployment itself settles rather than running
+    // forever.
+    advance(deps, id, cfg, authorized, test_caller());
+    advance(deps, id, cfg, authorized, test_caller());
+    CHECK(h.dispatch_count("stage", "a1") == 1); // still exactly one
+    auto dep = store.get_deployment(id);
+    REQUIRE(dep);
+    CHECK(dep->failed == 2);
 }
 
 TEST_CASE("deployment engine records a non-zero installer exit as failed",

--- a/tests/unit/server/test_deployment_engine.cpp
+++ b/tests/unit/server/test_deployment_engine.cpp
@@ -57,6 +57,9 @@ struct Harness {
     std::unordered_map<std::string, std::unordered_map<std::string, AgentResponse>> poll;
     // recorded dispatches: (action, agent_ids)
     std::vector<std::pair<std::string, std::vector<std::string>>> dispatched;
+    // The DispatchCaller each dispatch call actually received — the
+    // production-wiring assertion below reads this, not `dispatched`.
+    std::vector<yuzu::server::DispatchCaller> dispatch_callers;
 
     EngineDeps deps() {
         EngineDeps d;
@@ -68,8 +71,11 @@ struct Harness {
         d.dispatch_fn = [this](const std::string&, const std::string& action,
                                const std::vector<std::string>& agents, const std::string&,
                                const std::unordered_map<std::string, std::string>&,
-                               const std::string&) -> std::pair<std::string, int> {
+                               const std::string&,
+                               const yuzu::server::DispatchCaller& caller)
+            -> std::pair<std::string, int> {
             dispatched.push_back({action, agents});
+            dispatch_callers.push_back(caller);
             return {"cmd", static_cast<int>(agents.size())};
         };
         return d;
@@ -85,6 +91,12 @@ struct Harness {
         return n;
     }
 };
+
+// The caller every test below advances with, unless a test deliberately
+// wants a different one (the production-wiring case just below).
+yuzu::server::DispatchCaller test_caller() {
+    return yuzu::server::DispatchCaller{.principal = "deploy-op", .principal_role = "Administrator"};
+}
 
 DeploymentRow make_dep(const std::string& id) {
     DeploymentRow d;
@@ -145,7 +157,7 @@ TEST_CASE("deployment engine drives stage→execute, skips out-of-scope, runs on
     const std::string exec_eid = exec_execution_id(id);
 
     // ── Tick 1: stage dispatched to the authorized pending devices; a3 skipped ──
-    advance(deps, id, cfg, authorized);
+    advance(deps, id, cfg, authorized, test_caller());
     CHECK(step_of(store, id, "a1") == "staging");
     CHECK(step_of(store, id, "a2") == "staging");
     CHECK(step_of(store, id, "a3") == "skipped"); // re-authorization boundary
@@ -155,7 +167,7 @@ TEST_CASE("deployment engine drives stage→execute, skips out-of-scope, runs on
     // ── Tick 2: a1 stages OK → executes; a2 stage FAILS ──
     h.poll[stage_eid] = {{"a1", {1, "status|ok\nstaged_path|/p"}},
                          {"a2", {2, "error|hash mismatch"}}};
-    advance(deps, id, cfg, authorized);
+    advance(deps, id, cfg, authorized, test_caller());
     CHECK(step_of(store, id, "a1") == "executing");
     CHECK(step_of(store, id, "a2") == "failed");
     CHECK(h.dispatch_count("execute_staged", "a1") == 1);
@@ -163,7 +175,7 @@ TEST_CASE("deployment engine drives stage→execute, skips out-of-scope, runs on
 
     // ── Tick 3: a1 execute returns exit 0 → succeeded; deployment completes ──
     h.poll[exec_eid] = {{"a1", {1, "status|ok\nexit_code|0"}}};
-    advance(deps, id, cfg, authorized);
+    advance(deps, id, cfg, authorized, test_caller());
     CHECK(step_of(store, id, "a1") == "succeeded");
     auto dep = store.get_deployment(id);
     REQUIRE(dep);
@@ -173,8 +185,8 @@ TEST_CASE("deployment engine drives stage→execute, skips out-of-scope, runs on
     CHECK(dep->skipped == 1);
 
     // ── Execute-once: extra advances never re-dispatch the installer to a1 ──
-    advance(deps, id, cfg, authorized);
-    advance(deps, id, cfg, authorized);
+    advance(deps, id, cfg, authorized, test_caller());
+    advance(deps, id, cfg, authorized, test_caller());
     CHECK(h.dispatch_count("execute_staged", "a1") == 1); // still exactly one
 }
 
@@ -193,15 +205,86 @@ TEST_CASE("deployment engine records a non-zero installer exit as failed",
     DeploymentConfig cfg{"https://repo.lan/pkg.msi", "pkg.msi", std::string(64, 'a'), ""};
     const std::unordered_set<std::string> authorized{"z1"};
 
-    advance(deps, id, cfg, authorized); // stage dispatched
+    advance(deps, id, cfg, authorized, test_caller()); // stage dispatched
     h.poll[stage_execution_id(id)] = {{"z1", {1, "status|ok\nstaged_path|/p"}}};
-    advance(deps, id, cfg, authorized); // staged → executing
+    advance(deps, id, cfg, authorized, test_caller()); // staged → executing
     h.poll[exec_execution_id(id)] = {{"z1", {2, "status|error\nexit_code|1603"}}};
-    advance(deps, id, cfg, authorized); // executing → failed
+    advance(deps, id, cfg, authorized, test_caller()); // executing → failed
 
     auto devs = store.get_devices(id);
     REQUIRE(devs.size() == 1);
     CHECK(devs[0].step == "failed");
     CHECK(devs[0].exit_code == 1603);
     CHECK(store.get_deployment(id)->status == "complete");
+}
+
+// ── H1 production-wiring regression ───────────────────────────────────────
+//
+// Review finding (post-origin/dev-merge adversarial round): `advance()` had
+// no caller parameter at all, so `DeploymentRoutes` fed the shared
+// BACKGROUND dispatch closure (`command_dispatch_fn`, `DispatchCaller{.system
+// = true}`) to every deploy tick. The chokepoint's `caller.system`
+// early-return (`agent_registry.hpp`) admits a system caller unconditionally,
+// so `content_dist.stage` — declared `SoftwareDeployment:Write` — dispatched
+// under system authority regardless of what the triggering OPERATOR actually
+// held. A role with `SoftwareDeployment:Execute` but not `Write` should be
+// refused by the chokepoint; under the old wiring it never reached the
+// chokepoint's authorization check as itself at all.
+//
+// This proves the half of the fix reachable from this test binary: that
+// `advance()` now threads the CALLER it is given, verbatim, to `dispatch_fn`
+// — never silently substituting a system caller. `DeploymentRoutes` itself
+// is registered on the raw `httplib::Server&` (not yet migrated onto the
+// `HttpRouteSink` seam `RestApiV1`/`WorkflowRoutes` use), so it has no route-
+// level test harness in this repo. `caller_from_session` there populates
+// `principal`/`principal_role`/`exec_visible` from an injected `ExecVisibleFn`
+// (a governance-round follow-up fix: it originally omitted `exec_visible`,
+// defaulting it to `nullopt`/unfiltered — the exact shape `dispatch_caller.hpp`
+// reserves for a genuine `.system = true` background dispatcher, not an
+// operator-triggered one — which made the chokepoint's per-target
+// `Execution:Execute` intersection a silent no-op for every deployment
+// dispatch; `devices_fn(viewer)∩cohort` above is a DIFFERENT authorization
+// dimension, `Infrastructure:Read`/flat group-membership, and does not
+// substitute for it). It now matches the sibling pattern
+// (rest_api_v1.cpp et al.) field-for-field, unverified at the route level for
+// the same route-level-harness-gap reason as the rest of this comment. The
+// chokepoint's own enforcement of `SoftwareDeployment:Write` — that
+// Execute-without-Write is actually refused — is exhaustively covered
+// independently in test_dispatch_chokepoint.cpp for every declared
+// capability, unchanged by this fix; what THAT coverage could not see,
+// because the parameter did not exist, is proven here.
+TEST_CASE("H1: advance() threads the caller it is given to dispatch_fn, never a "
+          "system substitute",
+          "[pg][deployment][engine][security]") {
+    YUZU_REQUIRE_PG_DB_TPL(db, deprun_tpl);
+    PgPool pool{{.conninfo = db.dsn(), .size = 4}};
+    REQUIRE(pool.valid());
+    DeploymentRunStore store{pool};
+    REQUIRE(store.is_open());
+
+    const std::string id = "h1";
+    REQUIRE(store.create_deployment(make_dep(id), {tgt("w1")}));
+
+    Harness h{store};
+    auto deps = h.deps();
+    DeploymentConfig cfg{"https://repo.lan/pkg.msi", "pkg.msi", std::string(64, 'a'), ""};
+    const std::unordered_set<std::string> authorized{"w1"};
+
+    // A non-Administrator caller a real operator session would carry —
+    // deliberately NOT the shared test_caller() helper, so this test does
+    // not depend on that helper's own choices.
+    const yuzu::server::DispatchCaller live_caller{.principal = "carol",
+                                                    .principal_role = "PlatformEngineer"};
+    advance(deps, id, cfg, authorized, live_caller);
+
+    REQUIRE_FALSE(h.dispatch_callers.empty());
+    const auto& reached = h.dispatch_callers.front();
+    // The exact regression: this must be `false` and non-empty. Before the
+    // fix there was no parameter to assert on at all — `command_dispatch_fn`
+    // was hardcoded at the call site with `.system = true` and an empty
+    // principal, so a caller-identity assertion here could not even be
+    // expressed against production wiring.
+    CHECK_FALSE(reached.system);
+    CHECK(reached.principal == "carol");
+    CHECK(reached.principal_role == "PlatformEngineer");
 }

--- a/tests/unit/server/test_dispatch_chokepoint.cpp
+++ b/tests/unit/server/test_dispatch_chokepoint.cpp
@@ -1,0 +1,769 @@
+/**
+ * test_dispatch_chokepoint.cpp — PR1.9c: the ONE command-builder chokepoint.
+ *
+ * WHAT THIS FILE BINDS. `ServerImpl::build_classified_command` (server.cpp) is
+ * a private member with no live-Session-free construction path, so it is not
+ * directly reachable from a unit test — the same situation
+ * `dispatch_confined_arms.hpp`/`dispatch_target_shape.hpp` were extracted to
+ * solve for the arm-intersection and targeting-shape rules. This file binds
+ * the SAME pure decision `build_classified_command` is built around —
+ * `yuzu::server::detail::classify_and_authorize_dispatch` and
+ * `yuzu::server::detail::compute_dispatch_tag` (agent_registry.hpp) — directly,
+ * with a fake `has_permission` callback, so the classify+authorize rule is
+ * proven independent of a live `ServerImpl`/`RbacStore`/database. Every
+ * `build_classified_command` call site funnels through this exact function; a
+ * from-scratch re-implementation inside a test is the anti-pattern this
+ * codebase's own comments warn about repeatedly (#2500, dispatch_confined_arms.hpp).
+ *
+ * The four "denied, naming the securable" cases below are named after the real
+ * call sites they represent (spec: /api/command, forward_legacy_command, a
+ * scheduled dispatch, an MCP-shaped `dispatch_confined` caller) because none
+ * of those routes/seams is independently reachable from a unit test either
+ * (`/api/command` is registered inline on a raw httplib::Server inside
+ * `Server::start()`, #2557; MCP/schedule wiring lives in mcp_server.cpp /
+ * workflow_routes.hpp, both out of this package's scope per spec boundaries) —
+ * what IS common to all four, and what this file actually binds, is the ONE
+ * shared decision every one of them routes through.
+ *
+ * `AgentRegistry::send_to`/`send_to_all`'s narrowed signature (provenance not
+ * syntax, PLAN-011), the defensive dispatch_tag check, and the gateway
+ * routed-path capability check (PLAN item 5) ARE reachable with a real
+ * `AgentRegistry` — those sections bind the real thing.
+ */
+
+#include "agent_registry.hpp"
+#include "capability_decls/core_dispatch_capabilities.hpp"
+#include "command_capability.hpp"
+#include "command_capability_parsers.hpp"
+#include "dispatch_caller.hpp"
+#include "event_bus.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <yuzu/metrics.hpp>
+
+#include "agent.pb.h"
+
+#include <array>
+#include <map>
+#include <span>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+using namespace yuzu::server;
+using namespace yuzu::server::detail;
+namespace agent_pb = ::yuzu::agent::v1;
+
+// ═════════════════════════════════════════════════════════════════════════
+// PLAN-011 (provenance, not syntax) — the compile-time invariant.
+// ═════════════════════════════════════════════════════════════════════════
+//
+// A syntactically valid dispatch_tag proves nothing: encode_dispatch_tag is a
+// public, pure helper any caller could stamp onto a hand-built protobuf. The
+// guarantee AgentRegistry::send_to/send_to_all rest on is therefore a TYPE
+// invariant — there is no overload that accepts a bare
+// yuzu::agent::v1::CommandRequest, so a hand-built one cannot reach the
+// registry AT ALL, not even with a forged-but-well-formed tag.
+namespace {
+
+template <typename T, typename = void> struct can_send_to_raw_command : std::false_type {};
+template <typename T>
+struct can_send_to_raw_command<
+    T, std::void_t<decltype(std::declval<T&>().send_to(
+           std::declval<std::string>(), std::declval<agent_pb::CommandRequest>()))>>
+    : std::true_type {};
+
+template <typename T, typename = void> struct can_send_to_all_raw_command : std::false_type {};
+template <typename T>
+struct can_send_to_all_raw_command<
+    T, std::void_t<decltype(std::declval<T&>().send_to_all(
+           std::declval<agent_pb::CommandRequest>()))>> : std::true_type {};
+
+// Positive control: the exact same signature shape, but with a
+// ClassifiedCommand — proves the traits above are discriminating on the
+// TYPE, not merely permanently false for an unrelated reason (a rewritten
+// method name, a moved header, ...).
+template <typename T, typename = void> struct can_send_to_classified : std::false_type {};
+template <typename T>
+struct can_send_to_classified<
+    T, std::void_t<decltype(std::declval<T&>().send_to(
+           std::declval<std::string>(), std::declval<const ClassifiedCommand&>()))>>
+    : std::true_type {};
+
+template <typename T, typename = void> struct can_send_to_all_classified : std::false_type {};
+template <typename T>
+struct can_send_to_all_classified<
+    T, std::void_t<decltype(std::declval<T&>().send_to_all(
+           std::declval<const ClassifiedCommand&>()))>> : std::true_type {};
+
+} // namespace
+
+static_assert(!can_send_to_raw_command<AgentRegistry>::value,
+             "AgentRegistry::send_to must not accept a bare CommandRequest — a hand-built "
+             "protobuf, forged tag or not, must not be able to reach the registry (PLAN-011).");
+static_assert(!can_send_to_all_raw_command<AgentRegistry>::value,
+             "AgentRegistry::send_to_all must not accept a bare CommandRequest (PLAN-011).");
+static_assert(can_send_to_classified<AgentRegistry>::value,
+             "sanity: AgentRegistry::send_to must still accept a ClassifiedCommand — proves the "
+             "negative static_asserts above are discriminating on type, not vacuous.");
+static_assert(can_send_to_all_classified<AgentRegistry>::value,
+             "sanity: AgentRegistry::send_to_all must still accept a ClassifiedCommand.");
+
+TEST_CASE("ClassifiedCommand: only the test-only door can mint one outside ServerImpl; the "
+          "resulting value reaches send_to",
+          "[server][dispatch][chokepoint]") {
+    // Documents the invariant the static_asserts above prove at compile time:
+    // ClassifiedCommandTestAccess is a narrow, explicit, clearly-named door —
+    // mirroring EngineLivenessTestAccess (engine_principal_store.hpp) — not a
+    // public constructor, setter, or conversion. The declaration is visible
+    // to any TU that includes agent_registry.hpp, but production code has no
+    // LINKABLE door: ClassifiedCommandTestAccess::make's only definition
+    // lives in classified_command_test_access.cpp, a TU deliberately kept
+    // off every production source list, so a production caller would
+    // compile and then fail to LINK. Only ServerImpl::build_classified_command
+    // has a real, linkable path to construct one.
+    agent_pb::CommandRequest cmd;
+    cmd.set_command_id("door-test");
+    cmd.set_plugin("tar");
+    cmd.set_action("fleet_snapshot");
+    cmd.set_dispatch_tag(
+        encode_dispatch_tag(DispatchClass::ReadOnly, Mutability::None, std::string(32, 'a')));
+    auto classified = ClassifiedCommandTestAccess::make(cmd);
+    CHECK(classified.wire().command_id() == "door-test");
+
+    EventBus bus;
+    yuzu::MetricsRegistry metrics;
+    AgentRegistry registry(bus, metrics);
+    agent_pb::AgentInfo info;
+    info.set_agent_id("dev-door");
+    info.set_hostname("host.local");
+    registry.register_agent(info);
+
+    // No live stream and no gateway_node → send_to fails closed (false), not
+    // because of anything THIS test is proving — just documenting that a
+    // ClassifiedCommand behaves like any other command once past the door.
+    CHECK_FALSE(registry.send_to("dev-door", classified));
+}
+
+// ═════════════════════════════════════════════════════════════════════════
+// classify_and_authorize_dispatch — the pure classify+authorize decision.
+// ═════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+// A caller lacking (or being denied) any grant.
+[[nodiscard]] bool always_deny(std::string_view, std::string_view, authz::Operation) {
+    return false;
+}
+
+// A caller holding every grant it could ask for. Used specifically where a
+// test needs to prove a denial is NOT merely "RBAC said no" — e.g. the
+// system_reserved rule, or the anonymous-operator rule, both of which must
+// fire regardless of what RbacStore would have answered.
+[[nodiscard]] bool always_allow(std::string_view, std::string_view, authz::Operation) {
+    return true;
+}
+
+// A small, independent operator-space fixture — four rows, four distinct
+// securables, standing in for four different real plugin.action pairs a
+// real operator dispatch might target. Deliberately NOT the real catalogue
+// (owned by other packages) — this file's job is to bind the shared DECISION,
+// not to re-verify the real catalogue's own content (test_command_capability.cpp
+// and the plugin_action_catalogue_* fragments' own tests do that).
+inline constexpr std::array<CommandCapability, 4> kOperatorFixture{{
+    {
+        .plugin = "filesystem",
+        .action = "read",
+        .dispatch_class = DispatchClass::ReadOnly,
+        .mutability = Mutability::None,
+        .securable = "FileRetrieval",
+        .operation = authz::Operation::Read,
+        .risk_tier = authz::RiskTier::Low,
+        .system_reserved = false,
+    },
+    {
+        .plugin = "chargen",
+        .action = "chargen_start",
+        .dispatch_class = DispatchClass::Mutating,
+        .mutability = Mutability::Reversible,
+        .securable = "Execution",
+        .operation = authz::Operation::Execute,
+        .risk_tier = authz::RiskTier::Medium,
+        .system_reserved = false,
+    },
+    {
+        .plugin = "tar",
+        .action = "query",
+        .dispatch_class = DispatchClass::ReadOnly,
+        .mutability = Mutability::None,
+        .securable = "Infrastructure",
+        .operation = authz::Operation::Read,
+        .risk_tier = authz::RiskTier::Medium,
+        .system_reserved = false,
+    },
+    {
+        .plugin = "vuln_scan",
+        .action = "scan",
+        .dispatch_class = DispatchClass::ReadOnly,
+        .mutability = Mutability::None,
+        .securable = "Security",
+        .operation = authz::Operation::Read,
+        .risk_tier = authz::RiskTier::Low,
+        .system_reserved = false,
+    },
+}};
+
+} // namespace
+
+TEST_CASE("classify_and_authorize_dispatch: an unclassified plugin.action is rejected, never a "
+          "permissive default",
+          "[server][dispatch][chokepoint]") {
+    CommandCapabilityRegistry registry{std::span<const CommandCapability>(kOperatorFixture)};
+    DispatchCaller caller{.principal = "alice"};
+
+    // has_permission ALWAYS ALLOWS — proves the refusal fires at
+    // classification, before authorization is ever consulted.
+    auto result = classify_and_authorize_dispatch(registry, caller, "no_such_plugin",
+                                                   "no_such_action", always_allow);
+    REQUIRE_FALSE(result.has_value());
+    CHECK(result.error().reason == DispatchDenialReason::Unclassified);
+    // No securable to name — classification never resolved one.
+    CHECK(result.error().securable.empty());
+}
+
+TEST_CASE("classify_and_authorize_dispatch: an ambiguous plugin.action is rejected with a "
+          "DISTINCT counted error, never first-wins",
+          "[server][dispatch][chokepoint]") {
+    // A second, independently-authored fragment declaring the SAME
+    // plugin.action as kOperatorFixture's filesystem.read row, with
+    // deliberately CONFLICTING classification — proves Ambiguous is
+    // detected regardless of whether the two rows happen to agree.
+    static constexpr std::array<CommandCapability, 1> kDuplicateFragment{{
+        {
+            .plugin = "filesystem",
+            .action = "read",
+            .dispatch_class = DispatchClass::Mutating,
+            .mutability = Mutability::Reversible,
+            .securable = "Infrastructure",
+            .operation = authz::Operation::Write,
+            .risk_tier = authz::RiskTier::Medium,
+            .system_reserved = false,
+        },
+    }};
+    CommandCapabilityRegistry registry{std::span<const CommandCapability>(kOperatorFixture),
+                                       std::span<const CommandCapability>(kDuplicateFragment)};
+    DispatchCaller caller{.principal = "alice"};
+
+    auto result =
+        classify_and_authorize_dispatch(registry, caller, "filesystem", "read", always_allow);
+    REQUIRE_FALSE(result.has_value());
+    CHECK(result.error().reason == DispatchDenialReason::Ambiguous);
+    CHECK(result.error().securable.empty());
+
+    // A DIFFERENT action from the same registry is unaffected — ambiguity is
+    // per plugin.action, not a registry-wide poison (mirrors
+    // test_command_capability.cpp's own equivalent assertion on `classify`
+    // itself, one layer down).
+    auto other = classify_and_authorize_dispatch(registry, caller, "tar", "query", always_allow);
+    REQUIRE(other.has_value());
+}
+
+TEST_CASE("classify_and_authorize_dispatch: a DispatchCaller with system == false and an empty "
+          "principal is rejected — no anonymous operator dispatch",
+          "[server][dispatch][chokepoint]") {
+    CommandCapabilityRegistry registry{std::span<const CommandCapability>(kOperatorFixture)};
+    DispatchCaller anonymous{.principal = "", .system = false};
+
+    // has_permission ALWAYS ALLOWS — proves the empty principal is refused
+    // BEFORE ever reaching the permission callback, where a legacy-open
+    // RbacStore might otherwise admit an empty username by accident
+    // (RbacStore::check_permission has no notion of "no such caller").
+    auto result =
+        classify_and_authorize_dispatch(registry, anonymous, "filesystem", "read", always_allow);
+    REQUIRE_FALSE(result.has_value());
+    CHECK(result.error().reason == DispatchDenialReason::AnonymousOperator);
+}
+
+TEST_CASE("classify_and_authorize_dispatch: a non-authorized operator principal is denied, "
+          "naming the securable it was denied on — four call-site shapes",
+          "[server][dispatch][chokepoint]") {
+    CommandCapabilityRegistry registry{std::span<const CommandCapability>(kOperatorFixture)};
+
+    SECTION("/api/command-shaped: an interactive operator dispatching filesystem.read") {
+        DispatchCaller caller{.principal = "alice", .principal_role = "operator"};
+        auto result = classify_and_authorize_dispatch(registry, caller, "filesystem", "read",
+                                                       always_deny);
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error().reason == DispatchDenialReason::Forbidden);
+        CHECK(result.error().securable == "FileRetrieval");
+    }
+
+    SECTION("forward_legacy_command-shaped: an operator dispatching chargen.chargen_start") {
+        DispatchCaller caller{.principal = "bob", .principal_role = "operator"};
+        auto result = classify_and_authorize_dispatch(registry, caller, "chargen",
+                                                       "chargen_start", always_deny);
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error().reason == DispatchDenialReason::Forbidden);
+        CHECK(result.error().securable == "Execution");
+    }
+
+    SECTION("schedule-shaped: a scheduled bundle firing under its creating operator's recovered "
+            "principal, dispatching tar.query") {
+        DispatchCaller caller{.principal = "carol", .principal_role = "operator"};
+        auto result =
+            classify_and_authorize_dispatch(registry, caller, "tar", "query", always_deny);
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error().reason == DispatchDenialReason::Forbidden);
+        CHECK(result.error().securable == "Infrastructure");
+    }
+
+    SECTION("dispatch_confined-under-an-MCP-shaped caller: an MCP session's principal "
+            "dispatching vuln_scan.scan") {
+        DispatchCaller caller{.principal = "dave", .principal_role = "mcp-operator"};
+        auto result =
+            classify_and_authorize_dispatch(registry, caller, "vuln_scan", "scan", always_deny);
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error().reason == DispatchDenialReason::Forbidden);
+        CHECK(result.error().securable == "Security");
+    }
+}
+
+TEST_CASE("classify_and_authorize_dispatch: the three system dispatches succeed under a system "
+          "caller, regardless of what RbacStore would answer",
+          "[server][dispatch][chokepoint]") {
+    CommandCapabilityRegistry registry{
+        std::span<const CommandCapability>(capdecls::core_dispatch_capabilities())};
+    const DispatchCaller system_caller{.system = true};
+
+    SECTION("tar.fleet_snapshot") {
+        // has_permission ALWAYS DENIES — proves success is the STRUCTURAL
+        // system-arm rule, not an accidental RBAC pass.
+        auto result = classify_and_authorize_dispatch(registry, system_caller, "tar",
+                                                       "fleet_snapshot", always_deny);
+        REQUIRE(result.has_value());
+        CHECK(result->securable == "Response");
+        CHECK(result->operation == authz::Operation::Read);
+        CHECK(result->dispatch_class == DispatchClass::ReadOnly);
+        CHECK(result->system_reserved);
+    }
+    SECTION("__guard__.push_rules") {
+        auto result = classify_and_authorize_dispatch(registry, system_caller, "__guard__",
+                                                       "push_rules", always_deny);
+        REQUIRE(result.has_value());
+        CHECK(result->securable == "GuaranteedState");
+        CHECK(result->operation == authz::Operation::Push);
+        CHECK(result->system_reserved);
+    }
+    SECTION("asset_tags.sync") {
+        auto result =
+            classify_and_authorize_dispatch(registry, system_caller, "asset_tags", "sync",
+                                            always_deny);
+        REQUIRE(result.has_value());
+        CHECK(result->securable == "Tag");
+        CHECK(result->operation == authz::Operation::Write);
+        CHECK(result->system_reserved);
+    }
+}
+
+TEST_CASE("classify_and_authorize_dispatch: the three system dispatches are denied to an "
+          "operator caller lacking the securable — system_reserved is never caller-attributable",
+          "[server][dispatch][chokepoint]") {
+    CommandCapabilityRegistry registry{
+        std::span<const CommandCapability>(capdecls::core_dispatch_capabilities())};
+    const DispatchCaller operator_caller{.principal = "alice", .system = false};
+
+    SECTION("tar.fleet_snapshot") {
+        // has_permission ALWAYS ALLOWS — proves the denial is the
+        // system_reserved rule, not a missing RBAC grant an operator could
+        // otherwise be given.
+        auto result = classify_and_authorize_dispatch(registry, operator_caller, "tar",
+                                                       "fleet_snapshot", always_allow);
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error().reason == DispatchDenialReason::Forbidden);
+        CHECK(result.error().securable == "Response");
+    }
+    SECTION("__guard__.push_rules") {
+        auto result = classify_and_authorize_dispatch(registry, operator_caller, "__guard__",
+                                                       "push_rules", always_allow);
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error().reason == DispatchDenialReason::Forbidden);
+        CHECK(result.error().securable == "GuaranteedState");
+    }
+    SECTION("asset_tags.sync") {
+        auto result = classify_and_authorize_dispatch(registry, operator_caller, "asset_tags",
+                                                       "sync", always_allow);
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error().reason == DispatchDenialReason::Forbidden);
+        CHECK(result.error().securable == "Tag");
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════════
+// compute_dispatch_tag — the composition build_classified_command stamps.
+// ═════════════════════════════════════════════════════════════════════════
+
+TEST_CASE("compute_dispatch_tag: decodes to the classification supplied, and its plan hash "
+          "matches compute_plan_hash over the same inputs",
+          "[server][dispatch][chokepoint]") {
+    constexpr CommandCapability cap{
+        .plugin = "tar",
+        .action = "fleet_snapshot",
+        .dispatch_class = DispatchClass::ReadOnly,
+        .mutability = Mutability::None,
+        .securable = "Response",
+        .operation = authz::Operation::Read,
+        .risk_tier = authz::RiskTier::Low,
+        .system_reserved = true,
+    };
+    const std::map<std::string, std::string> params{{"a", "1"}, {"b", "2"}};
+
+    auto tag = compute_dispatch_tag(cap, "tar", "fleet_snapshot", params, "ids", "exec-1");
+
+    auto decoded = decode_dispatch_tag(tag);
+    REQUIRE(decoded.has_value());
+    CHECK(decoded->dispatch_class == DispatchClass::ReadOnly);
+    CHECK(decoded->mutability == Mutability::None);
+    CHECK(decoded->plan_hash ==
+          compute_plan_hash("tar", "fleet_snapshot", params, "ids", "exec-1"));
+
+    // Two dispatches differing ONLY in how targets were selected (target_arm)
+    // mint distinct plan identities — the property build_classified_command
+    // relies on `target_arm` for (spec item 1).
+    auto tag_other_arm =
+        compute_dispatch_tag(cap, "tar", "fleet_snapshot", params, "scope", "exec-1");
+    CHECK(tag_other_arm != tag);
+
+    // Likewise for execution_id.
+    auto tag_other_exec =
+        compute_dispatch_tag(cap, "tar", "fleet_snapshot", params, "ids", "exec-2");
+    CHECK(tag_other_exec != tag);
+}
+
+// ═════════════════════════════════════════════════════════════════════════
+// finalize_classified_command — the composition build_classified_command
+// runs AFTER classify_and_authorize_dispatch succeeds: the per-action kill
+// switch (M6/branch-review HIGH) and BR-009 canonical wire names (M6/MEDIUM).
+// Before this extraction NEITHER was reachable from a unit test — both lived
+// inline in ServerImpl::build_classified_command, a private member with no
+// live-Session-free construction path — so a revert of either behaviour
+// would have shipped silently. Mirrors classify_and_authorize_dispatch's own
+// section above: bind the shared function every real call site funnels
+// through, never a from-scratch re-implementation.
+// ═════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+constexpr CommandCapability kTarPurgeCap{
+    .plugin = "tar",
+    .action = "purge_source",
+    .dispatch_class = DispatchClass::Mutating,
+    .mutability = Mutability::Reversible,
+    .securable = "Infrastructure",
+    .operation = authz::Operation::Write,
+    .risk_tier = authz::RiskTier::Medium,
+    .system_reserved = false,
+};
+
+} // namespace
+
+TEST_CASE("finalize_classified_command: the per-action kill switch refuses AFTER classification, "
+          "naming the classified securable — never a permissive default on a thrown switch",
+          "[server][dispatch][chokepoint]") {
+    std::function<bool(std::string_view, std::string_view)> switch_off =
+        [](std::string_view, std::string_view) { return false; };
+
+    auto result = finalize_classified_command(kTarPurgeCap, switch_off, "tar", "purge_source",
+                                               "cmd-1", {}, {}, 0, 0, {}, {});
+    REQUIRE_FALSE(result.has_value());
+    CHECK(result.error().reason == DispatchDenialReason::KillSwitched);
+    // Names the securable classification already resolved — an incident
+    // review distinguishing "kill-switched on Infrastructure:Write" from a
+    // bare denial needs this, exactly as the Forbidden path does above.
+    CHECK(result.error().securable == "Infrastructure");
+    CHECK(result.error().operation == authz::Operation::Write);
+}
+
+TEST_CASE("finalize_classified_command: the kill switch is consulted on the CLASSIFIED plugin.action, "
+          "not the caller's raw spelling",
+          "[server][dispatch][chokepoint]") {
+    // A callback that only recognizes the canonical spelling — if
+    // finalize_classified_command consulted the caller's raw "TAR"/"PURGE_SOURCE"
+    // instead of cap.plugin/cap.action, this would (wrongly) refuse.
+    std::function<bool(std::string_view, std::string_view)> canonical_only =
+        [](std::string_view plugin, std::string_view action) {
+            return plugin == "tar" && action == "purge_source";
+        };
+
+    auto result = finalize_classified_command(kTarPurgeCap, canonical_only, "TAR", "PURGE_SOURCE",
+                                               "cmd-2", {}, {}, 0, 0, {}, {});
+    REQUIRE(result.has_value());
+}
+
+TEST_CASE("finalize_classified_command: an unwired kill-switch callback is legacy-open, mirroring "
+          "an absent PluginConfigStore in production — never a hard refusal",
+          "[server][dispatch][chokepoint]") {
+    std::function<bool(std::string_view, std::string_view)> unwired; // empty — no store wired
+
+    auto result = finalize_classified_command(kTarPurgeCap, unwired, "tar", "purge_source", "cmd-3",
+                                               {}, {}, 0, 0, {}, {});
+    REQUIRE(result.has_value());
+}
+
+TEST_CASE("finalize_classified_command: BR-009 — the wire command carries the CANONICAL "
+          "plugin/action the catalogue resolved, never the caller's raw casing",
+          "[server][dispatch][chokepoint]") {
+    std::function<bool(std::string_view, std::string_view)> switch_on =
+        [](std::string_view, std::string_view) { return true; };
+
+    // Caller dispatched with a differently-cased spelling — classify() is
+    // case-insensitive so this would have been authorized against kTarPurgeCap,
+    // but the agent matches the wire fields case-SENSITIVELY.
+    auto result = finalize_classified_command(kTarPurgeCap, switch_on, "TAR", "Purge_Source",
+                                               "cmd-4", {}, {}, 0, 0, {}, {});
+    REQUIRE(result.has_value());
+    CHECK(result->wire().plugin() == "tar");
+    CHECK(result->wire().action() == "purge_source");
+    CHECK(result->wire().command_id() == "cmd-4");
+}
+
+TEST_CASE("finalize_classified_command: parameters, payload, stagger and delay reach the wire "
+          "command verbatim, and the dispatch tag is composed over the CALLER's raw plugin/action "
+          "(not the canonical spelling) — matching what compute_dispatch_tag always received",
+          "[server][dispatch][chokepoint]") {
+    std::function<bool(std::string_view, std::string_view)> switch_on =
+        [](std::string_view, std::string_view) { return true; };
+    const std::unordered_map<std::string, std::string> params{{"path", "/var/log"}};
+
+    auto result =
+        finalize_classified_command(kTarPurgeCap, switch_on, "TAR", "purge_source", "cmd-5",
+                                    params, "payload-bytes", 5, 10, "ids", "exec-9");
+    REQUIRE(result.has_value());
+    CHECK(result->wire().parameters().at("path") == "/var/log");
+    CHECK(result->wire().payload() == "payload-bytes");
+    CHECK(result->wire().stagger_seconds() == 5);
+    CHECK(result->wire().delay_seconds() == 10);
+
+    const std::map<std::string, std::string> ordered_params{{"path", "/var/log"}};
+    auto decoded = decode_dispatch_tag(result->wire().dispatch_tag());
+    REQUIRE(decoded.has_value());
+    // Composed over "TAR" (the raw caller spelling this test passed), the
+    // SAME asymmetry build_classified_command has always had: the wire
+    // fields are canonicalized, the plan-hash inputs are not.
+    CHECK(decoded->plan_hash ==
+          compute_plan_hash("TAR", "purge_source", ordered_params, "ids", "exec-9"));
+}
+
+// ═════════════════════════════════════════════════════════════════════════
+// AgentRegistry::send_to/send_to_all — the defensive belt-and-braces tag
+// check (PLAN item 3) and the gateway routed-path capability check (item 5).
+// ═════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+agent_pb::AgentInfo make_agent_info(const std::string& id) {
+    agent_pb::AgentInfo info;
+    info.set_agent_id(id);
+    info.set_hostname("host.local");
+    return info;
+}
+
+agent_pb::CommandRequest make_well_formed_cmd(const std::string& command_id) {
+    agent_pb::CommandRequest cmd;
+    cmd.set_command_id(command_id);
+    cmd.set_plugin("tar");
+    cmd.set_action("fleet_snapshot");
+    cmd.set_dispatch_tag(
+        encode_dispatch_tag(DispatchClass::ReadOnly, Mutability::None, std::string(32, 'a')));
+    return cmd;
+}
+
+} // namespace
+
+TEST_CASE("AgentRegistry::send_to: the defensive tag check rejects an empty/malformed "
+          "dispatch_tag, counted separately from the gateway-capability denial",
+          "[server][dispatch][chokepoint]") {
+    EventBus bus;
+    yuzu::MetricsRegistry metrics;
+    AgentRegistry registry(bus, metrics);
+    registry.register_agent(make_agent_info("dev-A"));
+
+    agent_pb::CommandRequest cmd;
+    cmd.set_command_id("bad-tag-cmd");
+    cmd.set_plugin("tar");
+    cmd.set_action("fleet_snapshot");
+    // dispatch_tag left unset — decode_dispatch_tag("") fails (empty hash field).
+    auto classified = ClassifiedCommandTestAccess::make(cmd);
+
+    CHECK_FALSE(registry.send_to("dev-A", classified));
+    CHECK(metrics.counter("yuzu_server_dispatch_tag_invalid_total").value() == 1);
+    // NOT the gateway-capability counter — this agent isn't even gateway-routed.
+    CHECK(metrics
+             .counter("yuzu_server_gateway_capability_denied_total",
+                      {{"capability", std::string(kGatewayWireCapabilityDispatchTagV1)}})
+             .value() == 0);
+}
+
+TEST_CASE("AgentRegistry::send_to_all: the defensive tag check is evaluated once for the whole "
+          "broadcast, not per recipient",
+          "[server][dispatch][chokepoint]") {
+    EventBus bus;
+    yuzu::MetricsRegistry metrics;
+    AgentRegistry registry(bus, metrics);
+    registry.register_agent(make_agent_info("dev-A"));
+    registry.register_agent(make_agent_info("dev-B"));
+
+    agent_pb::CommandRequest cmd;
+    cmd.set_command_id("bad-tag-broadcast");
+    cmd.set_plugin("tar");
+    cmd.set_action("fleet_snapshot");
+    auto classified = ClassifiedCommandTestAccess::make(cmd);
+
+    CHECK(registry.send_to_all(classified) == 0);
+    CHECK(metrics.counter("yuzu_server_dispatch_tag_invalid_total").value() == 1);
+}
+
+TEST_CASE("AgentRegistry::send_to: a routed envelope to a gateway session that never advertised "
+          "command_dispatch_tag_v1 is denied and counted, not silently downgraded",
+          "[server][dispatch][chokepoint]") {
+    EventBus bus;
+    yuzu::MetricsRegistry metrics;
+    AgentRegistry registry(bus, metrics);
+    registry.register_agent(make_agent_info("dev-gw"));
+    // Node set, capabilities deliberately EMPTY — this gateway has not
+    // proven it forwards dispatch_tag untouched.
+    registry.set_gateway_route("dev-gw", "gw-node-1", {});
+
+    auto classified = ClassifiedCommandTestAccess::make(make_well_formed_cmd("routed-cmd"));
+
+    CHECK_FALSE(registry.send_to("dev-gw", classified));
+    CHECK(registry.drain_gateway_pending().empty());
+    CHECK(metrics
+             .counter("yuzu_server_gateway_capability_denied_total",
+                      {{"capability", std::string(kGatewayWireCapabilityDispatchTagV1)}})
+             .value() == 1);
+}
+
+TEST_CASE("AgentRegistry::send_to: a routed envelope succeeds once the gateway has advertised "
+          "command_dispatch_tag_v1",
+          "[server][dispatch][chokepoint]") {
+    EventBus bus;
+    yuzu::MetricsRegistry metrics;
+    AgentRegistry registry(bus, metrics);
+    registry.register_agent(make_agent_info("dev-gw"));
+    registry.set_gateway_route("dev-gw", "gw-node-1",
+                               {std::string(kGatewayWireCapabilityDispatchTagV1)});
+
+    auto classified = ClassifiedCommandTestAccess::make(make_well_formed_cmd("routed-cmd-ok"));
+
+    CHECK(registry.send_to("dev-gw", classified));
+    auto pending = registry.drain_gateway_pending();
+    REQUIRE(pending.size() == 1);
+    CHECK(pending[0].agent_id == "dev-gw");
+    CHECK(pending[0].cmd.command_id() == "routed-cmd-ok");
+}
+
+TEST_CASE("AgentRegistry::send_to_all: an individual gateway recipient missing the "
+          "advertisement is excluded from the count without failing the rest of the broadcast",
+          "[server][dispatch][chokepoint]") {
+    EventBus bus;
+    yuzu::MetricsRegistry metrics;
+    AgentRegistry registry(bus, metrics);
+    registry.register_agent(make_agent_info("dev-ok"));
+    registry.set_gateway_route("dev-ok", "gw-node-1",
+                               {std::string(kGatewayWireCapabilityDispatchTagV1)});
+    registry.register_agent(make_agent_info("dev-missing"));
+    // dev-missing's gateway never advertised the capability.
+    registry.set_gateway_route("dev-missing", "gw-node-2", {});
+
+    auto classified = ClassifiedCommandTestAccess::make(make_well_formed_cmd("broadcast-cmd"));
+
+    CHECK(registry.send_to_all(classified) == 1);
+    auto pending = registry.drain_gateway_pending();
+    REQUIRE(pending.size() == 1);
+    CHECK(pending[0].agent_id == "dev-ok");
+}
+
+// ═════════════════════════════════════════════════════════════════════════
+// PLAN item 5 (CC-03) — AgentRegistry's gateway wire-capability accessors.
+// NotifyStreamStatus (gateway_service_impl.cpp) is a thin delegation to
+// these — set_gateway_route on CONNECTED (M1 review fix: node + capabilities
+// publish together, not two separate calls), clear_stream_if_session
+// (extended, agent_registry.cpp) covers DISCONNECTED. Bound directly here
+// rather than via a live GatewayUpstreamServiceImpl, which needs a real
+// auth::AuthManager/AutoApproveEngine this package does not own and no
+// existing test constructs.
+// ═════════════════════════════════════════════════════════════════════════
+
+TEST_CASE("AgentRegistry: gateway wire capabilities are recorded and queryable",
+          "[server][dispatch][chokepoint][gateway]") {
+    EventBus bus;
+    yuzu::MetricsRegistry metrics;
+    AgentRegistry registry(bus, metrics);
+    registry.register_agent(make_agent_info("dev-A"));
+
+    // Node value is irrelevant here — gateway_has_wire_capability never
+    // reads it — so a fixed placeholder is used throughout this test.
+    registry.set_gateway_route("dev-A", "irrelevant-node", {"command_dispatch_tag_v1", "other_cap"});
+
+    CHECK(registry.gateway_has_wire_capability("dev-A", "command_dispatch_tag_v1"));
+    CHECK(registry.gateway_has_wire_capability("dev-A", "other_cap"));
+    CHECK_FALSE(registry.gateway_has_wire_capability("dev-A", "unadvertised_cap"));
+    // Unknown agent: fail closed.
+    CHECK_FALSE(registry.gateway_has_wire_capability("dev-nonexistent", "command_dispatch_tag_v1"));
+}
+
+TEST_CASE("AgentRegistry: a reconnect REPLACES advertised wire capabilities, never merges",
+          "[server][dispatch][chokepoint][gateway]") {
+    EventBus bus;
+    yuzu::MetricsRegistry metrics;
+    AgentRegistry registry(bus, metrics);
+    registry.register_agent(make_agent_info("dev-A"));
+
+    registry.set_gateway_route("dev-A", "irrelevant-node", {"cap_a", "cap_b"});
+    REQUIRE(registry.gateway_has_wire_capability("dev-A", "cap_a"));
+    REQUIRE(registry.gateway_has_wire_capability("dev-A", "cap_b"));
+
+    // A reconnect behind a DIFFERENT gateway build advertises a narrower set.
+    registry.set_gateway_route("dev-A", "irrelevant-node", {"cap_c"});
+
+    CHECK_FALSE(registry.gateway_has_wire_capability("dev-A", "cap_a"));
+    CHECK_FALSE(registry.gateway_has_wire_capability("dev-A", "cap_b"));
+    CHECK(registry.gateway_has_wire_capability("dev-A", "cap_c"));
+}
+
+TEST_CASE("AgentRegistry: clear_stream_if_session clears advertised wire capabilities — the "
+          "DISCONNECTED path",
+          "[server][dispatch][chokepoint][gateway]") {
+    EventBus bus;
+    yuzu::MetricsRegistry metrics;
+    AgentRegistry registry(bus, metrics);
+    registry.register_agent(make_agent_info("dev-A"));
+    registry.map_session("sess-1", "dev-A");
+    registry.set_gateway_route("dev-A", "irrelevant-node",
+                               {std::string(kGatewayWireCapabilityDispatchTagV1)});
+    REQUIRE(registry.gateway_has_wire_capability(
+        "dev-A", kGatewayWireCapabilityDispatchTagV1));
+
+    // Mirrors GatewayUpstreamServiceImpl::NotifyStreamStatus's DISCONNECTED
+    // branch exactly: clear_stream_if_session(agent_id, session_id).
+    registry.clear_stream_if_session("dev-A", "sess-1");
+
+    CHECK_FALSE(
+        registry.gateway_has_wire_capability("dev-A", kGatewayWireCapabilityDispatchTagV1));
+}
+
+TEST_CASE("AgentRegistry: clear_gateway_wire_capabilities drops the advertised set directly",
+          "[server][dispatch][chokepoint][gateway]") {
+    EventBus bus;
+    yuzu::MetricsRegistry metrics;
+    AgentRegistry registry(bus, metrics);
+    registry.register_agent(make_agent_info("dev-A"));
+    registry.set_gateway_route("dev-A", "irrelevant-node", {"cap_a"});
+    REQUIRE(registry.gateway_has_wire_capability("dev-A", "cap_a"));
+
+    registry.clear_gateway_wire_capabilities("dev-A");
+
+    CHECK_FALSE(registry.gateway_has_wire_capability("dev-A", "cap_a"));
+}

--- a/tests/unit/server/test_dispatch_chokepoint.cpp
+++ b/tests/unit/server/test_dispatch_chokepoint.cpp
@@ -286,6 +286,50 @@ TEST_CASE("classify_and_authorize_dispatch: a DispatchCaller with system == fals
     CHECK(result.error().reason == DispatchDenialReason::AnonymousOperator);
 }
 
+// #3133 round-2 review HIGH (falsifier): a schedule whose stored creator no
+// longer resolves must be DENIED at the chokepoint even when RBAC is
+// administratively off (the shipped default), where the permission callback
+// admits everyone. The full chain, at the pure level: the resolver decision
+// (caller_for_stored_username) yields an empty-principal deny-all caller for
+// an unresolvable username, and the chokepoint refuses that caller as
+// AnonymousOperator BEFORE the always-allowing permission callback is ever
+// consulted. Every other dispatch surface gets account-existence for free
+// from session authentication; the schedule fire path is the only one that
+// recovers authority from a bare stored string, which is why this exact
+// composition needs its own lock.
+TEST_CASE("caller_for_stored_username: an unresolvable creator denies at the chokepoint "
+          "even with an always-allowing (RBAC-off) permission callback",
+          "[server][dispatch][chokepoint][schedule]") {
+    CommandCapabilityRegistry registry{std::span<const CommandCapability>(kOperatorFixture)};
+
+    SECTION("unresolvable: empty principal, deny-all visibility, chokepoint refuses") {
+        const auto caller = caller_for_stored_username("alice", /*principal_resolves=*/false,
+                                                       "admin", std::nullopt);
+        CHECK(caller.principal.empty());
+        CHECK_FALSE(caller.system);
+        // Present-EMPTY visible set (deny-all), never nullopt-unfiltered.
+        REQUIRE(caller.exec_visible.has_value());
+        CHECK(caller.exec_visible->empty());
+
+        auto result =
+            classify_and_authorize_dispatch(registry, caller, "filesystem", "read", always_allow);
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error().reason == DispatchDenialReason::AnonymousOperator);
+    }
+    SECTION("resolvable: the caller carries through untouched") {
+        const auto caller = caller_for_stored_username("alice", /*principal_resolves=*/true,
+                                                       "operator", std::nullopt);
+        CHECK(caller.principal == "alice");
+        CHECK(caller.principal_role == "operator");
+        CHECK_FALSE(caller.system);
+        CHECK_FALSE(caller.exec_visible.has_value()); // nullopt passed through unchanged
+
+        auto result =
+            classify_and_authorize_dispatch(registry, caller, "filesystem", "read", always_allow);
+        REQUIRE(result.has_value());
+    }
+}
+
 TEST_CASE("classify_and_authorize_dispatch: a non-authorized operator principal is denied, "
           "naming the securable it was denied on — four call-site shapes",
           "[server][dispatch][chokepoint]") {

--- a/tests/unit/server/test_dispatch_confined_arms.cpp
+++ b/tests/unit/server/test_dispatch_confined_arms.cpp
@@ -478,7 +478,7 @@ TEST_CASE("resolve_scope_targets: a degraded registry evaluation with no princip
 // none of them called through it. This test does, against a REAL
 // `AgentRegistry` (not a fake — `AgentRegistry` has zero virtuals and cannot
 // be faked polymorphically), using the registry's gateway-pending path
-// (`set_gateway_node` + `drain_gateway_pending()`) to observe exactly which
+// (`set_gateway_route` + `drain_gateway_pending()`) to observe exactly which
 // agent_ids a dispatch reached without needing a live gRPC stream.
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -486,6 +486,7 @@ TEST_CASE("resolve_scope_targets: a degraded registry evaluation with no princip
 
 namespace {
 using yuzu::server::detail::AgentRegistry;
+using yuzu::server::detail::ClassifiedCommandTestAccess;
 using yuzu::server::detail::EventBus;
 namespace agent_pb = ::yuzu::agent::v1;
 
@@ -508,13 +509,29 @@ TEST_CASE("wire_and_dispatch_confined: the Ids arm intersects exec_visible again
         // Gateway-pending path: send_to() queues onto drain_gateway_pending()
         // and returns true with NO live gRPC stream needed — the observable
         // hook this test uses to see exactly who was targeted.
-        registry.set_gateway_node(id, "test-gateway");
+        // p8/PR1.9c CC-03: send_to()'s routed-path check now refuses a
+        // dispatch-tagged command to a gateway session that hasn't advertised
+        // command_dispatch_tag_v1 — irrelevant to what THIS test binds (the
+        // exec_visible intersection), so advertise it for every fixture agent
+        // exactly as a real gateway's CONNECTED notification would.
+        registry.set_gateway_route(
+            id, "test-gateway",
+            {std::string(yuzu::server::detail::kGatewayWireCapabilityDispatchTagV1)});
     }
 
     yuzu::agent::v1::CommandRequest cmd;
     cmd.set_command_id("wiring-test-cmd");
     cmd.set_plugin("os_info");
     cmd.set_action("version");
+    // p8/PR1.9c PLAN-011: send_to()'s defensive belt-and-braces check now
+    // refuses a command whose dispatch_tag doesn't decode — irrelevant to
+    // what THIS test binds, so stamp a well-formed one. Wrapped via the
+    // test-only door (`ClassifiedCommandTestAccess`) mirroring
+    // `EngineLivenessTestAccess`: `send_to`/`send_to_all` accept only a
+    // `ClassifiedCommand`, mintable in production ONLY by
+    // `ServerImpl::build_classified_command`.
+    cmd.set_dispatch_tag("v1|ro|none|0123456789abcdef0123456789abcdef");
+    auto classified = ClassifiedCommandTestAccess::make(cmd);
 
     // Confined to dev-A only; agent_ids names all three. If the intersection
     // is deleted (the exact K-1 mutation), all three get queued instead of
@@ -529,7 +546,7 @@ TEST_CASE("wire_and_dispatch_confined: the Ids arm intersects exec_visible again
         /*tag_store=*/nullptr, /*custom_properties_store=*/nullptr,
         /*execution_tracker=*/nullptr, noop_audit, noop_audit,
         /*command_id=*/"wiring-test-cmd", /*execution_id=*/"", /*principal_role=*/"",
-        agent_ids, /*scope_expr=*/"", exec_visible, /*broadcast_on_none=*/false, cmd);
+        agent_ids, /*scope_expr=*/"", exec_visible, /*broadcast_on_none=*/false, classified);
 
     CHECK(sent == 1);
     auto pending = registry.drain_gateway_pending();

--- a/tests/unit/server/test_mcp_server.cpp
+++ b/tests/unit/server/test_mcp_server.cpp
@@ -696,15 +696,18 @@ struct McpTestServer {
     /// dispatch_fn (the confinement the production dispatch lambda applies).
     yuzu::server::authz::VisibleSet last_dispatch_exec_visible;
 
-    /// CDX-R5-02: the per-caller exec-visible derivation for MCP dispatch
-    /// confinement. CDX-R6-02: an UNWIRED callback now fails CLOSED in the
-    /// handlers (a present-empty visible set denies every target), so the
-    /// harness DEFAULT wires a callback that explicitly returns nullopt
-    /// (unfiltered) -- that keeps every existing MCP test on the pre-#1788
-    /// full-fleet path. A confinement test overrides this with a specific set;
-    /// a fail-closed test sets it to `{}` (genuinely unwired).
-    yuzu::server::mcp::McpServer::ExecVisibleFn exec_visible_fn_for_test{
-        [](const auth::Session&) { return yuzu::server::authz::VisibleSet{}; }};
+    /// CDX-R5-02 / PLAN-006: the per-caller DispatchCaller derivation for MCP
+    /// dispatch confinement + identity. CDX-R6-02: an UNWIRED callback now
+    /// fails CLOSED on visibility in the handlers (a present-empty visible set
+    /// denies every target; an empty principal), so the harness DEFAULT wires
+    /// a callback whose `exec_visible` is explicitly nullopt (unfiltered) --
+    /// that keeps every existing MCP test on the pre-#1788 full-fleet path. A
+    /// confinement test overrides this with a specific set; a fail-closed test
+    /// sets it to `{}` (genuinely unwired).
+    yuzu::server::mcp::McpServer::CallerFn caller_fn_for_test{
+        [](const auth::Session&) -> yuzu::server::DispatchCaller {
+            return yuzu::server::DispatchCaller{.exec_visible = yuzu::server::authz::VisibleSet{}};
+        }};
 
     /// governance R1 (QE SHOULD-1 + happy-LOW-2): allow a test to wire a
     /// real ExecutionTracker so the create_execution / set_agents_targeted
@@ -1063,7 +1066,7 @@ private:
             /*access_review_store=*/nullptr,
             /*auth_db=*/nullptr,
             /*directory_sync=*/nullptr,
-            /*exec_visible_fn=*/exec_visible_fn_for_test,
+            /*caller_fn=*/caller_fn_for_test,
             // 2f PR 3b: the POST handler leases from the SAME budget as GET.
             // Default nullptr keeps every pre-3b test on the plain path - a test
             // that does not opt in cannot accidentally start streaming.
@@ -4764,7 +4767,7 @@ TEST_CASE("MCP Integration: execute_instruction happy dispatch", "[mcp][integrat
     auto dispatch = [&](const std::string& plugin, const std::string& action,
                         const std::vector<std::string>& agent_ids, const std::string& scope_expr,
                         const std::unordered_map<std::string, std::string>& params,
-                        const std::string& execution_id, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                        const std::string& execution_id, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         ts.last_dispatch_plugin = plugin;
         ts.last_dispatch_action = action;
         ts.last_dispatch_agent_ids = agent_ids;
@@ -4822,17 +4825,17 @@ TEST_CASE("MCP execute_instruction derives the caller's exec_visible and threads
           "[mcp][integration][execute][scope]") {
     McpTestServer ts;
     // A service-scoped-style confinement: the caller can see only agent-A.
-    ts.exec_visible_fn_for_test = [](const auth::Session&) {
+    ts.caller_fn_for_test = [](const auth::Session&) -> yuzu::server::DispatchCaller {
         std::unordered_set<std::string> s{"agent-A"};
-        return yuzu::server::authz::VisibleSet{s};
+        return yuzu::server::DispatchCaller{.exec_visible = yuzu::server::authz::VisibleSet{s}};
     };
     auto dispatch = [&](const std::string&, const std::string&,
                         const std::vector<std::string>& agent_ids, const std::string&,
                         const std::unordered_map<std::string, std::string>&, const std::string&,
-                        const yuzu::server::authz::VisibleSet& exec_visible)
+                        const yuzu::server::DispatchCaller& caller)
         -> std::pair<std::string, int> {
         ts.last_dispatch_agent_ids = agent_ids;
-        ts.last_dispatch_exec_visible = exec_visible;
+        ts.last_dispatch_exec_visible = caller.exec_visible;
         return {"cmd-x", 0};
     };
     ts.start_with_dispatch(dispatch, "operator");
@@ -4849,6 +4852,35 @@ TEST_CASE("MCP execute_instruction derives the caller's exec_visible and threads
     CHECK(ts.last_dispatch_exec_visible->count("agent-B") == 0);
 }
 
+// PLAN-006: the sibling of the confinement handoff test above, but asserting
+// the IDENTITY half of DispatchCaller — a wired CallerFn's principal must
+// reach the dispatch seam, not just its exec_visible.
+TEST_CASE("MCP execute_instruction threads the caller's principal into dispatch (PLAN-006)",
+          "[mcp][integration][execute][scope]") {
+    McpTestServer ts;
+    ts.caller_fn_for_test = [](const auth::Session& s) -> yuzu::server::DispatchCaller {
+        return yuzu::server::DispatchCaller{.principal = s.username,
+                                            .principal_role = auth::role_to_string(s.role)};
+    };
+    yuzu::server::DispatchCaller captured;
+    auto dispatch = [&](const std::string&, const std::string&,
+                        const std::vector<std::string>&, const std::string&,
+                        const std::unordered_map<std::string, std::string>&, const std::string&,
+                        const yuzu::server::DispatchCaller& caller)
+        -> std::pair<std::string, int> {
+        captured = caller;
+        return {"cmd-x", 0};
+    };
+    ts.start_with_dispatch(dispatch, "operator");
+    auto res = ts.call(
+        R"({"jsonrpc":"2.0","method":"tools/call","id":177,"params":{"name":"execute_instruction","arguments":{"plugin":"os_info","action":"version","agent_ids":["agent-A"]}}})");
+    REQUIRE(res);
+    CHECK(res->status == 200);
+    CHECK(captured.principal == ts.mock_username);
+    CHECK_FALSE(captured.principal_role.empty());
+    CHECK_FALSE(captured.system);
+}
+
 TEST_CASE("MCP execute_instruction FAILS CLOSED when the exec-visible derivation is unwired "
           "(CDX-R6-02)",
           "[mcp][integration][execute][scope]") {
@@ -4856,13 +4888,13 @@ TEST_CASE("MCP execute_instruction FAILS CLOSED when the exec-visible derivation
     // Genuinely UNWIRED (not the harness's nullopt default): the handler must
     // hand dispatch a PRESENT EMPTY visible set (deny all), never nullopt
     // (unfiltered) -- ADR-0033 §1, a missing applicable filter denies.
-    ts.exec_visible_fn_for_test = {};
+    ts.caller_fn_for_test = {};
     auto dispatch = [&](const std::string&, const std::string&,
                         const std::vector<std::string>&, const std::string&,
                         const std::unordered_map<std::string, std::string>&, const std::string&,
-                        const yuzu::server::authz::VisibleSet& exec_visible)
+                        const yuzu::server::DispatchCaller& caller)
         -> std::pair<std::string, int> {
-        ts.last_dispatch_exec_visible = exec_visible;
+        ts.last_dispatch_exec_visible = caller.exec_visible;
         return {"cmd-x", 0};
     };
     ts.start_with_dispatch(dispatch, "operator");
@@ -4872,6 +4904,31 @@ TEST_CASE("MCP execute_instruction FAILS CLOSED when the exec-visible derivation
     CHECK(res->status == 200);
     REQUIRE(ts.last_dispatch_exec_visible.has_value()); // PRESENT (deny), not nullopt
     CHECK(ts.last_dispatch_exec_visible->empty());       // EMPTY -> the production sink dispatches to no one
+}
+
+// PLAN-006: the identity sibling of the fail-closed test above — an unwired
+// CallerFn must hand dispatch an EMPTY principal too, not merely a deny-all
+// exec_visible.
+TEST_CASE("MCP execute_instruction hands dispatch an EMPTY principal when the CallerFn is unwired "
+          "(PLAN-006)",
+          "[mcp][integration][execute][scope]") {
+    McpTestServer ts;
+    ts.caller_fn_for_test = {};
+    yuzu::server::DispatchCaller captured;
+    auto dispatch = [&](const std::string&, const std::string&,
+                        const std::vector<std::string>&, const std::string&,
+                        const std::unordered_map<std::string, std::string>&, const std::string&,
+                        const yuzu::server::DispatchCaller& caller)
+        -> std::pair<std::string, int> {
+        captured = caller;
+        return {"cmd-x", 0};
+    };
+    ts.start_with_dispatch(dispatch, "operator");
+    auto res = ts.call(
+        R"({"jsonrpc":"2.0","method":"tools/call","id":178,"params":{"name":"execute_instruction","arguments":{"plugin":"os_info","action":"version","agent_ids":["agent-A"]}}})");
+    REQUIRE(res);
+    CHECK(res->status == 200);
+    CHECK(captured.principal.empty());
 }
 
 // ── 23b. execute_instruction with real ExecutionTracker — non-empty path ──
@@ -4917,7 +4974,7 @@ TEST_CASE("MCP Integration: execute_instruction populates execution_id and threa
     auto dispatch = [&](const std::string& plugin, const std::string& action,
                         const std::vector<std::string>& agent_ids, const std::string& scope_expr,
                         const std::unordered_map<std::string, std::string>& params,
-                        const std::string& execution_id, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                        const std::string& execution_id, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         ts.last_dispatch_plugin = plugin;
         ts.last_dispatch_action = action;
         ts.last_dispatch_agent_ids = agent_ids;
@@ -4984,7 +5041,7 @@ TEST_CASE("MCP Integration: execute_instruction missing plugin", "[mcp][integrat
     McpTestServer ts;
     auto dispatch = [](const std::string&, const std::string&, const std::vector<std::string>&,
                        const std::string&, const std::unordered_map<std::string, std::string>&,
-                       const std::string& /*execution_id*/, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                       const std::string& /*execution_id*/, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         return {"", 0};
     };
     ts.start_with_dispatch(dispatch, "operator");
@@ -5007,7 +5064,7 @@ TEST_CASE("MCP Integration: execute_instruction missing action", "[mcp][integrat
     McpTestServer ts;
     auto dispatch = [](const std::string&, const std::string&, const std::vector<std::string>&,
                        const std::string&, const std::unordered_map<std::string, std::string>&,
-                       const std::string& /*execution_id*/, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                       const std::string& /*execution_id*/, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         return {"", 0};
     };
     ts.start_with_dispatch(dispatch, "operator");
@@ -5040,7 +5097,7 @@ TEST_CASE("MCP Integration: execute_instruction enforces input bounds on the ope
     bool dispatched = false;
     auto dispatch = [&](const std::string&, const std::string&, const std::vector<std::string>&,
                         const std::string&, const std::unordered_map<std::string, std::string>&,
-                        const std::string&, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                        const std::string&, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         dispatched = true;
         return {"cmd-abc", 1};
     };
@@ -5214,7 +5271,7 @@ TEST_CASE("MCP Integration: type-confused targeting is rejected, never widened t
     auto dispatch = [&](const std::string&, const std::string&,
                         const std::vector<std::string>& agent_ids, const std::string& scope_expr,
                         const std::unordered_map<std::string, std::string>&,
-                        const std::string&, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                        const std::string&, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         ++dispatch_calls;
         dispatched_ids = agent_ids;
         dispatched_scope = scope_expr;
@@ -5309,7 +5366,7 @@ TEST_CASE("MCP Integration: an input-bound denial emits a counted, correlated au
     ts.metrics_for_test = &reg;
     auto dispatch = [](const std::string&, const std::string&, const std::vector<std::string>&,
                        const std::string&, const std::unordered_map<std::string, std::string>&,
-                       const std::string&, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> { return {"", 0}; };
+                       const std::string&, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> { return {"", 0}; };
     ts.start_with_dispatch(dispatch, "operator");
 
     const std::string big(129, 'a');
@@ -5446,7 +5503,7 @@ TEST_CASE("MCP Integration: execute_instruction zero agents reached",
     McpTestServer ts;
     auto dispatch = [&](const std::string&, const std::string&, const std::vector<std::string>&,
                         const std::string&, const std::unordered_map<std::string, std::string>&,
-                        const std::string& /*execution_id*/, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                        const std::string& /*execution_id*/, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         return {"cmd-xyz", 0};
     };
     ts.start_with_dispatch(dispatch, "operator");
@@ -5486,7 +5543,7 @@ TEST_CASE("MCP Integration: execute_instruction default scope __all__",
     auto dispatch = [&](const std::string& plugin, const std::string& action,
                         const std::vector<std::string>& agent_ids, const std::string& scope_expr,
                         const std::unordered_map<std::string, std::string>& params,
-                        const std::string& /*execution_id*/, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                        const std::string& /*execution_id*/, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         ts.last_dispatch_scope = scope_expr;
         ts.last_dispatch_agent_ids = agent_ids;
         return {"cmd-default", 1};
@@ -5513,7 +5570,7 @@ TEST_CASE("MCP Integration: execute_instruction explicit agent_ids",
     auto dispatch = [&](const std::string&, const std::string&,
                         const std::vector<std::string>& agent_ids, const std::string& scope_expr,
                         const std::unordered_map<std::string, std::string>&,
-                        const std::string& /*execution_id*/, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                        const std::string& /*execution_id*/, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         ts.last_dispatch_agent_ids = agent_ids;
         ts.last_dispatch_scope = scope_expr;
         return {"cmd-agents", 2};
@@ -5539,7 +5596,7 @@ TEST_CASE("MCP Integration: execute_instruction params forwarding", "[mcp][integ
     auto dispatch = [&](const std::string&, const std::string&, const std::vector<std::string>&,
                         const std::string&,
                         const std::unordered_map<std::string, std::string>& params,
-                        const std::string& /*execution_id*/, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                        const std::string& /*execution_id*/, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         ts.last_dispatch_params = params;
         return {"cmd-params", 1};
     };
@@ -5563,7 +5620,7 @@ TEST_CASE("MCP Integration: execute_instruction non-string params", "[mcp][integ
     auto dispatch = [&](const std::string&, const std::string&, const std::vector<std::string>&,
                         const std::string&,
                         const std::unordered_map<std::string, std::string>& params,
-                        const std::string& /*execution_id*/, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                        const std::string& /*execution_id*/, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         ts.last_dispatch_params = params;
         return {"cmd-nonstr", 1};
     };
@@ -5588,7 +5645,7 @@ TEST_CASE("MCP Integration: execute_instruction blocked by read_only_mode",
     ts.read_only_mode_ = true;
     auto dispatch = [](const std::string&, const std::string&, const std::vector<std::string>&,
                        const std::string&, const std::unordered_map<std::string, std::string>&,
-                       const std::string& /*execution_id*/, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                       const std::string& /*execution_id*/, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         return {"cmd-ro", 1};
     };
     ts.start_with_dispatch(dispatch, "operator");
@@ -5611,7 +5668,7 @@ TEST_CASE("MCP Integration: execute_instruction blocked by readonly tier",
     McpTestServer ts;
     auto dispatch = [](const std::string&, const std::string&, const std::vector<std::string>&,
                        const std::string&, const std::unordered_map<std::string, std::string>&,
-                       const std::string& /*execution_id*/, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                       const std::string& /*execution_id*/, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         return {"cmd-ro", 1};
     };
     ts.start_with_dispatch(dispatch, "readonly");
@@ -5634,7 +5691,7 @@ TEST_CASE("MCP Integration: execute_instruction operator tier proceeds",
     auto dispatch = [&](const std::string& plugin, const std::string& action,
                         const std::vector<std::string>&, const std::string&,
                         const std::unordered_map<std::string, std::string>&,
-                        const std::string& /*execution_id*/, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                        const std::string& /*execution_id*/, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         ts.last_dispatch_plugin = plugin;
         ts.last_dispatch_action = action;
         return {"cmd-op", 3};
@@ -5672,7 +5729,7 @@ TEST_CASE("MCP Integration: execute_instruction supervised tier, no approval man
     McpTestServer ts;
     auto dispatch = [](const std::string&, const std::string&, const std::vector<std::string>&,
                        const std::string&, const std::unordered_map<std::string, std::string>&,
-                       const std::string& /*execution_id*/, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                       const std::string& /*execution_id*/, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         return {"cmd-sup", 1};
     };
     ts.start_with_dispatch(dispatch, "supervised"); // approval_manager_for_test == nullptr
@@ -5712,7 +5769,7 @@ TEST_CASE("MCP Integration: execute_instruction supervised tier mints approval t
     bool dispatched = false;
     auto dispatch = [&](const std::string&, const std::string&, const std::vector<std::string>&,
                         const std::string&, const std::unordered_map<std::string, std::string>&,
-                        const std::string& /*execution_id*/, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                        const std::string& /*execution_id*/, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         dispatched = true;
         return {"cmd-sup", 1};
     };
@@ -5739,7 +5796,7 @@ TEST_CASE("MCP Integration: execute_instruction audit on success", "[mcp][integr
     McpTestServer ts;
     auto dispatch = [](const std::string&, const std::string&, const std::vector<std::string>&,
                        const std::string&, const std::unordered_map<std::string, std::string>&,
-                       const std::string& /*execution_id*/, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                       const std::string& /*execution_id*/, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         return {"cmd-audit", 2};
     };
     ts.start_with_dispatch(dispatch, "operator");
@@ -5763,7 +5820,7 @@ TEST_CASE("MCP Integration: execute_instruction audit on no-agents",
     McpTestServer ts;
     auto dispatch = [](const std::string&, const std::string&, const std::vector<std::string>&,
                        const std::string&, const std::unordered_map<std::string, std::string>&,
-                       const std::string& /*execution_id*/, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                       const std::string& /*execution_id*/, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         return {"cmd-empty", 0};
     };
     ts.start_with_dispatch(dispatch, "operator");
@@ -6016,7 +6073,7 @@ TEST_CASE("MCP query_responses: full execute_instruction -> collect-by-execution
     ts.response_store_for_test = &store;
     auto dispatch = [&](const std::string&, const std::string&, const std::vector<std::string>&,
                         const std::string&, const std::unordered_map<std::string, std::string>&,
-                        const std::string& execution_id, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                        const std::string& execution_id, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         ts.last_dispatch_execution_id = execution_id;
         return {"cmd-loop", 1};
     };
@@ -7091,7 +7148,7 @@ bool audit_has(const std::vector<std::string>& log, const std::string& entry) {
 yuzu::server::mcp::McpServer::DispatchFn fake_bundle_dispatch() {
     return [](const std::string& plugin, const std::string& action, const std::vector<std::string>&,
               const std::string&, const std::unordered_map<std::string, std::string>&,
-              const std::string&, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+              const std::string&, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         return {"cmd-" + plugin + "-" + action, 1};
     };
 }
@@ -7108,14 +7165,14 @@ TEST_CASE("MCP execute_bundle denies an out-of-scope target agent, dispatches an
     McpTestServer ts;
     ts.response_store_for_test = &store;
     // Caller (service-scoped-style) can see only agent-A.
-    ts.exec_visible_fn_for_test = [](const auth::Session&) {
+    ts.caller_fn_for_test = [](const auth::Session&) -> yuzu::server::DispatchCaller {
         std::unordered_set<std::string> s{"agent-A"};
-        return yuzu::server::authz::VisibleSet{s};
+        return yuzu::server::DispatchCaller{.exec_visible = yuzu::server::authz::VisibleSet{s}};
     };
     ts.start_with_dispatch([&dispatched](const std::string&, const std::string&,
                                          const std::vector<std::string>&, const std::string&,
                                          const std::unordered_map<std::string, std::string>&,
-                                         const std::string&, const yuzu::server::authz::VisibleSet&)
+                                         const std::string&, const yuzu::server::DispatchCaller&)
                                -> std::pair<std::string, int> {
         dispatched = true;
         return {"cmd", 1};
@@ -7145,11 +7202,11 @@ TEST_CASE("MCP execute_bundle FAILS CLOSED when the exec-visible derivation is u
     ts.response_store_for_test = &store;
     // Genuinely UNWIRED (not the harness's nullopt default): a missing applicable
     // filter must DENY, not admit every target (ADR-0033 §1).
-    ts.exec_visible_fn_for_test = {};
+    ts.caller_fn_for_test = {};
     ts.start_with_dispatch([&dispatched](const std::string&, const std::string&,
                                          const std::vector<std::string>&, const std::string&,
                                          const std::unordered_map<std::string, std::string>&,
-                                         const std::string&, const yuzu::server::authz::VisibleSet&)
+                                         const std::string&, const yuzu::server::DispatchCaller&)
                                -> std::pair<std::string, int> {
         dispatched = true;
         return {"cmd", 1};
@@ -7166,7 +7223,7 @@ TEST_CASE("MCP execute_bundle admits a management-group-scoped operator with NO 
           "[pg][mcp][bundle][scope]") {
     // Simulates the exact twin-disagreement the finding named: a caller who is
     // NOT globally granted Execution:Execute (perm_override denies it) but IS
-    // scoped to see this one device (exec_visible_fn admits agent-A). REST's
+    // scoped to see this one device (caller_fn admits agent-A). REST's
     // /api/v1/bundles has never required the global grant, only the per-target
     // scoped_perm_fn; before this fix MCP additionally required the global
     // grant and 403'd this exact caller. The twins must now agree: admitted.
@@ -7183,14 +7240,14 @@ TEST_CASE("MCP execute_bundle admits a management-group-scoped operator with NO 
         // session here) is unaffected.
         return !(securable == "Execution" && op == "Execute");
     };
-    ts.exec_visible_fn_for_test = [](const auth::Session&) {
+    ts.caller_fn_for_test = [](const auth::Session&) -> yuzu::server::DispatchCaller {
         std::unordered_set<std::string> s{"agent-A"};
-        return yuzu::server::authz::VisibleSet{s};
+        return yuzu::server::DispatchCaller{.exec_visible = yuzu::server::authz::VisibleSet{s}};
     };
     ts.start_with_dispatch([&dispatched](const std::string&, const std::string&,
                                          const std::vector<std::string>&, const std::string&,
                                          const std::unordered_map<std::string, std::string>&,
-                                         const std::string&, const yuzu::server::authz::VisibleSet&)
+                                         const std::string&, const yuzu::server::DispatchCaller&)
                                -> std::pair<std::string, int> {
         dispatched = true;
         return {"cmd", 1};
@@ -7218,7 +7275,7 @@ TEST_CASE("MCP execute_bundle fans each step out + returns bundle_id", "[pg][mcp
     ts.start_with_dispatch([&calls](const std::string& plugin, const std::string& action,
                                     const std::vector<std::string>&, const std::string&,
                                     const std::unordered_map<std::string, std::string>&,
-                                    const std::string& correlation, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                                    const std::string& correlation, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         calls.push_back({plugin, action, correlation});
         return {"cmd-" + plugin + "-" + action, 1};
     });
@@ -7374,7 +7431,7 @@ TEST_CASE("MCP get_bundle_result surfaces dispatch_failed + succeeded=0", "[pg][
     ts.start_with_dispatch([](const std::string&, const std::string&,
                               const std::vector<std::string>&, const std::string&,
                               const std::unordered_map<std::string, std::string>&,
-                              const std::string&, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                              const std::string&, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         return {std::string{}, 0}; // reached no agent
     });
     auto disp = ts.call(
@@ -8402,7 +8459,7 @@ TEST_CASE("MCP: a schema-inexpressible violation never mints or consumes a ticke
     int dispatch_calls = 0;
     auto dispatch = [&](const std::string&, const std::string&, const std::vector<std::string>&,
                         const std::string&, const std::unordered_map<std::string, std::string>&,
-                        const std::string&, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                        const std::string&, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         ++dispatch_calls;
         return {"cmd-abc", 1};
     };
@@ -9257,7 +9314,7 @@ TEST_CASE("MCP 2405: non-string approval_id is rejected on declaring and non-dec
         auto dispatch = [](const std::string&, const std::string&, const std::vector<std::string>&,
                            const std::string&,
                            const std::unordered_map<std::string, std::string>&,
-                           const std::string&, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                           const std::string&, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
             return {"cmd-x", 1};
         };
         ts2.start_with_dispatch(dispatch, "supervised");
@@ -9291,7 +9348,7 @@ TEST_CASE("MCP 2405: string approval_id is tolerated on tools that do not declar
         auto dispatch = [&](const std::string&, const std::string&,
                             const std::vector<std::string>&, const std::string&,
                             const std::unordered_map<std::string, std::string>&,
-                            const std::string&, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                            const std::string&, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
             dispatched = true;
             return {"cmd-ok", 1};
         };
@@ -10225,12 +10282,12 @@ TEST_CASE("MCP quarantine_device ticket round-trip records + dispatches isolatio
     auto dispatch = [&](const std::string& plugin, const std::string& action,
                         const std::vector<std::string>& agent_ids, const std::string&,
                         const std::unordered_map<std::string, std::string>& params,
-                        const std::string&, const yuzu::server::authz::VisibleSet& exec_visible) -> std::pair<std::string, int> {
+                        const std::string&, const yuzu::server::DispatchCaller& caller) -> std::pair<std::string, int> {
         ts.last_dispatch_plugin = plugin;
         ts.last_dispatch_action = action;
         ts.last_dispatch_agent_ids = agent_ids;
         ts.last_dispatch_params = params;
-        ts.last_dispatch_exec_visible = exec_visible;
+        ts.last_dispatch_exec_visible = caller.exec_visible;
         return {"cmd-quar", 1};
     };
     ts.start_with_dispatch(dispatch, "supervised"); // Security:Execute requires approval (C2)
@@ -11470,7 +11527,7 @@ TEST_CASE("MCP Integration: execute_instruction progress bridge - GET-only mode 
         auto dispatch = [&](const std::string&, const std::string&,
                             const std::vector<std::string>&, const std::string&,
                             const std::unordered_map<std::string, std::string>&,
-                            const std::string&, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                            const std::string&, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
             return {"cmd-bridge", 2};
         };
         ts.start_with_dispatch(dispatch, "operator");
@@ -11597,7 +11654,7 @@ TEST_CASE("MCP Integration: execute_instruction progress bridge - GET-only mode 
         auto dispatch = [&](const std::string&, const std::string&,
                             const std::vector<std::string>&, const std::string&,
                             const std::unordered_map<std::string, std::string>&,
-                            const std::string&, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                            const std::string&, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
             return {"cmd-dup", 1};
         };
         ts.start_with_dispatch(dispatch, "operator");
@@ -11623,7 +11680,7 @@ TEST_CASE("MCP Integration: execute_instruction progress bridge - GET-only mode 
         auto dispatch = [&](const std::string&, const std::string&,
                             const std::vector<std::string>&, const std::string&,
                             const std::unordered_map<std::string, std::string>&,
-                            const std::string&, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                            const std::string&, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
             throw std::runtime_error("boom");
         };
         ts.start_with_dispatch(dispatch, "operator");
@@ -11641,7 +11698,7 @@ TEST_CASE("MCP Integration: execute_instruction progress bridge - GET-only mode 
         auto dispatch = [&](const std::string&, const std::string&,
                             const std::vector<std::string>&, const std::string&,
                             const std::unordered_map<std::string, std::string>&,
-                            const std::string&, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                            const std::string&, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
             return {"cmd-zero", 0};
         };
         ts.start_with_dispatch(dispatch, "operator");
@@ -11663,7 +11720,7 @@ TEST_CASE("MCP Integration: execute_instruction progress bridge - GET-only mode 
         auto dispatch = [&](const std::string&, const std::string&,
                             const std::vector<std::string>&, const std::string&,
                             const std::unordered_map<std::string, std::string>&,
-                            const std::string& execution_id, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                            const std::string& execution_id, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
             yuzu::server::AgentExecStatus a;
             a.agent_id = "agent-001";
             a.status = "success";
@@ -11698,7 +11755,7 @@ TEST_CASE("MCP Integration: execute_instruction progress bridge - GET-only mode 
         auto dispatch = [&](const std::string&, const std::string&,
                             const std::vector<std::string>&, const std::string&,
                             const std::unordered_map<std::string, std::string>&,
-                            const std::string&, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                            const std::string&, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
             return {"cmd-armfault", 2};
         };
         ts.start_with_dispatch(dispatch, "operator");
@@ -11726,7 +11783,7 @@ TEST_CASE("MCP Integration: execute_instruction progress bridge - GET-only mode 
         auto dispatch = [&](const std::string&, const std::string&,
                             const std::vector<std::string>&, const std::string&,
                             const std::unordered_map<std::string, std::string>&,
-                            const std::string&, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                            const std::string&, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
             return {"cmd-resvfault", 2};
         };
         ts.start_with_dispatch(dispatch, "operator");
@@ -11748,7 +11805,7 @@ TEST_CASE("MCP Integration: execute_instruction progress bridge - GET-only mode 
         auto dispatch = [&](const std::string&, const std::string&,
                             const std::vector<std::string>&, const std::string&,
                             const std::unordered_map<std::string, std::string>&,
-                            const std::string&, const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                            const std::string&, const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
             return {"cmd-subfault", 2};
         };
         ts.start_with_dispatch(dispatch, "operator");
@@ -11855,7 +11912,7 @@ TEST_CASE("streamed POST opt-out: --no-mcp-streamed-post falls back to a plain r
     auto dispatch = [&](const std::string&, const std::string&, const std::vector<std::string>&,
                         const std::string&, const std::unordered_map<std::string, std::string>&,
                         const std::string&,
-                        const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                        const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         dispatched = true;
         return {"cmd-dormant", 1};
     };
@@ -11935,7 +11992,7 @@ TEST_CASE("MCP Integration: execute_instruction streamed POST (2f PR 3b C8)",
     auto dispatch = [&](const std::string&, const std::string&, const std::vector<std::string>&,
                         const std::string&, const std::unordered_map<std::string, std::string>&,
                         const std::string&,
-                        const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                        const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         return {"cmd-streamed", 2};
     };
     const auto audit_has = [&](const std::string& row) {
@@ -12103,7 +12160,7 @@ TEST_CASE("MCP Integration: execute_instruction streamed POST (2f PR 3b C8)",
             [&](const std::string&, const std::string&, const std::vector<std::string>&,
                 const std::string&, const std::unordered_map<std::string, std::string>&,
                 const std::string&,
-                const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
                 inner = call_sse(exec_body(745, /*with_token=*/true)); // same id, re-entrant
                 return {"cmd-dup-inflight", 2};
             },
@@ -12287,7 +12344,7 @@ TEST_CASE("MCP Integration: execute_instruction streamed POST (2f PR 3b C8)",
             [&](const std::string&, const std::string&, const std::vector<std::string>&,
                 const std::string&, const std::unordered_map<std::string, std::string>&,
                 const std::string&,
-                const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
                 (void)bridge.request_cancel(sid, nlohmann::json(780));
                 return {"cmd-cancelled", 2};
             },
@@ -12309,7 +12366,7 @@ TEST_CASE("MCP Integration: execute_instruction streamed POST (2f PR 3b C8)",
             [](const std::string&, const std::string&, const std::vector<std::string>&,
                const std::string&, const std::unordered_map<std::string, std::string>&,
                const std::string&,
-               const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> { return {"cmd-none", 0}; },
+               const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> { return {"cmd-none", 0}; },
             "operator");
         ts.mcp.set_stream_bridge(&bridge);
 
@@ -12384,7 +12441,7 @@ TEST_CASE("MCP Integration: notifications/cancelled records cancel intent (2f PR
             [](const std::string&, const std::string&, const std::vector<std::string>&,
                const std::string&, const std::unordered_map<std::string, std::string>&,
                const std::string&,
-               const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> { return {"cmd-c9", 2}; },
+               const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> { return {"cmd-c9", 2}; },
             "operator");
         ts.mcp.set_stream_bridge(&bridge);
         // Reserve leaves the record kArming, which is the only phase that has
@@ -12406,7 +12463,7 @@ TEST_CASE("MCP Integration: notifications/cancelled records cancel intent (2f PR
             [](const std::string&, const std::string&, const std::vector<std::string>&,
                const std::string&, const std::unordered_map<std::string, std::string>&,
                const std::string&,
-               const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> { return {"cmd-c9", 2}; },
+               const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> { return {"cmd-c9", 2}; },
             "operator");
         ts.mcp.set_stream_bridge(&bridge);
 
@@ -12424,7 +12481,7 @@ TEST_CASE("MCP Integration: notifications/cancelled records cancel intent (2f PR
             [](const std::string&, const std::string&, const std::vector<std::string>&,
                const std::string&, const std::unordered_map<std::string, std::string>&,
                const std::string&,
-               const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> { return {"cmd-c9", 2}; },
+               const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> { return {"cmd-c9", 2}; },
             "operator");
         ts.mcp.set_stream_bridge(&bridge);
         REQUIRE(bridge.reserve(sid, "test-user", nlohmann::json(900), nlohmann::json("tok"),
@@ -12444,7 +12501,7 @@ TEST_CASE("MCP Integration: notifications/cancelled records cancel intent (2f PR
             [](const std::string&, const std::string&, const std::vector<std::string>&,
                const std::string&, const std::unordered_map<std::string, std::string>&,
                const std::string&,
-               const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> { return {"cmd-c9", 2}; },
+               const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> { return {"cmd-c9", 2}; },
             "operator");
         ts.mcp.set_stream_bridge(&bridge);
 
@@ -12478,7 +12535,7 @@ TEST_CASE("MCP Integration: notifications/cancelled records cancel intent (2f PR
             [](const std::string&, const std::string&, const std::vector<std::string>&,
                const std::string&, const std::unordered_map<std::string, std::string>&,
                const std::string&,
-               const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> { return {"cmd-c9live", 2}; },
+               const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> { return {"cmd-c9live", 2}; },
             "operator");
         ts.mcp.set_stream_bridge(&bridge);
 
@@ -12516,7 +12573,7 @@ TEST_CASE("MCP Integration: notifications/cancelled records cancel intent (2f PR
             [](const std::string&, const std::string&, const std::vector<std::string>&,
                const std::string&, const std::unordered_map<std::string, std::string>&,
                const std::string&,
-               const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> { return {"cmd-c9", 2}; },
+               const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> { return {"cmd-c9", 2}; },
             "operator");
         ts.mcp.set_stream_bridge(&bridge);
 
@@ -12573,7 +12630,7 @@ TEST_CASE("CH-5/CH-6: streamed POSTs debit the shared budget and leave the plain
     auto dispatch = [](const std::string&, const std::string&, const std::vector<std::string>&,
                        const std::string&, const std::unordered_map<std::string, std::string>&,
                        const std::string&,
-                       const yuzu::server::authz::VisibleSet&) -> std::pair<std::string, int> {
+                       const yuzu::server::DispatchCaller&) -> std::pair<std::string, int> {
         return {"cmd-ch56", 2};
     };
 

--- a/tests/unit/server/test_rest_bundle.cpp
+++ b/tests/unit/server/test_rest_bundle.cpp
@@ -50,6 +50,7 @@ yuzu::test::PgTestTemplate responsestore_tpl{"responsestore", [](const std::stri
 struct DispatchCall {
     std::string plugin, action, scope_expr, execution_id;
     std::vector<std::string> agent_ids;
+    yuzu::server::DispatchCaller caller;
 };
 
 struct AuditRow {
@@ -115,9 +116,9 @@ struct BundleHarness {
                                  const std::string& scope_expr,
                                  const std::unordered_map<std::string, std::string>&,
                                  const std::string& exec_id,
-                                 const yuzu::server::authz::VisibleSet&)
+                                 const yuzu::server::DispatchCaller& caller)
                 -> std::pair<std::string, int> {
-                calls.push_back({plugin, action, scope_expr, exec_id, agent_ids});
+                calls.push_back({plugin, action, scope_expr, exec_id, agent_ids, caller});
                 return {"cmd-" + plugin + "-" + action, dispatch_sent};
             };
         }
@@ -197,7 +198,8 @@ bool has_audit(const std::vector<AuditRow>& a, const std::string& verb, const st
 
 } // namespace
 
-TEST_CASE("POST /api/v1/bundles dispatches each step and returns 202 + execution_id",
+TEST_CASE("POST /api/v1/bundles dispatches each step and returns 202 + execution_id, "
+          "carrying the caller's principal (PLAN-006 parity)",
           "[pg][bundle][rest]") {
     YUZU_REQUIRE_PG_DB_TPL(db, responsestore_tpl);
     PgPool pool{{.conninfo = db.dsn(), .size = 4}};
@@ -218,6 +220,18 @@ TEST_CASE("POST /api/v1/bundles dispatches each step and returns 202 + execution
     CHECK(h.calls[0].agent_ids == std::vector<std::string>{"agent-1"});
     CHECK(h.calls[0].execution_id == exec_id); // all steps share the correlation id
     CHECK(h.calls[1].execution_id == exec_id);
+
+    // M11 (review finding, post-merge round): sibling dispatch surfaces
+    // (workflow, dashboard, REST purge) each have an explicit PLAN-006 case
+    // asserting the authenticated caller's PRINCIPAL reaches dispatch — the
+    // bundle surface, one of the two paths the original CRITICAL fix
+    // repaired, did not. The harness's dispatch_fn now captures `caller`
+    // (was previously an unnamed, ignored parameter), so a future
+    // regression that silently drops the principal on this surface fails
+    // here.
+    CHECK(h.calls[0].caller.principal == h.principal);
+    CHECK_FALSE(h.calls[0].caller.system);
+    CHECK(h.calls[1].caller.principal == h.principal);
 
     // Per-step audit verbs, device-scoped (governance F1), + the dispatch envelope.
     CHECK(has_audit(h.audits, "bundle.os_info.uptime", "Agent"));

--- a/tests/unit/server/test_rest_guaranteed_state.cpp
+++ b/tests/unit/server/test_rest_guaranteed_state.cpp
@@ -227,11 +227,11 @@ struct RestGsHarness {
             [this](const std::string& plugin, const std::string& action,
                    const std::vector<std::string>& ids, const std::string&,
                    const std::unordered_map<std::string, std::string>&, const std::string&,
-                   const yuzu::server::authz::VisibleSet& exec_visible)
+                   const yuzu::server::DispatchCaller& caller)
             -> std::pair<std::string, int> {
             last_live_plugin = plugin;
             last_live_action = action;
-            last_live_exec_visible = exec_visible;
+            last_live_exec_visible = caller.exec_visible;
             // Model what the production seam does to the Ids arm rather than
             // ignoring the set the route just derived — otherwise this fake
             // reports a successful dispatch whatever confinement decided, which
@@ -239,7 +239,7 @@ struct RestGsHarness {
             // every pre-existing case here is unaffected.
             const bool admitted =
                 std::all_of(ids.begin(), ids.end(), [&](const std::string& id) {
-                    return yuzu::server::authz::in_scope(exec_visible, id);
+                    return yuzu::server::authz::in_scope(caller.exec_visible, id);
                 });
             return {plugin + "-live", admitted ? live_sent : 0};
         };

--- a/tests/unit/server/test_rest_result_sets_async.cpp
+++ b/tests/unit/server/test_rest_result_sets_async.cpp
@@ -178,10 +178,10 @@ struct AsyncHarness {
                                  const std::string& scope_expr,
                                  const std::unordered_map<std::string, std::string>& params,
                                  const std::string& exec_id,
-                                 const yuzu::server::authz::VisibleSet& exec_visible)
+                                 const yuzu::server::DispatchCaller& caller)
                 -> std::pair<std::string, int> {
                 calls.push_back(
-                    {plugin, action, scope_expr, agent_ids, params, exec_id, exec_visible});
+                    {plugin, action, scope_expr, agent_ids, params, exec_id, caller.exec_visible});
                 if (dispatch_throws)
                     throw std::runtime_error("simulated dispatch failure");
                 return {"cmd-" + std::to_string(calls.size()), dispatch_sent};

--- a/tests/unit/server/test_rest_tar_purge.cpp
+++ b/tests/unit/server/test_rest_tar_purge.cpp
@@ -61,6 +61,11 @@ struct PurgeHarness {
     /// scoped_perm_fn above remains this route's PRIMARY authorization — the
     /// VisibleSet is a second, independent confinement check at the seam.
     yuzu::server::authz::VisibleSet last_exec_visible;
+    /// PR1.9c: the WHOLE caller the route handed to dispatch. `principal` is
+    /// the half that matters — `build_classified_command` refuses an empty one
+    /// as `AnonymousOperator` before the legacy-open bypass, so a route that
+    /// derives a visible set but no identity dispatches to nobody.
+    yuzu::server::DispatchCaller last_caller;
     /// The VisibleSet the wired derivation returns; nullopt = unfiltered.
     yuzu::server::authz::VisibleSet exec_visible_override{};
     /// false → register with an EMPTY `exec_visible_fn`, modelling a deployment
@@ -99,9 +104,10 @@ struct PurgeHarness {
             [this](const std::string& plugin, const std::string& action,
                    const std::vector<std::string>& ids, const std::string&,
                    const std::unordered_map<std::string, std::string>& params, const std::string&,
-                   const yuzu::server::authz::VisibleSet& exec_visible)
+                   const yuzu::server::DispatchCaller& caller)
             -> std::pair<std::string, int> {
-            last_exec_visible = exec_visible;
+            last_exec_visible = caller.exec_visible;
+            last_caller = caller;
             calls.push_back({plugin, action, ids, params});
             // Model what the production seam does to the Ids arm, rather than
             // ignoring the set the route just handed us: a target the caller
@@ -112,7 +118,7 @@ struct PurgeHarness {
             // pre-existing case in this file is unaffected.
             const bool admitted =
                 std::all_of(ids.begin(), ids.end(), [&](const std::string& id) {
-                    return yuzu::server::authz::in_scope(exec_visible, id);
+                    return yuzu::server::authz::in_scope(caller.exec_visible, id);
                 });
             return {"cmd-" + std::to_string(calls.size()), admitted ? dispatch_sent : 0};
         };
@@ -281,4 +287,41 @@ TEST_CASE("REST purge: offline agent (0 reached) → 404 after dispatch attempt"
     h.post(R"({"device_id":"dev-A","source":"process"})", st);
     CHECK(st == 404);
     REQUIRE(h.calls.size() == 1); // dispatch was attempted, reached 0 agents
+}
+
+// ── PR1.9c regression: the PRODUCTION wiring must supply a principal ─────────
+//
+// This is the test the branch review's CRITICAL slipped past. `RestApiV1`'s
+// dispatch callback used to end in a bare `VisibleSet`, so the route derived a
+// confinement set and NO identity; `ServerImpl::build_classified_command`
+// refuses an empty `DispatchCaller::principal` as `AnonymousOperator` BEFORE
+// the legacy-open/RBAC-off bypass, so every REST v1 dispatch reached zero
+// agents and surfaced as `503 "device offline"` against a healthy fleet.
+//
+// Nothing caught it because the existing coverage tests the two halves apart:
+// `test_dispatch_chokepoint.cpp` proves the pure function REFUSES an empty
+// principal, and every REST/MCP suite injects a fake dispatch lambda, so no
+// test ever asked whether the real route SUPPLIES one. This case closes that
+// seam — it drives the genuine `resolve_secondary_caller` path in
+// rest_api_v1.cpp through a real `auth_fn` and asserts the identity actually
+// arrives at the dispatch boundary.
+TEST_CASE("REST purge: the route hands dispatch a NON-EMPTY principal (anonymous-operator "
+          "regression)",
+          "[server][tar][purge][rest]") {
+    PurgeHarness h;
+    int st = 0;
+    h.post(R"({"device_id":"dev-A","source":"tcp"})", st);
+    REQUIRE(st == 202); // purge is accepted-and-dispatched, like its siblings above
+    REQUIRE(h.calls.size() == 1);
+
+    // The harness authenticates as "purge-op"; the route must carry that
+    // through, not a default-constructed caller. An empty principal here means
+    // production dispatch is dead on arrival regardless of what this test's
+    // fake returns for `sent`.
+    CHECK_FALSE(h.last_caller.principal.empty());
+    CHECK(h.last_caller.principal == "purge-op");
+    // `system` must stay false: this is an operator dispatch, and a true here
+    // would route it under system authority — bypassing the system_reserved
+    // guard the chokepoint applies only to non-system callers.
+    CHECK_FALSE(h.last_caller.system);
 }

--- a/tests/unit/server/test_schedule_runner.cpp
+++ b/tests/unit/server/test_schedule_runner.cpp
@@ -45,6 +45,7 @@ struct DispatchCall {
     std::string action;
     std::string scope;
     std::string execution_id;
+    DispatchCaller caller;
 };
 
 struct Harness {
@@ -74,12 +75,22 @@ struct Harness {
                   [this](const std::string& plugin, const std::string& action,
                          const std::vector<std::string>&, const std::string& scope,
                          const std::unordered_map<std::string, std::string>&,
-                         const std::string& execution_id) -> std::pair<std::string, int> {
+                         const std::string& execution_id,
+                         const DispatchCaller& caller) -> std::pair<std::string, int> {
                       if (throw_on_dispatch)
                           throw std::runtime_error("dispatch boom");
-                      calls.push_back({plugin, action, scope, execution_id});
+                      calls.push_back({plugin, action, scope, execution_id, caller});
                       return {"cmd-" + std::to_string(calls.size()), reach};
                   },
+              // #3133 review fix: resolve_caller re-resolves a real,
+              // non-system caller from the schedule's creator at fire time —
+              // this fake mirrors that shape rather than a stale/system
+              // caller, so a regression back to system=true is observable
+              // via the DispatchCall.caller field above.
+              .resolve_caller =
+                  [](const std::string& username) {
+                  return DispatchCaller{.principal = username, .system = false};
+              },
           }) {
         engine.create_tables();
         tracker.create_tables();
@@ -156,6 +167,13 @@ TEST_CASE("ScheduleRunner: due interval schedule fires once and advances", "[sch
     // schedule into a no-op that still advances and still logs a fire, which is
     // the worst shape a regression here could take: unattended and quiet.
     CHECK(h.calls[0].scope == "__all__");
+    // #3133 review fix: the dispatched caller must be the schedule's creator,
+    // re-resolved via resolve_caller — NEVER system=true. Without this
+    // assertion a regression back to a hardcoded system caller (the exact
+    // bug the review found) would pass every other check in this file
+    // silently, since none of them inspect the caller at all.
+    CHECK_FALSE(h.calls[0].caller.system);
+    CHECK(h.calls[0].caller.principal == "admin");
 
     // Tracked execution row, targeted count recorded.
     auto exec = h.tracker.get_execution(h.calls[0].execution_id);

--- a/tests/unit/server/test_tar_tree_routes.cpp
+++ b/tests/unit/server/test_tar_tree_routes.cpp
@@ -10,6 +10,7 @@
 ///   * the cache token is CSPRNG and an entropy failure fails closed (no cache entry),
 ///   * preset/os are neutralized in the audit detail.
 
+#include "authz_model.hpp"
 #include "secure_random.hpp"
 #include "tar_tree_routes.hpp"
 #include "test_route_sink.hpp"
@@ -72,6 +73,7 @@ struct TarHarness {
         std::string action, result, target_id, detail;
     };
     std::vector<AuditRow> audit_log;
+    DispatchCaller last_dispatch_caller; // #3133: observes what dispatch actually received
 
     TarHarness() {
         auto auth = [this](const httplib::Request&,
@@ -106,12 +108,24 @@ struct TarHarness {
         // keyed off the SQL the route built, so the responses stub can disambiguate.
         auto dispatch = [this](const std::string&, const std::string&, const std::vector<std::string>&,
                                const std::string&,
-                               const std::unordered_map<std::string, std::string>& params)
+                               const std::unordered_map<std::string, std::string>& params,
+                               const DispatchCaller& caller)
             -> std::pair<std::string, int> {
+            last_dispatch_caller = caller;
             const auto it = params.find("sql");
             const bool is_proc =
                 it != params.end() && it->second.find("$Process_Live") != std::string::npos;
             return {is_proc ? kProcCmd : kTcpCmd, 1};
+        };
+        // #3133 review fix: mirrors the production idiom (resolve the session,
+        // derive a real caller) closely enough for this harness's simplified
+        // auth — never a synthesized system caller. An unresolved session
+        // (empty session_user) fails closed with an empty principal, same
+        // contract every production CallerFn documents.
+        auto caller_fn = [this](const httplib::Request&) -> DispatchCaller {
+            if (session_user.empty())
+                return DispatchCaller{.exec_visible = authz::deny_all()};
+            return DispatchCaller{.principal = session_user, .system = false};
         };
         auto responses = [this](const std::string& cmd,
                                  const std::string& /*agent_id*/) -> std::vector<DexAgentResponse> {
@@ -135,7 +149,8 @@ struct TarHarness {
                 throw std::runtime_error("audit DB write blew up");
             return audit_ok; // DexRoutes::AuditFn (aliased by TarTreeRoutes) is bool-returning (#1549)
         };
-        routes.register_routes(sink, auth, perm, scoped, devices, lookup, dispatch, responses, audit);
+        routes.register_routes(sink, auth, perm, scoped, devices, lookup, dispatch, responses, audit,
+                               caller_fn);
     }
 
     // Drive /result directly (skips /run; the result route reads pcmd/tcmd from the
@@ -424,6 +439,39 @@ TEST_CASE("tar routes: a throwing audit_fn is caught + flags Sec-Audit-Failed at
         CHECK(r->status == 200);
         CHECK(r->get_header_value("Sec-Audit-Failed") == "true");
         CHECK(h.find_audit("tar.sources.configure", "dispatched") != nullptr);
+    }
+}
+
+// #3133 external PR review finding: this route gated only Infrastructure:Read
+// before dispatching the mutating, Infrastructure:Write-classified
+// tar.configure action through a hardcoded system=true closure — bypassing
+// the chokepoint's per-action authorization entirely regardless of the
+// caller's actual grants. The fix threads the real, non-system caller
+// through every dispatch in this class; this pins it at the exact route the
+// review flagged, and the four others sharing the same dispatch_fn_ member.
+TEST_CASE("tar routes: every dispatch carries the real caller, never a system one",
+         "[tar][routes][security]") {
+    TarHarness h;
+    h.session_user = "alice";
+
+    SECTION("process-tree /run") {
+        // /result only polls pre-canned command ids (run_result() skips /run
+        // by design, per the harness's own doc comment) — /run is the
+        // handler that actually calls dispatch_fn_.
+        (void)h.sink.Get("/fragments/tar/process-tree/run?device=dev-A&preset=10m");
+        CHECK_FALSE(h.last_dispatch_caller.system);
+        CHECK(h.last_dispatch_caller.principal == "alice");
+    }
+    SECTION("capture-sources/push — tar.configure") {
+        (void)h.sink.Post(
+            "/fragments/tar/capture-sources/push?device=dev-A&changes=process%3Don", "");
+        CHECK_FALSE(h.last_dispatch_caller.system);
+        CHECK(h.last_dispatch_caller.principal == "alice");
+    }
+    SECTION("capture-sources/load — tar.status + tar.compatibility") {
+        (void)h.sink.Get("/fragments/tar/capture-sources/load?device=dev-A");
+        CHECK_FALSE(h.last_dispatch_caller.system);
+        CHECK(h.last_dispatch_caller.principal == "alice");
     }
 }
 

--- a/tests/unit/server/test_workflow_routes.cpp
+++ b/tests/unit/server/test_workflow_routes.cpp
@@ -139,11 +139,17 @@ struct ExecHarness {
     /// into the dispatch stub (the confinement the production dispatch_confined
     /// seam then applies). Mirrors test_mcp_server.cpp's last_dispatch_exec_visible.
     yuzu::server::authz::VisibleSet last_dispatch_exec_visible;
-    /// K-R7-02: the reassignable per-request exec-visible derivation. Default
-    /// returns nullopt (UNFILTERED) so every pre-existing workflow test keeps the
+    /// PLAN-006: the full DispatchCaller (identity + exec_visible) the execute
+    /// handler threaded into the dispatch stub, so a test can assert the
+    /// principal half independently of last_dispatch_exec_visible above.
+    yuzu::server::DispatchCaller last_dispatch_caller;
+    /// K-R7-02 / PLAN-006: the reassignable per-request DispatchCaller
+    /// derivation. Default returns a DispatchCaller whose exec_visible is
+    /// nullopt (UNFILTERED) so every pre-existing workflow test keeps the
     /// full-fleet path; a confinement test overrides it with a specific set.
-    WorkflowRoutes::ExecVisibleFn exec_visible_fn{
-        [](const httplib::Request&) { return yuzu::server::authz::VisibleSet{}; }};
+    WorkflowRoutes::CallerFn caller_fn{[](const httplib::Request&) -> yuzu::server::DispatchCaller {
+        return yuzu::server::DispatchCaller{.exec_visible = yuzu::server::authz::VisibleSet{}};
+    }};
     WorkflowRoutes routes;
 
     /// Per-process monotonic counter for execution IDs. Replaces the prior
@@ -157,7 +163,7 @@ struct ExecHarness {
     /// bus so SSE-handler 503-on-no-bus tests can exercise the path where
     /// the route is registered but the underlying bus is intentionally
     /// not wired (governance qe-S1).
-    /// `wire_exec_visible = false` registers with an EMPTY ExecVisibleFn so the
+    /// `wire_exec_visible = false` registers with an EMPTY CallerFn so the
     /// production execute handler's own fail-closed branch (unwired → present-
     /// empty deny-all) is exercised (K-R7-02).
     bool wire_exec_visible{true};
@@ -239,15 +245,17 @@ struct ExecHarness {
                                    const std::string& scope_expr,
                                    const std::unordered_map<std::string, std::string>&,
                                    const std::string& execution_id,
-                                   const yuzu::server::authz::VisibleSet& exec_visible)
+                                   const yuzu::server::DispatchCaller& caller)
             -> std::pair<std::string, int> {
             last_dispatch_execution_id = execution_id;
             // #2500: capture what the sink was actually asked to target.
             ++dispatch_calls;
             last_dispatch_agent_ids = agent_ids;
             last_dispatch_scope = scope_expr;
-            // K-R7-02: capture the confinement threaded into dispatch.
-            last_dispatch_exec_visible = exec_visible;
+            // K-R7-02 / PLAN-006: capture the confinement + identity threaded
+            // into dispatch.
+            last_dispatch_exec_visible = caller.exec_visible;
+            last_dispatch_caller = caller;
             return {dispatch_cmd_override, dispatch_sent_override};
         };
 
@@ -263,12 +271,13 @@ struct ExecHarness {
         wf_deps.execution_tracker = tracker.get();
         wf_deps.instruction_store = instructions.get();
         wf_deps.command_dispatch_fn = cmd_dispatch;
-        // K-R7-02: wire the exec-visible derivation (or leave it EMPTY so the
-        // handler's own fail-closed path runs). The wired form delegates to the
-        // reassignable member so a test can override it after construction.
+        // K-R7-02 / PLAN-006: wire the DispatchCaller derivation (or leave it
+        // EMPTY so the handler's own fail-closed path runs). The wired form
+        // delegates to the reassignable member so a test can override it after
+        // construction.
         if (wire_exec_visible) {
-            wf_deps.exec_visible_fn = [this](const httplib::Request& req) {
-                return exec_visible_fn ? exec_visible_fn(req) : yuzu::server::authz::VisibleSet{};
+            wf_deps.caller_fn = [this](const httplib::Request& req) -> yuzu::server::DispatchCaller {
+                return caller_fn ? caller_fn(req) : yuzu::server::DispatchCaller{};
             };
         }
         wf_deps.response_store = responses.get();
@@ -1826,8 +1835,9 @@ TEST_CASE("K-R7-02 — instruction execute threads the caller's exec_visible int
     h.dispatch_cmd_override = "cmd-x";
     h.dispatch_sent_override = 1;
     // Service-scoped confinement: the caller can see only agent-A.
-    h.exec_visible_fn = [](const httplib::Request&) {
-        return yuzu::server::authz::VisibleSet{std::unordered_set<std::string>{"agent-A"}};
+    h.caller_fn = [](const httplib::Request&) -> yuzu::server::DispatchCaller {
+        return yuzu::server::DispatchCaller{
+            .exec_visible = yuzu::server::authz::VisibleSet{std::unordered_set<std::string>{"agent-A"}}};
     };
     // Target agent-B (an id-list arm), OUTSIDE the caller's visible set.
     auto res = h.sink.Post("/api/instructions/def-CONF1/execute", R"({"agent_ids":["agent-B"]})");
@@ -1850,8 +1860,9 @@ TEST_CASE("K-R7-02 — instruction execute broadcast still carries the caller's 
     h.make_def("def-CONF3", "conf3");
     h.dispatch_cmd_override = "cmd-z";
     h.dispatch_sent_override = 1;
-    h.exec_visible_fn = [](const httplib::Request&) {
-        return yuzu::server::authz::VisibleSet{std::unordered_set<std::string>{"agent-A"}};
+    h.caller_fn = [](const httplib::Request&) -> yuzu::server::DispatchCaller {
+        return yuzu::server::DispatchCaller{
+            .exec_visible = yuzu::server::authz::VisibleSet{std::unordered_set<std::string>{"agent-A"}}};
     };
     // Omitted target → the handler names __all__ (broadcast). Even that composes
     // with the visible set.
@@ -1866,7 +1877,7 @@ TEST_CASE("K-R7-02 — instruction execute broadcast still carries the caller's 
 
 TEST_CASE("K-R7-02 — instruction execute FAILS CLOSED when the exec-visible derivation is unwired",
           "[pg][workflow][executions][execute][scope][security]") {
-    // Genuinely UNWIRED ExecVisibleFn: the production handler must hand dispatch
+    // Genuinely UNWIRED CallerFn: the production handler must hand dispatch
     // a PRESENT EMPTY visible set (deny all), never nullopt (unfiltered).
     YUZU_REQUIRE_PG_DB_TPL(db, responsestore_tpl);
     PgPool pool{{.conninfo = db.dsn(), .size = 4}};
@@ -1880,6 +1891,46 @@ TEST_CASE("K-R7-02 — instruction execute FAILS CLOSED when the exec-visible de
     CHECK(h.dispatch_calls == 1);
     REQUIRE(h.last_dispatch_exec_visible.has_value()); // PRESENT (deny), not nullopt
     CHECK(h.last_dispatch_exec_visible->empty());       // EMPTY → production sink reaches no one
+}
+
+// PLAN-006: the sibling of the confinement handoff test above, asserting the
+// IDENTITY half of DispatchCaller — a wired CallerFn's principal must reach
+// the dispatch seam, not just its exec_visible.
+TEST_CASE("PLAN-006 — instruction execute threads the caller's principal into dispatch",
+          "[pg][workflow][executions][execute][scope]") {
+    YUZU_REQUIRE_PG_DB_TPL(db, responsestore_tpl);
+    PgPool pool{{.conninfo = db.dsn(), .size = 4}};
+    ExecHarness h(pool);
+    h.make_def("def-CONF4", "conf4");
+    h.dispatch_cmd_override = "cmd-p";
+    h.dispatch_sent_override = 1;
+    h.caller_fn = [](const httplib::Request&) -> yuzu::server::DispatchCaller {
+        return yuzu::server::DispatchCaller{.principal = "wf-operator", .principal_role = "admin"};
+    };
+    auto res = h.sink.Post("/api/instructions/def-CONF4/execute", R"({"agent_ids":["agent-A"]})");
+    REQUIRE(res);
+    CHECK(res->status == 200);
+    CHECK(h.dispatch_calls == 1);
+    CHECK(h.last_dispatch_caller.principal == "wf-operator");
+    CHECK(h.last_dispatch_caller.principal_role == "admin");
+    CHECK_FALSE(h.last_dispatch_caller.system);
+}
+
+TEST_CASE("PLAN-006 — instruction execute FAILS CLOSED on an empty principal when unwired",
+          "[pg][workflow][executions][execute][scope][security]") {
+    // Genuinely UNWIRED CallerFn: the production handler must hand dispatch an
+    // EMPTY principal alongside a present-empty exec_visible.
+    YUZU_REQUIRE_PG_DB_TPL(db, responsestore_tpl);
+    PgPool pool{{.conninfo = db.dsn(), .size = 4}};
+    ExecHarness h(pool, /*with_bus=*/true, /*budget=*/nullptr, /*wire_exec_visible=*/false);
+    h.make_def("def-CONF5", "conf5");
+    h.dispatch_cmd_override = "cmd-pfc";
+    h.dispatch_sent_override = 1;
+    auto res = h.sink.Post("/api/instructions/def-CONF5/execute", R"({"agent_ids":["agent-A"]})");
+    REQUIRE(res);
+    CHECK(res->status == 200);
+    CHECK(h.dispatch_calls == 1);
+    CHECK(h.last_dispatch_caller.principal.empty());
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1904,8 +1955,9 @@ TEST_CASE("CDX-FV-03 — workflow execute threads the caller's exec_visible into
     h.dispatch_cmd_override = "cmd-wf1";
     h.dispatch_sent_override = 1;
     // Service-scoped confinement: the caller can see only agent-A.
-    h.exec_visible_fn = [](const httplib::Request&) {
-        return yuzu::server::authz::VisibleSet{std::unordered_set<std::string>{"agent-A"}};
+    h.caller_fn = [](const httplib::Request&) -> yuzu::server::DispatchCaller {
+        return yuzu::server::DispatchCaller{
+            .exec_visible = yuzu::server::authz::VisibleSet{std::unordered_set<std::string>{"agent-A"}}};
     };
 
     // Target agent-B — an id-list arm OUTSIDE the caller's visible set. The
@@ -1923,7 +1975,7 @@ TEST_CASE("CDX-FV-03 — workflow execute threads the caller's exec_visible into
 
 TEST_CASE("CDX-FV-03 — workflow execute FAILS CLOSED when the exec-visible derivation is unwired",
           "[pg][workflow][executions][execute][scope][security]") {
-    // Genuinely UNWIRED ExecVisibleFn. ADR-0033 §1: the handler must hand step
+    // Genuinely UNWIRED CallerFn. ADR-0033 §1: the handler must hand step
     // dispatch a PRESENT EMPTY visible set (deny all), never nullopt — nullopt
     // means UNFILTERED at the shared seam, i.e. the whole fleet.
     YUZU_REQUIRE_PG_DB_TPL(db, responsestore_tpl);


### PR DESCRIPTION
<!-- Placeholders to fill before raising:
     PR #TBD-n — PR numbers in the Stack ladder diagram, filled at raise time
-->
## Contents

- [Headline](#headline)
- [Stack](#stack)
- [Description](#description)
- [Impact](#impact)
- [Testing & verification](#testing--verification)
- [Related items](#related-items)

## Headline

Until now a command could reach an agent through several doors, each with its own idea
of what checking meant — and some doors dispatched under blanket system trust with no
per-caller check at all.

This PR installs the single checkpoint: every command is classified against the
registry from the previous rung and authorized against the real caller's identity
before it can be sent, and the type system makes it impossible to hand-build a command
around the checkpoint. Every operator-facing surface — the API, the dashboard,
scheduled workflows, the operator console, bundles, and automatic deployment — now
carries the true caller through to that decision.

This is the security-review rung of the ladder: the enforcement heart of the whole
stack, kept small so it can be reviewed line by line. It also closes a real gap a
governance review found — automatic deployment previously dispatched with no per-device
confinement, letting an operator scoped to part of the fleet trigger deployments
outside it.

## Stack

```
dev
 └─ feat/1.9a-dispatch-tag-wire          (PR #3131)
     └─ feat/1.9b-capability-registry    (PR #3132)
         └─ feat/1.9c-dispatch-chokepoint   ◀── THIS PR
             └─ feat/1.5-plugin-config-plane
                 └─ feat/1.6a-upload-grants
                     └─ feat/1.6b-content-dist-uploader
                         └─ feat/1.5-1.6-operator-surface
dev
 └─ feat/1.10-abi4-descriptors           (parallel — no stack dependency)
```

**Merge mechanics**

- Base now: `feat/1.9b-capability-registry`. This PR must not be merged before its
  predecessor.
- On the predecessor's merge: this PR is retargeted to `dev`, rebased, and only then
  is auto-merge armed.
- Depends on this PR: `feat/1.5-plugin-config-plane`.
- Review order: the stack reviews bottom-up; this PR is the security-review center of
  gravity — budget review depth here.

Rung 3 of an eight-PR split of the verified integration branch
`integr/wave1-completion` @ `48aecb08` (raised whole as #3115, closed unmerged as too
large to review; it remains the integration reference and carries the full granular
history).

- Hand-carved seams, named honestly:
  1. The kill-switch call site ships in its designed legacy-open form — an empty
     `std::function` meaning "no kill-switch provider configured" — which is exactly
     the seam it was extracted to be. The plugin-config rung (next) rewrites those
     ~10 lines to the store-backed, fail-closed form. Nothing here pretends to
     enforce a kill switch yet.
  2. The e2e API script lands 17 of its final 18 lines (the three dispatch deny
     counters); the one-line schedule-arming assert lands with the plugin-config rung
     that introduces that metric.
- Every rung is a byte-exact carve of `48aecb08`; the split converges to that tree —
  see Testing & verification.

## Description

- **Summary** — `ServerImpl::build_classified_command` becomes the one place a
  `CommandRequest` is built: classify via the capability registry, authorize the
  resolved securable/operation against the caller, return a `ClassifiedCommand`.
  `DispatchCaller` (principal, role, `Execution:Execute` visible set, explicit
  `system` flag) is threaded through REST v1, the dashboard, scheduled workflows, MCP,
  REST bundles, and `/auto` deployment. Includes the deployment/e2e glue, deployment
  docs, engine-level caller-threading regression tests, and `docs/authz-model.md`
  flipping to "wired". Diffstat: +2,932/−533 over 42 files.
- **Rationale & drivers** — A chokepoint is the only structure that guarantees a
  command reaching an agent was actually classified and authorized; per-surface checks
  drift. Fail-closed posture throughout: an empty principal is `AnonymousOperator` and
  is denied; genuine background dispatchers must say so explicitly; fail-closed
  constructions write an explicit deny-all visible set rather than relying on
  defaults.
- **Technical overview** —
  - `ClassifiedCommand`'s private constructor means
    `AgentRegistry::send_to`/`send_to_all` cannot accept a hand-built
    `pb::CommandRequest`, syntactically valid dispatch tag or not.
  - The wire is built from the classification's canonical plugin/action names, closing
    the authorize-as-one-casing, execute-as-another gap.
  - `/auto` deployment now populates the caller's `Execution:Execute` visible set —
    the governance-found HIGH: it previously dispatched under system authority with no
    per-device confinement.
  - Gateway deny counters are pre-registered, so "the check never ran" is
    distinguishable from "no denials".
  - Caller-threading regression tests assert the dispatch paths carry a real,
    non-empty principal — at the route level where a harness exists (TAR purge), and
    at the engine layer for `/auto` deployment (`advance()` threads the caller it is
    given; `DeploymentRoutes`' route-level session extraction has no in-repo harness
    and is exercised by the e2e surface, not unit tests). The suite was previously
    green only because tests injected fake dispatch lambdas.
  - Eight dev-side test files widen fake dispatch signatures to match.

## Impact

- **Capabilities** — new: the dispatch chokepoint and caller threading across every
  operator-facing dispatch surface; deployment docs (server-admin, preflight, SOC2)
  updated to match.
- **Security:** every dispatch surface — including `/auto` deployment as of this PR —
  authorizes against the real caller's identity and `Execution:Execute` visibility
  instead of some surfaces dispatching under system trust. Anonymous callers are
  denied fail-closed. Bypassing the checkpoint is structurally impossible, not
  convention. Canonical wire names remove a classification/wire mismatch.
- **Reliability:** deny counters pre-registered — the gate's silence is now
  observable, not ambiguous.

## Testing & verification

**Verification transfer — the full gate suite ran once, at the final tree of this
stack.**

- This PR is a byte-exact carve of `integr/wave1-completion` @ `48aecb08`, the tree
  where all gates ran and passed:
  - Three-way review — external branch review, `/code-review`, `/adversarial-review`
    (all originally BLOCK; every finding remediated on the branch) — plus the full
    8-gate `/governance` pipeline, whose one independently-verified HIGH (the `/auto`
    deployment confinement gap) is fixed in this very rung.
  - `/test` on two hosts: macOS full C++ suite, and the-rig (Windows/MSVC full surface,
    build clean; Postgres-tagged suites 1,910 cases / 60,459 assertions; gateway eunit
    218/218; server/agent/TAR suites in full) — zero failures on every the-rig suite;
    macOS green apart from the documented pre-existing APFS `wal_sidecar_present`
    cases (environmental, Linux CI is the enforcement point).
- The split converges to that exact tree: the union of the stack tip (`02daf462`) and
  `feat/1.10-abi4-descriptors` (`a7239ce6`) is tree-identical to `48aecb08` — verified
  by merge + `git diff` (empty). One deterministic check that no line was lost or
  altered in the carve.

**This rung's own checks**

- Incremental build clean (`ninja -k 0`).
- Targeted suites, all green, all zero failures:
  - chokepoint suite — 27 cases / 267 assertions;
  - command-capability suite — 24 cases / 1,416 assertions;
  - dispatch suites — 84 cases / 1,651 assertions;
  - catalogue completeness gate (Python) — 6/6.

## Related items

- Roadmap item 1.9 — this rung completes it.
- #2783 — third-party plugin classification: referenced, not addressed here.
- Integration reference: closed #3115.
- Changelog fragments: the remaining `1.9-*` fragments, including the
  dispatch-chokepoint security fragment carrying the deployment-ordering warning
  (upgrade the gateway before the server, or routed dispatches are denied), plus the
  deployment fragments.

