### PR TITLE
feat(agents): content_dist authenticated uploader — grant-redeeming chunked upload client (PR1.6b)

### DIFF
--- a/agents/plugins/content_dist/src/content_dist_plugin.cpp
+++ b/agents/plugins/content_dist/src/content_dist_plugin.cpp
@@ -766,6 +766,14 @@ private:
                 "error|missing required parameters: path, grant_id, grant_secret");
             return 1;
         }
+        // #3136 minor: local grammar precheck. The server already fails
+        // closed (grant_unknown) on a malformed credential, so this only
+        // improves the error the caller sees before a doomed round-trip.
+        if (!up::is_valid_credential_parts(grant_id, grant_secret)) {
+            ctx.write_output("error|grant_id/grant_secret do not match the expected credential "
+                             "shape (32/64 lowercase hex)");
+            return 1;
+        }
 
         fs::path file_path{std::string{path_str}};
         std::error_code ec;
@@ -792,6 +800,15 @@ private:
             }
             auto file_str = file_path.string();
             auto base_str = canon_base.string();
+            // #3136 minor: a base_dir that IS the filesystem root (e.g. "/")
+            // canonicalizes to a string already ending in a separator, so
+            // requiring file_str[base_str.size()] to ALSO be a separator
+            // rejected every child path — index base_str.size() lands one
+            // character past the separator base_str already carries. Strip
+            // one trailing separator first so the boundary check below is
+            // uniform regardless of whether the base itself ends in one.
+            if (!base_str.empty() && (base_str.back() == '/' || base_str.back() == '\\'))
+                base_str.pop_back();
             if (file_str.size() < base_str.size() ||
                 file_str.compare(0, base_str.size(), base_str) != 0 ||
                 (file_str.size() > base_str.size() && file_str[base_str.size()] != '/' &&
@@ -813,6 +830,12 @@ private:
         try {
             max_mb = std::stoi(std::string{max_str});
         } catch (...) {}
+        // #3136 minor: clamp to the [1,1000] range t2_capabilities.yaml
+        // declares for this parameter. The server's own declared-size
+        // enforcement is authoritative regardless, but a caller bypassing
+        // YAML validation should still get a locally-consistent precheck
+        // rather than an unbounded or non-positive local cap.
+        max_mb = std::clamp(max_mb, 1, 1000);
         if (static_cast<std::uintmax_t>(file_size) > static_cast<std::uintmax_t>(max_mb) * 1024 * 1024) {
             ctx.write_output(
                 std::format("error|file too large ({} bytes, max {} MB)", file_size, max_mb));
@@ -900,6 +923,13 @@ private:
 
         if (session->chunk_max_bytes <= 0) {
             ctx.write_output("error|server returned an invalid chunk_max_bytes");
+            return 1;
+        }
+        // #3136 minor: same local grammar precheck as the grant credential
+        // above, applied to the server-returned session credential before
+        // it's used to build every subsequent request's session header.
+        if (!up::is_valid_credential_parts(session->upload_id, session->session_secret)) {
+            ctx.write_output("error|server returned a session credential of unexpected shape");
             return 1;
         }
 

--- a/agents/plugins/content_dist/src/content_dist_plugin.cpp
+++ b/agents/plugins/content_dist/src/content_dist_plugin.cpp
@@ -6,22 +6,30 @@
  *   "execute_staged" — Execute a previously staged file.
  *   "list_staged"    — List files in the staging directory.
  *   "cleanup"        — Remove staged files older than N hours.
- *   "upload_file"    — Upload a local file to the Yuzu server.
+ *   "upload_file"    — Upload a local file to the Yuzu server via the
+ *                       one-time upload-grant + authenticated chunked
+ *                       receive protocol (PR1.6, CC-06).
  *
- * Security: uses cpp-httplib for downloads (no shell invocation).
+ * Security: uses cpp-httplib for downloads/uploads (no shell invocation).
  *           execute_staged uses CreateProcessW/fork+execvp (no shell interpretation).
  *           Args validated to block shell metacharacters.
  */
 
 #include <yuzu/plugin.hpp>
 
+#include "content_dist_upload_parsers.hpp"
+
+#include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <cstring>
 #include <filesystem>
 #include <format>
 #include <fstream>
+#include <optional>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <vector>
 
 #ifdef _WIN32
@@ -48,6 +56,7 @@
 #include <httplib.h>
 
 namespace fs = std::filesystem;
+namespace up = yuzu::content_dist::upload;
 
 namespace {
 
@@ -67,44 +76,171 @@ fs::path staging_dir() {
     return dir;
 }
 
+// Incremental SHA-256: `update()` any number of times over buffers fed to it
+// in order, `finalize()` once at the end. Extracted out of what used to be a
+// single whole-stream `sha256_stream()` so `do_upload` (below) can feed it
+// the EXACT buffer just transmitted, immediately once the server has
+// acknowledged it — binding the committed digest to bytes actually sent
+// over the wire rather than a second, independent re-read of the file after
+// the fact (#P7-003: a second read pass cannot see a write that lands, via
+// another handle, in the gap between "chunk sent" and "file re-read").
+#ifdef _WIN32
+class IncrementalSha256 {
+public:
+    IncrementalSha256() { init(); }
+    ~IncrementalSha256() { destroy(); }
+    IncrementalSha256(const IncrementalSha256&) = delete;
+    IncrementalSha256& operator=(const IncrementalSha256&) = delete;
+
+    /// Restart the digest so it covers nothing. An incremental hash cannot be
+    /// REWOUND, so this is how `do_upload` repairs its digest when a server
+    /// resync moves the acknowledged offset (see `rehash_prefix` there).
+    void reset() {
+        destroy();
+        init();
+    }
+
+    /// False once ANY crypto call has failed. Every subsequent operation
+    /// no-ops and `finalize()` yields nullopt, so a provider/allocation
+    /// failure surfaces as a controlled upload error instead of hashing
+    /// through invalid handles (governance: fail closed, never a silent
+    /// wrong digest).
+    [[nodiscard]] bool ok() const noexcept { return valid_; }
+
+    void update(const char* data, std::size_t len) {
+        if (!valid_)
+            return;
+        if (!BCRYPT_SUCCESS(BCryptHashData(hash_, reinterpret_cast<PUCHAR>(const_cast<char*>(data)),
+                                           static_cast<ULONG>(len), 0)))
+            valid_ = false;
+    }
+
+    [[nodiscard]] std::optional<std::string> finalize() {
+        if (!valid_)
+            return std::nullopt;
+        std::vector<UCHAR> digest(hash_len_);
+        if (!BCRYPT_SUCCESS(BCryptFinishHash(hash_, digest.data(), hash_len_, 0))) {
+            valid_ = false;
+            return std::nullopt;
+        }
+        std::string hex;
+        for (auto b : digest)
+            hex += std::format("{:02x}", b);
+        return hex;
+    }
+
+private:
+    void init() {
+        valid_ = true;
+        if (!BCRYPT_SUCCESS(
+                BCryptOpenAlgorithmProvider(&alg_, BCRYPT_SHA256_ALGORITHM, nullptr, 0))) {
+            valid_ = false;
+            return;
+        }
+        DWORD result_len = 0;
+        if (!BCRYPT_SUCCESS(BCryptGetProperty(alg_, BCRYPT_HASH_LENGTH,
+                                              reinterpret_cast<PUCHAR>(&hash_len_),
+                                              sizeof(hash_len_), &result_len, 0))) {
+            valid_ = false;
+            return;
+        }
+        if (!BCRYPT_SUCCESS(BCryptCreateHash(alg_, &hash_, nullptr, 0, nullptr, 0, 0)))
+            valid_ = false;
+    }
+    void destroy() {
+        if (hash_) {
+            BCryptDestroyHash(hash_);
+            hash_ = nullptr;
+        }
+        if (alg_) {
+            BCryptCloseAlgorithmProvider(alg_, 0);
+            alg_ = nullptr;
+        }
+    }
+
+    BCRYPT_ALG_HANDLE alg_{nullptr};
+    BCRYPT_HASH_HANDLE hash_{nullptr};
+    DWORD hash_len_{0};
+    bool valid_{false};
+};
+#else
+class IncrementalSha256 {
+public:
+    IncrementalSha256() { init(); }
+    ~IncrementalSha256() { destroy(); }
+    IncrementalSha256(const IncrementalSha256&) = delete;
+    IncrementalSha256& operator=(const IncrementalSha256&) = delete;
+
+    /// Restart the digest so it covers nothing. An incremental hash cannot be
+    /// REWOUND, so this is how `do_upload` repairs its digest when a server
+    /// resync moves the acknowledged offset (see `rehash_prefix` there).
+    void reset() {
+        destroy();
+        init();
+    }
+
+    /// False once ANY crypto call has failed. Every subsequent operation
+    /// no-ops and `finalize()` yields nullopt, so an allocation/init failure
+    /// surfaces as a controlled upload error instead of hashing through a
+    /// null context (governance: fail closed, never a silent wrong digest).
+    [[nodiscard]] bool ok() const noexcept { return valid_; }
+
+    void update(const char* data, std::size_t len) {
+        if (!valid_)
+            return;
+        if (EVP_DigestUpdate(ctx_, data, len) != 1)
+            valid_ = false;
+    }
+
+    [[nodiscard]] std::optional<std::string> finalize() {
+        if (!valid_)
+            return std::nullopt;
+        unsigned char digest[EVP_MAX_MD_SIZE];
+        unsigned int len = 0;
+        if (EVP_DigestFinal_ex(ctx_, digest, &len) != 1) {
+            valid_ = false;
+            return std::nullopt;
+        }
+        std::string hex;
+        for (unsigned i = 0; i < len; ++i)
+            hex += std::format("{:02x}", digest[i]);
+        return hex;
+    }
+
+private:
+    void init() {
+        ctx_ = EVP_MD_CTX_new();
+        valid_ = ctx_ != nullptr && EVP_DigestInit_ex(ctx_, EVP_sha256(), nullptr) == 1;
+    }
+    void destroy() {
+        if (ctx_) {
+            EVP_MD_CTX_free(ctx_);
+            ctx_ = nullptr;
+        }
+    }
+
+    EVP_MD_CTX* ctx_{nullptr};
+    bool valid_{false};
+};
+#endif
+
+// SHA-256 over an already-open, positioned ifstream, reading from its
+// CURRENT position to EOF — never opens or closes the handle itself.
+std::string sha256_stream(std::ifstream& file) {
+    IncrementalSha256 hasher;
+    char buf[8192];
+    while (file.read(buf, sizeof(buf)) || file.gcount() > 0)
+        hasher.update(buf, static_cast<std::size_t>(file.gcount()));
+    // Matches sha256_file's existing fail-empty convention below — a crypto
+    // provider failure here reads the same as an unopenable file.
+    return hasher.finalize().value_or(std::string{});
+}
+
 std::string sha256_file(const fs::path& path) {
     std::ifstream file(path, std::ios::binary);
     if (!file)
         return {};
-#ifdef _WIN32
-    BCRYPT_ALG_HANDLE alg = nullptr;
-    BCRYPT_HASH_HANDLE hash = nullptr;
-    BCryptOpenAlgorithmProvider(&alg, BCRYPT_SHA256_ALGORITHM, nullptr, 0);
-    DWORD hash_len = 0, result_len = 0;
-    BCryptGetProperty(alg, BCRYPT_HASH_LENGTH, reinterpret_cast<PUCHAR>(&hash_len),
-                      sizeof(hash_len), &result_len, 0);
-    BCryptCreateHash(alg, &hash, nullptr, 0, nullptr, 0, 0);
-    char buf[8192];
-    while (file.read(buf, sizeof(buf)) || file.gcount() > 0)
-        BCryptHashData(hash, reinterpret_cast<PUCHAR>(buf), static_cast<ULONG>(file.gcount()), 0);
-    std::vector<UCHAR> digest(hash_len);
-    BCryptFinishHash(hash, digest.data(), hash_len, 0);
-    BCryptDestroyHash(hash);
-    BCryptCloseAlgorithmProvider(alg, 0);
-    std::string hex;
-    for (auto b : digest)
-        hex += std::format("{:02x}", b);
-    return hex;
-#else
-    auto* ctx = EVP_MD_CTX_new();
-    EVP_DigestInit_ex(ctx, EVP_sha256(), nullptr);
-    char buf[8192];
-    while (file.read(buf, sizeof(buf)) || file.gcount() > 0)
-        EVP_DigestUpdate(ctx, buf, static_cast<size_t>(file.gcount()));
-    unsigned char digest[EVP_MAX_MD_SIZE];
-    unsigned int len = 0;
-    EVP_DigestFinal_ex(ctx, digest, &len);
-    EVP_MD_CTX_free(ctx);
-    std::string hex;
-    for (unsigned i = 0; i < len; ++i)
-        hex += std::format("{:02x}", digest[i]);
-    return hex;
-#endif
+    return sha256_stream(file);
 }
 
 bool is_safe_filename(std::string_view name) {
@@ -595,22 +731,39 @@ private:
         return 0;
     }
 
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+    // Sends the grant/session credential's DELETE (cancel) so a
+    // server-side partial blob is discarded, then surfaces `error_msg`.
+    // Never itself an error — a cancel failure is not this command's
+    // failure to report, the upload's own failure already is. Only
+    // declared when SSLClient exists at all (see `do_upload`'s matching
+    // build guard below) — TLS is mandatory for this transport, so there
+    // is no non-SSL variant to guard against.
+    void abort_upload(httplib::SSLClient& client, const std::string& cancel_path,
+                      const std::string& session_header, yuzu::CommandContext& ctx,
+                      const std::string& error_msg) {
+        httplib::Headers cancel_headers = {{"X-Yuzu-Upload-Session", session_header}};
+        client.Delete(cancel_path, cancel_headers);
+        ctx.write_output(std::format("error|{}", error_msg));
+    }
+#endif
+
+    // ", reason=<name>" when present, empty otherwise — pulled out of the
+    // several error-message call sites below so none of them has to juggle
+    // a mixed string_view/const-char* ternary.
+    static std::string describe_reason(std::optional<up::Reason> reason) {
+        if (!reason)
+            return {};
+        return std::string{", reason="} + std::string{up::reason_string(*reason)};
+    }
+
     int do_upload(yuzu::CommandContext& ctx, yuzu::Params params) {
         auto path_str = params.get("path");
-        auto server_url = params.get("server_url");
-        if (path_str.empty()) {
-            ctx.write_output("error|missing required parameter: path");
-            return 1;
-        }
-
-        // If no server_url provided, try to derive from agent config
-        if (server_url.empty()) {
-            yuzu::PluginContext pctx{g_ctx};
-            server_url = pctx.get_config("agent.server_web_url");
-        }
-        if (server_url.empty()) {
+        auto grant_id = params.get("grant_id");
+        auto grant_secret = params.get("grant_secret");
+        if (path_str.empty() || grant_id.empty() || grant_secret.empty()) {
             ctx.write_output(
-                "error|missing server_url parameter and agent.server_web_url not configured");
+                "error|missing required parameters: path, grant_id, grant_secret");
             return 1;
         }
 
@@ -648,90 +801,395 @@ private:
             }
         }
 
-        auto file_size = fs::file_size(file_path, ec);
+        std::error_code size_ec;
+        const auto file_size = static_cast<std::int64_t>(fs::file_size(file_path, size_ec));
+        if (size_ec || file_size <= 0) {
+            ctx.write_output("error|failed to determine file size, or file is empty");
+            return 1;
+        }
+
         int max_mb = 100;
         auto max_str = params.get("max_size_mb", "100");
         try {
             max_mb = std::stoi(std::string{max_str});
         } catch (...) {}
-        if (file_size > static_cast<std::uintmax_t>(max_mb) * 1024 * 1024) {
+        if (static_cast<std::uintmax_t>(file_size) > static_cast<std::uintmax_t>(max_mb) * 1024 * 1024) {
             ctx.write_output(
                 std::format("error|file too large ({} bytes, max {} MB)", file_size, max_mb));
             return 1;
         }
 
-        // Compute SHA-256
-        auto hash = sha256_file(file_path);
-        if (hash.empty()) {
-            ctx.write_output("error|failed to compute file hash");
+        // The base URL comes ONLY from the agent's own configured server
+        // transport (agent.server_web_url) — this action no longer accepts
+        // an operator-supplied URL parameter at all (CC-06), and no request
+        // below ever carries a self-declared agent id: identity is entirely
+        // a server-side fact tied to the grant. TLS is mandatory —
+        // an explicit http:// value is a hard configuration error, never
+        // silently used or upgraded; a bare host (no scheme) defaults to
+        // https, matching this plugin's pre-existing bare-host convention.
+        yuzu::PluginContext pctx{g_ctx};
+        auto configured = pctx.get_config("agent.server_web_url");
+        if (configured.empty()) {
+            ctx.write_output(
+                "error|agent.server_web_url is not configured; cannot reach the upload endpoint");
+            return 1;
+        }
+        if (configured.starts_with("http://")) {
+            ctx.write_output("error|agent.server_web_url must not be http://; TLS is mandatory");
+            return 1;
+        }
+        std::string url_to_parse = configured.starts_with("https://")
+                                       ? std::string{configured}
+                                       : ("https://" + std::string{configured});
+        ParsedUrl base;
+        if (!parse_url(url_to_parse, base) || !base.is_https) {
+            ctx.write_output("error|agent.server_web_url is not a valid host or URL");
             return 1;
         }
 
-        // Read file contents
-        std::ifstream ifs(file_path, std::ios::binary);
-        if (!ifs) {
+#ifndef CPPHTTPLIB_OPENSSL_SUPPORT
+        ctx.write_output("error|HTTPS not supported in this build (OpenSSL not available)");
+        return 1;
+#else
+        httplib::SSLClient client(base.host, base.port);
+        client.set_connection_timeout(30);
+        client.set_read_timeout(300);
+        client.enable_server_certificate_verification(true);
+
+        // The destination is opened EXACTLY ONCE for this upload. Every
+        // chunk below reads its bytes via `seekg` on THIS SAME ifstream
+        // handle, and the commit hash is accumulated incrementally from the
+        // SAME buffer each chunk transmits, the moment the server
+        // acknowledges it — never by reopening the file or independently
+        // re-reading it through a second pass — so the committed digest
+        // can never describe different bytes than were actually streamed
+        // to the server (#P7-003).
+        std::ifstream file(file_path, std::ios::binary);
+        if (!file.is_open()) {
             ctx.write_output("error|failed to open file");
             return 1;
         }
-        std::string content((std::istreambuf_iterator<char>(ifs)),
-                            std::istreambuf_iterator<char>());
-        ifs.close();
 
-        // Parse server URL and POST the file
-        std::string url{server_url};
-        std::string scheme = "https";
-        std::string host = url;
+        // ── Session open ─────────────────────────────────────────────
+        const std::string grant_header = std::string{grant_id} + "." + std::string{grant_secret};
+        httplib::Headers open_headers = {{"X-Yuzu-Upload-Grant", grant_header}};
 
-        if (url.starts_with("https://")) {
-            host = url.substr(8);
-            scheme = "https";
-        } else if (url.starts_with("http://")) {
-            host = url.substr(7);
-            scheme = "http";
+        std::optional<up::SessionOpenResponse> session;
+        for (int attempt = 1;; ++attempt) {
+            auto open_res = client.Post("/api/v1/uploads", open_headers);
+            const int status = open_res ? open_res->status : 0;
+            if (open_res && status == 201) {
+                session = up::parse_session_open_response(open_res->body);
+                if (!session) {
+                    ctx.write_output("error|malformed session-open response from server");
+                    return 1;
+                }
+                break;
+            }
+            std::optional<up::Reason> reason;
+            if (open_res)
+                reason = up::parse_error_envelope(open_res->body).reason;
+            auto decision = up::decide_next_action(status, reason, attempt);
+            if (decision.action != up::UploadDecision::kRetry) {
+                ctx.write_output(std::format("error|failed to open upload session (HTTP {}{})",
+                                             status, describe_reason(reason)));
+                return 1;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(decision.backoff_ms));
         }
 
-        // Strip trailing slash
-        while (!host.empty() && host.back() == '/')
-            host.pop_back();
+        if (session->chunk_max_bytes <= 0) {
+            ctx.write_output("error|server returned an invalid chunk_max_bytes");
+            return 1;
+        }
 
-        ctx.report_progress(10);
+        const std::string session_header = session->upload_id + "." + session->session_secret;
+        const std::string chunk_path = "/api/v1/uploads/" + session->upload_id + "/chunk";
+        const std::string commit_path = "/api/v1/uploads/" + session->upload_id + "/commit";
+        const std::string cancel_path = "/api/v1/uploads/" + session->upload_id;
 
-        auto filename = file_path.filename().string();
+        ctx.report_progress(5);
 
-        httplib::UploadFormDataItems items = {
-            {"file", content, filename, "application/octet-stream"},
-            {"sha256", hash, "", "text/plain"},
-            {"original_path", std::string{path_str}, "", "text/plain"},
+        // ── Chunk streaming ──────────────────────────────────────────
+        // The commit digest is built INCREMENTALLY, and the invariant that
+        // makes it correct is positional, not response-shaped: `hasher`
+        // must cover EXACTLY `[0, hashed_to)` of the local file at all
+        // times, and `hashed_to` must equal `offset` before the next chunk
+        // is planned. The ordinary path keeps that invariant by feeding
+        // `hasher` the exact buffer just transmitted the moment the server
+        // acknowledges it (never a later, independent re-read — see the
+        // RAII-handle comment above, #P7-003). Two situations cannot do
+        // that because the bytes were never in THIS process's memory or
+        // this hasher's history: a RESUMED session's already-uploaded
+        // prefix, and a `kResync` response whose authoritative offset jumps
+        // PAST what this hasher has hashed (the chunk landed on the server
+        // but this process never saw the success response, so it never
+        // called `update()` for it). Both repair the SAME way — read the
+        // missing range from the SAME open handle and hash it — via one
+        // shared helper so the two call sites cannot drift.
+        IncrementalSha256 hasher;
+        std::int64_t hashed_to = 0;
+
+        // Advance `hasher` to cover `[hashed_to, target)`, reading from the
+        // same `file` handle. `plan_resync_rehash` (the pure decision this
+        // wraps — content_dist_upload_parsers.hpp) says whether there is
+        // anything to do; a `nullopt` covers the ordinary post-chunk case
+        // where `hashed_to` already equals the new offset. Returns false on
+        // a read or crypto failure, having already written the
+        // operator-facing error.
+        auto rehash_to = [&](std::int64_t target) -> bool {
+            auto range = up::plan_resync_rehash(hashed_to, target);
+            if (!range)
+                return true;
+            file.clear();
+            file.seekg(range->start, std::ios::beg);
+            std::vector<char> prefix_buf(64 * 1024);
+            std::int64_t remaining = range->end - range->start;
+            while (remaining > 0) {
+                const auto want = static_cast<std::streamsize>(
+                    std::min<std::int64_t>(remaining, static_cast<std::int64_t>(prefix_buf.size())));
+                file.read(prefix_buf.data(), want);
+                if (file.gcount() != want) {
+                    ctx.write_output("error|failed to read local file while hashing "
+                                     "already-acknowledged bytes");
+                    return false;
+                }
+                hasher.update(prefix_buf.data(), static_cast<std::size_t>(want));
+                if (!hasher.ok()) {
+                    ctx.write_output("error|digest computation failed while hashing "
+                                     "already-acknowledged bytes");
+                    return false;
+                }
+                remaining -= want;
+            }
+            hashed_to = target;
+            return true;
         };
 
-        std::unique_ptr<httplib::Client> client;
-#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-        if (scheme == "https") {
-            client = std::make_unique<httplib::Client>(scheme + "://" + host);
-        } else
-#endif
-        {
-            client = std::make_unique<httplib::Client>("http://" + host);
+        if (session->offset > 0 && !rehash_to(session->offset)) {
+            return 1;
         }
-        client->set_connection_timeout(30);
-        client->set_read_timeout(300);
 
-        auto result = client->Post("/api/v1/file-retrieval", items);
+        std::int64_t offset = session->offset;
+        std::int64_t last_progress_offset = -1;
+        int attempt = 1;
+        std::vector<char> buf;
 
-        ctx.report_progress(90);
+        while (offset < file_size) {
+            if (offset > last_progress_offset) {
+                last_progress_offset = offset;
+                attempt = 1;
+            }
 
-        if (!result || result->status >= 400) {
-            auto status = result ? result->status : 0;
-            ctx.write_output(std::format("error|upload failed (HTTP {})", status));
+            auto spec = up::plan_next_chunk(offset, file_size, session->chunk_max_bytes);
+            if (!spec) {
+                abort_upload(client, cancel_path, session_header, ctx,
+                            "internal chunk-planning error");
+                return 1;
+            }
+            const auto chunk_len = spec->end - spec->start + 1;
+            buf.resize(static_cast<std::size_t>(chunk_len));
+            file.clear();
+            file.seekg(spec->start, std::ios::beg);
+            file.read(buf.data(), static_cast<std::streamsize>(chunk_len));
+            if (file.gcount() != static_cast<std::streamsize>(chunk_len)) {
+                abort_upload(client, cancel_path, session_header, ctx,
+                            "failed to read local file while streaming");
+                return 1;
+            }
+
+            httplib::Headers chunk_headers = {
+                {"X-Yuzu-Upload-Session", session_header},
+                {"Content-Range", std::format("bytes {}-{}/{}", spec->start, spec->end, spec->total)},
+            };
+            auto res = client.Put(chunk_path, chunk_headers, std::string(buf.data(), buf.size()),
+                                  "application/octet-stream");
+            const int status = res ? res->status : 0;
+
+            if (res && status == 200) {
+                auto ack = up::parse_chunk_ack_offset(res->body);
+                // The only valid ack is EXACTLY `spec->end + 1` — the agent
+                // already knows what a successful write of THIS chunk must
+                // produce, so a missing or disagreeing offset is a
+                // malformed/inconsistent response, not new state to adopt
+                // (#P7-004).
+                auto validated = up::validate_chunk_ack(ack, spec->end + 1, file_size);
+                if (!validated) {
+                    abort_upload(client, cancel_path, session_header, ctx,
+                                "server returned a missing or inconsistent chunk offset "
+                                "acknowledgement");
+                    return 1;
+                }
+                // Hash the SAME buffer just transmitted, now that the
+                // server has confirmed receipt of exactly this range.
+                // `spec->start == hashed_to` always holds here: either the
+                // previous iteration advanced both together, or the resync
+                // branch below called `rehash_to` before looping back.
+                hasher.update(buf.data(), buf.size());
+                if (!hasher.ok()) {
+                    abort_upload(client, cancel_path, session_header, ctx,
+                                "digest computation failed");
+                    return 1;
+                }
+                offset = *validated;
+                hashed_to = offset;
+                ctx.report_progress(
+                    5 + static_cast<int>(offset * 90 / file_size)); // 5..95 while streaming
+                continue;
+            }
+
+            std::optional<up::Reason> reason;
+            if (res)
+                reason = up::parse_error_envelope(res->body).reason;
+            auto decision = up::decide_next_action(status, reason, attempt);
+            switch (decision.action) {
+            case up::UploadDecision::kResync: {
+                auto authoritative = res ? up::parse_error_envelope(res->body).offset
+                                         : std::nullopt;
+                auto resynced = authoritative
+                                    ? up::reconcile_resume_offset(*authoritative, file_size)
+                                    : std::nullopt;
+                if (!resynced) {
+                    abort_upload(client, cancel_path, session_header, ctx,
+                                "server reported offset_mismatch without a usable offset");
+                    return 1;
+                }
+                // A FORWARD resync means the server accepted a chunk whose
+                // success response this process never saw — those bytes
+                // are in the file but never reached `hasher`. Repair the
+                // digest's coverage before adopting the new offset, or the
+                // eventual commit hash silently omits them (they were
+                // uploaded and are part of the file the server has; the
+                // committed digest must include them too).
+                if (*resynced > hashed_to && !rehash_to(*resynced)) {
+                    return 1;
+                }
+                if (*resynced <= offset) {
+                    // No forward progress — without a bounded budget here a
+                    // server that keeps handing back a non-advancing
+                    // offset would drive an unbounded resend loop
+                    // (#P7-006). Reuses the SAME attempt/backoff budget as
+                    // an ordinary retry; a resync that DOES advance resets
+                    // it via the `offset > last_progress_offset` check at
+                    // the top of the loop, same as any other progress.
+                    if (up::attempts_exhausted(attempt)) {
+                        abort_upload(client, cancel_path, session_header, ctx,
+                                    "offset_mismatch resync made no forward progress after "
+                                    "repeated attempts");
+                        return 1;
+                    }
+                    std::this_thread::sleep_for(
+                        std::chrono::milliseconds(up::backoff_delay_ms(attempt)));
+                    ++attempt;
+                }
+                offset = *resynced;
+                continue;
+            }
+            case up::UploadDecision::kRetry:
+                ++attempt;
+                std::this_thread::sleep_for(std::chrono::milliseconds(decision.backoff_ms));
+                continue;
+            case up::UploadDecision::kAbort:
+                abort_upload(client, cancel_path, session_header, ctx,
+                            std::format("chunk upload failed (HTTP {}{})", status,
+                                        describe_reason(reason)));
+                return 1;
+            }
+        }
+
+        auto finalized_hash = hasher.finalize();
+        if (!finalized_hash) {
+            abort_upload(client, cancel_path, session_header, ctx,
+                        "failed to compute upload hash");
+            return 1;
+        }
+        const std::string computed_hash = *finalized_hash;
+
+        // ── Commit ───────────────────────────────────────────────────
+        // Bounded retry loop mirroring session-open's, driven by the SAME
+        // `decide_next_action` (#P7-002: a transient commit failure used to
+        // cancel the upload outright instead of honouring the retry
+        // policy). A `session_terminal` reason on commit specifically, or a
+        // pure connection-level/unreasoned failure once the retry budget is
+        // exhausted, is outcome-AMBIGUOUS: the server may already have
+        // committed THIS exact upload from an earlier attempt whose
+        // response never reached the agent (`file_retrieval_routes.cpp`'s
+        // commit handler races itself by design — a concurrent winner
+        // reports `session_terminal` to the loser). The status route
+        // answers 200 with the current state even for a terminal session,
+        // so that ambiguity is resolved there BEFORE declaring failure or
+        // sending a cancel that would otherwise be pointless or misleading.
+        httplib::Headers commit_headers = {{"X-Yuzu-Upload-Session", session_header}};
+        const std::string commit_body = "{\"sha256\":\"" + computed_hash + "\"}";
+
+        std::optional<up::CommitResponse> commit_result;
+        for (int commit_attempt = 1;; ++commit_attempt) {
+            auto commit_res =
+                client.Post(commit_path, commit_headers, commit_body, "application/json");
+            const int commit_status = commit_res ? commit_res->status : 0;
+            if (commit_res && commit_status == 200) {
+                commit_result = up::parse_commit_response(commit_res->body);
+                if (!commit_result) {
+                    ctx.write_output("error|malformed commit response from server");
+                    return 1;
+                }
+                break;
+            }
+
+            std::optional<up::Reason> reason;
+            if (commit_res)
+                reason = up::parse_error_envelope(commit_res->body).reason;
+            auto decision = up::decide_next_action(commit_status, reason, commit_attempt);
+
+            const bool ambiguous = reason == up::Reason::kSessionTerminal ||
+                                   (decision.action != up::UploadDecision::kRetry &&
+                                    up::is_transient_no_reason(commit_status, reason));
+            if (ambiguous) {
+                auto status_res = client.Get(
+                    cancel_path, httplib::Headers{{"X-Yuzu-Upload-Session", session_header}});
+                if (status_res && status_res->status == 200) {
+                    auto st = up::parse_status_response(status_res->body);
+                    if (st && st->state == "committed") {
+                        // Reported response values are our own locally
+                        // transmitted state — the server's commit ONLY
+                        // succeeds with the sha256 this exact run posted
+                        // (`upload_grant::verify_commit`), so these are the
+                        // values that committed, whichever attempt won.
+                        commit_result = up::CommitResponse{"committed", file_size, computed_hash};
+                        break;
+                    }
+                }
+            }
+
+            if (decision.action == up::UploadDecision::kRetry) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(decision.backoff_ms));
+                continue;
+            }
+
+            abort_upload(client, cancel_path, session_header, ctx,
+                        std::format("commit failed (HTTP {}{})", commit_status,
+                                    describe_reason(reason)));
+            return 1;
+        }
+
+        // The server's own reported size/hash must agree with what this
+        // run computed and transmitted — a 200 naming different metadata
+        // is a server-contract violation, not a result to trust (#P7-009).
+        if (!up::commit_matches(*commit_result, file_size, computed_hash)) {
+            ctx.write_output(std::format(
+                "error|commit response does not match the uploaded file (expected size={} "
+                "sha256={}, server reported size={} sha256={})",
+                file_size, computed_hash, commit_result->actual_size, commit_result->sha256));
             return 1;
         }
 
         ctx.report_progress(100);
         ctx.write_output("status|ok");
-        ctx.write_output(std::format("sha256|{}", hash));
-        ctx.write_output(std::format("size|{}", file_size));
-        ctx.write_output(std::format("filename|{}", filename));
+        ctx.write_output(std::format("sha256|{}", commit_result->sha256));
+        ctx.write_output(std::format("size|{}", commit_result->actual_size));
+        ctx.write_output(std::format("upload_id|{}", session->upload_id));
         return 0;
+#endif
     }
 
     int do_cleanup(yuzu::CommandContext& ctx, yuzu::Params params) {

--- a/agents/plugins/content_dist/src/content_dist_upload_parsers.hpp
+++ b/agents/plugins/content_dist/src/content_dist_upload_parsers.hpp
@@ -35,6 +35,7 @@
 ///    `"offset"` key into the SAME `error` object (never top-level).
 ///    `reason` is one of the closed 10-value set below.
 
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <optional>
@@ -42,6 +43,42 @@
 #include <string_view>
 
 namespace yuzu::content_dist::upload {
+
+// ── Credential grammar ────────────────────────────────────────────────────
+//
+// #3136 minor: the frozen `<id>.<secret>` grammar `X-Yuzu-Upload-Grant`/
+// `X-Yuzu-Upload-Session` both use — duplicated from
+// server/core/src/upload_grant_parsers.hpp's `kCredentialIdHexLen`/
+// `kCredentialSecretHexLen`/`is_lowercase_hex` (never included: the
+// agents/plugins/* <-> server/core/* layering split this file's header
+// already documents). The server already fails closed on a malformed
+// credential (grant_unknown/session_unknown), so this is a LOCAL,
+// clarity-of-error precheck only — a malformed grant_id/grant_secret
+// parameter is caught before a doomed network round-trip, with a message
+// naming the actual problem instead of a generic 401.
+
+inline constexpr std::size_t kCredentialIdHexLen = 32;
+inline constexpr std::size_t kCredentialSecretHexLen = 64;
+
+[[nodiscard]] inline bool is_lowercase_hex(std::string_view s, std::size_t len) noexcept {
+    if (s.size() != len)
+        return false;
+    for (char c : s) {
+        if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')))
+            return false;
+    }
+    return true;
+}
+
+/// True iff `id` is exactly `kCredentialIdHexLen` lowercase hex chars and
+/// `secret` is exactly `kCredentialSecretHexLen` lowercase hex chars — the
+/// shape both `grant_id`/`grant_secret` (mint-time) and the server-returned
+/// `upload_id`/`session_secret` (session-open time) must satisfy.
+[[nodiscard]] inline bool is_valid_credential_parts(std::string_view id,
+                                                    std::string_view secret) noexcept {
+    return is_lowercase_hex(id, kCredentialIdHexLen) &&
+          is_lowercase_hex(secret, kCredentialSecretHexLen);
+}
 
 // ── Chunk planning ──────────────────────────────────────────────────────
 
@@ -391,8 +428,16 @@ struct SessionOpenResponse {
 
 /// Parses `{"upload_id","session_secret","chunk_max_bytes","offset","expires_at"}`
 /// (session-open success body). `nullopt` on any missing/malformed field, or
-/// a structurally impossible value (`chunk_max_bytes <= 0`, negative offset)
-/// — never a partially-populated result.
+/// a structurally impossible value (`chunk_max_bytes <= 0`, `offset != 0`) —
+/// never a partially-populated result. `offset` must be EXACTLY 0: this is
+/// the fresh-session response, and server/core/src/upload_grant_parsers.hpp's
+/// frozen protocol text states a successful session open always returns
+/// `offset 0` (never merely non-negative) — the resume-poll case where a
+/// non-zero offset is legitimate is `StatusResponse`/`parse_status_response`
+/// below, a separate type used at the one distinct call site that polls an
+/// already-open session (#3136 review: this parser's own file header claims
+/// to implement the frozen text "verbatim", so it must actually reject what
+/// that text calls impossible, not merely non-negative).
 [[nodiscard]] inline std::optional<SessionOpenResponse>
 parse_session_open_response(std::string_view body) {
     auto upload_id = detail::extract_string(body, "upload_id");
@@ -401,7 +446,7 @@ parse_session_open_response(std::string_view body) {
     auto offset = detail::extract_int(body, "offset");
     auto expires = detail::extract_int(body, "expires_at");
     if (!upload_id || upload_id->empty() || !secret || secret->empty() || !chunk_max ||
-        *chunk_max <= 0 || !offset || *offset < 0 || !expires)
+        *chunk_max <= 0 || !offset || *offset != 0 || !expires)
         return std::nullopt;
     return SessionOpenResponse{*upload_id, *secret, *chunk_max, *offset, *expires};
 }

--- a/agents/plugins/content_dist/src/content_dist_upload_parsers.hpp
+++ b/agents/plugins/content_dist/src/content_dist_upload_parsers.hpp
@@ -1,0 +1,486 @@
+#pragma once
+
+/// @file content_dist_upload_parsers.hpp
+/// PURE decision layer for `content_dist`'s `upload_file` action — the AGENT
+/// half of the one-time upload grant + authenticated chunked receive
+/// protocol (PR1.6, CC-06). Every branch a reviewer needs to audit for
+/// chunk planning, resume, retry/backoff and the ten-reason wire
+/// classification lives HERE, as free functions over plain values — no
+/// httplib, no filesystem, no sleeping, no clock read. `content_dist_plugin.cpp`
+/// is the thin OS/network shell around this header.
+///
+/// FROZEN PROTOCOL (Architect-frozen; implemented verbatim against the
+/// identical text `server/core/src/upload_grant_parsers.hpp` implements —
+/// this header deliberately DUPLICATES that header's ten-value reason
+/// enum/strings rather than including it: an `agents/plugins/*` source must
+/// never depend on a `server/core/src/*` header, the same layering split
+/// every other agent plugin already observes):
+///
+///  * Session open (agent, POST /api/v1/uploads, header
+///    `X-Yuzu-Upload-Grant: <grant_id>.<grant_secret>`, TLS required) ->
+///    `{"upload_id","session_secret","chunk_max_bytes","offset","expires_at"}`,
+///    HTTP 201.
+///  * Chunk (agent, PUT /api/v1/uploads/{upload_id}/chunk, header
+///    `X-Yuzu-Upload-Session: <upload_id>.<session_secret>`,
+///    `Content-Range: bytes <start>-<end>/<total>`, body = raw bytes) ->
+///    `{"offset":<new_offset>}`, HTTP 200 on success.
+///  * Status (agent, GET /api/v1/uploads/{upload_id}, session header) ->
+///    `{"state","offset","expires_at"}`.
+///  * Commit (agent, POST /api/v1/uploads/{upload_id}/commit, session
+///    header, body `{"sha256":"..."}`) -> `{"state":"committed","actual_size","sha256"}`,
+///    HTTP 200.
+///  * Cancel (agent, DELETE /api/v1/uploads/{upload_id}, session header).
+///  * Error envelope: `{"error":{"code":<http>,"message":"...","reason":"..."},
+///    "meta":{"api_version":"v1"}}` — `offset_mismatch` merges an extra
+///    `"offset"` key into the SAME `error` object (never top-level).
+///    `reason` is one of the closed 10-value set below.
+
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace yuzu::content_dist::upload {
+
+// ── Chunk planning ──────────────────────────────────────────────────────
+
+/// One planned chunk: `[start, end]` inclusive, `total` echoing the whole
+/// upload's declared size (the `Content-Range` header's three numbers).
+struct ChunkSpec {
+    std::int64_t start{0};
+    std::int64_t end{0}; ///< inclusive
+    std::int64_t total{0};
+};
+
+/// The next chunk to send from `offset`, honouring the server-supplied
+/// `chunk_max_bytes` (never buffering — or planning — the whole file at
+/// once). `nullopt` when there is nothing left to send (`offset >=
+/// file_size`) or the inputs are structurally invalid.
+[[nodiscard]] inline std::optional<ChunkSpec>
+plan_next_chunk(std::int64_t offset, std::int64_t file_size, std::int64_t chunk_max_bytes) noexcept {
+    if (file_size <= 0 || chunk_max_bytes <= 0 || offset < 0 || offset >= file_size)
+        return std::nullopt;
+    const auto remaining = file_size - offset;
+    const auto len = remaining < chunk_max_bytes ? remaining : chunk_max_bytes;
+    return ChunkSpec{offset, offset + len - 1, file_size};
+}
+
+/// Total number of chunks `plan_next_chunk` will walk through for a fresh
+/// (offset-0) upload — used only for progress reporting, never for
+/// planning a request body.
+[[nodiscard]] inline std::int64_t chunk_count(std::int64_t file_size,
+                                              std::int64_t chunk_max_bytes) noexcept {
+    if (file_size <= 0 || chunk_max_bytes <= 0)
+        return 0;
+    return (file_size + chunk_max_bytes - 1) / chunk_max_bytes;
+}
+
+// ── Resume-offset reconciliation ────────────────────────────────────────
+
+/// Validate a server-asserted "authoritative offset" (the `offset` field a
+/// 409 `offset_mismatch` body carries) before trusting it as the new resume
+/// point: it must land within `[0, file_size]`. `nullopt` on anything else
+/// — a server claiming an offset past the end of the very file it is
+/// receiving is a protocol violation, not something to resume from.
+[[nodiscard]] inline std::optional<std::int64_t>
+reconcile_resume_offset(std::int64_t authoritative_offset, std::int64_t file_size) noexcept {
+    if (authoritative_offset < 0 || authoritative_offset > file_size)
+        return std::nullopt;
+    return authoritative_offset;
+}
+
+/// A byte range `[start, end)` this process's running commit-digest hasher
+/// has not yet covered but must, before adopting `resynced_offset` as the
+/// new resume point.
+struct RehashRange {
+    std::int64_t start;
+    std::int64_t end; ///< exclusive
+};
+
+/// The commit digest is built incrementally as bytes are ACKNOWLEDGED, so
+/// its coverage (`hashed_to`) normally tracks `offset` exactly. A FORWARD
+/// resync breaks that: it means the server accepted a chunk whose success
+/// response this process never saw, so `hasher` was never fed that range —
+/// the bytes exist on disk and on the server, but not in the digest. This
+/// is the fix for the defect where a lost chunk-ack response, followed by a
+/// resync, produced a commit hash silently missing the acknowledged bytes
+/// (the eventual commit then 422s with `hash_mismatch`, the session is
+/// terminal, and the already-redeemed grant has no retry).
+///
+/// Returns the range to hash before advancing, or `nullopt` when
+/// `resynced_offset` does not exceed `hashed_to` — the ordinary case where
+/// nothing is missing (a resync that repeats or retreats, or one that
+/// exactly matches what has already been hashed). Never returns a range
+/// with `start < 0`: `hashed_to` is caller-tracked and only ever advances
+/// forward from 0, and `reconcile_resume_offset` has already bounded
+/// `resynced_offset` to `[0, file_size]` before this is called.
+[[nodiscard]] inline std::optional<RehashRange>
+plan_resync_rehash(std::int64_t hashed_to, std::int64_t resynced_offset) noexcept {
+    if (resynced_offset <= hashed_to)
+        return std::nullopt;
+    return RehashRange{hashed_to, resynced_offset};
+}
+
+/// Validates a SUCCESSFUL chunk PUT's acknowledged offset. Unlike
+/// `offset_mismatch` reconciliation (where the server's number is the only
+/// source of truth), a 200 ack is checked against what the agent already
+/// knows: the request it just sent covered exactly `[spec.start, spec.end]`,
+/// so the only valid acknowledged offset is `spec.end + 1`
+/// (`expected_next_offset`). A missing field, a value that disagrees, or one
+/// outside `[0, file_size]` is a malformed or inconsistent response — not
+/// new state to trust — so the caller must treat it as a failure rather
+/// than silently adopting an arbitrary offset.
+[[nodiscard]] inline std::optional<std::int64_t>
+validate_chunk_ack(std::optional<std::int64_t> acked_offset, std::int64_t expected_next_offset,
+                   std::int64_t file_size) noexcept {
+    if (!acked_offset || *acked_offset != expected_next_offset || *acked_offset < 0 ||
+        *acked_offset > file_size)
+        return std::nullopt;
+    return *acked_offset;
+}
+
+// ── The closed 10-value reason set ──────────────────────────────────────
+
+enum class Reason {
+    kGrantUnknown,
+    kGrantAlreadyRedeemed,
+    kExpired,
+    kOffsetMismatch,
+    kChunkTooLarge,
+    kSizeExceeded,
+    kHashMismatch,
+    kSessionUnknown,
+    kSessionTerminal,
+    kTlsRequired,
+};
+
+[[nodiscard]] inline std::optional<Reason> parse_reason(std::string_view s) noexcept {
+    if (s == "grant_unknown") return Reason::kGrantUnknown;
+    if (s == "grant_already_redeemed") return Reason::kGrantAlreadyRedeemed;
+    if (s == "expired") return Reason::kExpired;
+    if (s == "offset_mismatch") return Reason::kOffsetMismatch;
+    if (s == "chunk_too_large") return Reason::kChunkTooLarge;
+    if (s == "size_exceeded") return Reason::kSizeExceeded;
+    if (s == "hash_mismatch") return Reason::kHashMismatch;
+    if (s == "session_unknown") return Reason::kSessionUnknown;
+    if (s == "session_terminal") return Reason::kSessionTerminal;
+    if (s == "tls_required") return Reason::kTlsRequired;
+    return std::nullopt;
+}
+
+[[nodiscard]] inline std::string_view reason_string(Reason r) noexcept {
+    switch (r) {
+    case Reason::kGrantUnknown: return "grant_unknown";
+    case Reason::kGrantAlreadyRedeemed: return "grant_already_redeemed";
+    case Reason::kExpired: return "expired";
+    case Reason::kOffsetMismatch: return "offset_mismatch";
+    case Reason::kChunkTooLarge: return "chunk_too_large";
+    case Reason::kSizeExceeded: return "size_exceeded";
+    case Reason::kHashMismatch: return "hash_mismatch";
+    case Reason::kSessionUnknown: return "session_unknown";
+    case Reason::kSessionTerminal: return "session_terminal";
+    case Reason::kTlsRequired: return "tls_required";
+    }
+    return "grant_unknown"; // unreachable — every enumerator handled above
+}
+
+/// What the shell should do next. `kRetry` — same request, no new
+/// server-supplied state needed. `kResync` — re-derive local state (the
+/// send offset) from the response, then continue immediately. `kAbort` —
+/// unrecoverable; the shell surfaces the failure and, if a session is open,
+/// sends the cancel (DELETE).
+enum class UploadDecision {
+    kRetry,
+    kResync,
+    kAbort,
+};
+
+/// Classifies each of the ten frozen reasons. Only one is recoverable
+/// in-band:
+///   * `offset_mismatch` -> Resync — the response body carries the
+///     authoritative offset (`reconcile_resume_offset` above); the agent's
+///     local send position was wrong, the server's is truth.
+/// Every other reason names a terminal, non-retryable outcome per the
+/// frozen protocol text (`expired`/`size_exceeded`/`hash_mismatch` all
+/// explicitly terminate the session server-side; `grant_unknown`/
+/// `grant_already_redeemed`/`session_unknown`/`session_terminal`/
+/// `tls_required` are all "this credential or transport can never succeed",
+/// not "try again") -> Abort. `chunk_too_large` is ALSO Abort, not Retry: the
+/// agent already learned `chunk_max_bytes` at session-open and every
+/// `plan_next_chunk` call honours it deterministically, so this can only
+/// legitimately fire from a local planning bug or a cap that changed
+/// mid-session — either way a retry resends the IDENTICAL range with the
+/// SAME already-known cap and cannot converge on its own (the frozen
+/// protocol gives the agent no new cap to reconcile from, unlike
+/// `offset_mismatch`'s authoritative offset), so retrying only burns the
+/// attempt budget on a structurally guaranteed repeat failure.
+[[nodiscard]] inline UploadDecision classify_reason(Reason r) noexcept {
+    switch (r) {
+    case Reason::kOffsetMismatch:
+        return UploadDecision::kResync;
+    case Reason::kChunkTooLarge:
+    case Reason::kGrantUnknown:
+    case Reason::kGrantAlreadyRedeemed:
+    case Reason::kExpired:
+    case Reason::kSizeExceeded:
+    case Reason::kHashMismatch:
+    case Reason::kSessionUnknown:
+    case Reason::kSessionTerminal:
+    case Reason::kTlsRequired:
+        return UploadDecision::kAbort;
+    }
+    return UploadDecision::kAbort; // unreachable — every enumerator handled above
+}
+
+// ── Retry/backoff (pure function of status + reason + attempt; no sleep) ──
+
+/// Attempt numbers start at 1. Deliberately small and fixed — this is a
+/// per-chunk retry budget, not a long-lived reconnect policy; the caller
+/// resets the attempt counter whenever real forward progress is made (a
+/// higher offset than previously seen), so a flaky link that eventually
+/// makes progress never exhausts this budget, only a genuinely stuck one
+/// does.
+inline constexpr int kMaxAttempts = 5;
+
+[[nodiscard]] inline bool attempts_exhausted(int attempt) noexcept { return attempt >= kMaxAttempts; }
+
+inline constexpr std::int64_t kBackoffBaseMs = 250;
+inline constexpr std::int64_t kBackoffCapMs = 30000;
+
+/// Deterministic exponential backoff, capped. Pure — returns a delay for
+/// the CALLER to sleep on; this function never sleeps itself.
+[[nodiscard]] inline std::int64_t backoff_delay_ms(int attempt) noexcept {
+    if (attempt < 1)
+        attempt = 1;
+    std::int64_t delay = kBackoffBaseMs;
+    for (int i = 1; i < attempt && delay < kBackoffCapMs; ++i)
+        delay *= 2;
+    return delay < kBackoffCapMs ? delay : kBackoffCapMs;
+}
+
+struct RetryDecision {
+    UploadDecision action{UploadDecision::kAbort};
+    std::int64_t backoff_ms{0}; ///< engaged only when action == kRetry
+};
+
+/// Whether a non-2xx response carrying NO recognized `reason` (a generic
+/// envelope, or no envelope at all) is the "connection-level or unreasoned
+/// server error" case that `decide_next_action` treats as retryable: a 5xx,
+/// or `http_status == 0` (the shell's spelling for a connection failure —
+/// no response reached it at all). Exposed separately from
+/// `decide_next_action` so a caller can also use it OUTSIDE the retry
+/// decision itself — e.g. to recognize an outcome-AMBIGUOUS commit failure
+/// (a lost response can mean the server already committed) once the retry
+/// budget is exhausted and worth resolving with a status check before
+/// declaring failure.
+[[nodiscard]] inline bool is_transient_no_reason(int http_status,
+                                                 std::optional<Reason> reason) noexcept {
+    return !reason.has_value() && (http_status == 0 || (http_status >= 500 && http_status < 600));
+}
+
+/// The single entry point the shell calls after every non-2xx response
+/// (chunk, session-open, or commit). `reason` is the parsed `error.reason`
+/// field when the body carried one of the ten frozen strings — `nullopt`
+/// for a generic envelope (no `reason` field at all: an operator-route-style
+/// 400/503) or a connection-level failure the shell reports as
+/// `http_status == 0`.
+///
+///   * A recognized `reason` always drives the outcome via `classify_reason`
+///     above — a `kRetry` result would additionally check the attempt
+///     budget, though no reason classifies as Retry today (see
+///     `classify_reason`'s doc comment) — this stays defensive against a
+///     future reclassification rather than assuming the branch is dead.
+///   * No `reason` at all: `is_transient_no_reason` above is the ONLY other
+///     retryable case — any other unreasoned status (e.g. a 400 from a
+///     locally malformed Content-Range) is a structural bug, not a
+///     transient condition, so it aborts.
+[[nodiscard]] inline RetryDecision decide_next_action(int http_status, std::optional<Reason> reason,
+                                                      int attempt) noexcept {
+    if (reason.has_value()) {
+        const auto action = classify_reason(*reason);
+        if (action != UploadDecision::kRetry)
+            return {action, 0};
+        if (attempts_exhausted(attempt))
+            return {UploadDecision::kAbort, 0};
+        return {UploadDecision::kRetry, backoff_delay_ms(attempt)};
+    }
+    if (!is_transient_no_reason(http_status, reason))
+        return {UploadDecision::kAbort, 0};
+    if (attempts_exhausted(attempt))
+        return {UploadDecision::kAbort, 0};
+    return {UploadDecision::kRetry, backoff_delay_ms(attempt)};
+}
+
+// ── Minimal compact-JSON field extraction ───────────────────────────────
+//
+// `content_dist`'s meson.build carries no `nlohmann_dep` (unlike every
+// plugin that already uses `<nlohmann/json.hpp>`) and this package's
+// `owned_files` does not include that build file — widening it is out of
+// scope (see this package's spec boundaries). Every response this header
+// parses is a small, FLAT, compact-dumped (`nlohmann::json::dump()`'s
+// default: no inserted whitespace) object produced by
+// `file_retrieval_routes.cpp` on the other end, so a plain `"key":` token
+// scan is sufficient and exact for this closed set of shapes — this is
+// intentionally NOT a general JSON parser.
+namespace detail {
+
+[[nodiscard]] inline std::optional<std::string> extract_string(std::string_view json,
+                                                                std::string_view key) {
+    const std::string needle = "\"" + std::string(key) + "\":\"";
+    const auto pos = json.find(needle);
+    if (pos == std::string_view::npos)
+        return std::nullopt;
+    std::size_t i = pos + needle.size();
+    std::string out;
+    while (i < json.size() && json[i] != '"') {
+        if (json[i] == '\\' && i + 1 < json.size()) {
+            out.push_back(json[i + 1]);
+            i += 2;
+            continue;
+        }
+        out.push_back(json[i]);
+        ++i;
+    }
+    if (i >= json.size()) // unterminated string — malformed, refuse to guess
+        return std::nullopt;
+    return out;
+}
+
+[[nodiscard]] inline std::optional<std::int64_t> extract_int(std::string_view json,
+                                                              std::string_view key) {
+    const std::string needle = "\"" + std::string(key) + "\":";
+    const auto pos = json.find(needle);
+    if (pos == std::string_view::npos)
+        return std::nullopt;
+    std::size_t i = pos + needle.size();
+    bool neg = false;
+    if (i < json.size() && json[i] == '-') {
+        neg = true;
+        ++i;
+    }
+    if (i >= json.size() || json[i] < '0' || json[i] > '9')
+        return std::nullopt;
+    constexpr std::int64_t kMax = std::numeric_limits<std::int64_t>::max();
+    std::int64_t v = 0;
+    while (i < json.size() && json[i] >= '0' && json[i] <= '9') {
+        const int digit = json[i] - '0';
+        // Reject BEFORE the multiply/add would overflow — computing past
+        // INT64_MAX and only checking afterward is undefined behavior for a
+        // signed type, not a value this parser could reliably detect once
+        // it has already happened.
+        if (v > (kMax - digit) / 10)
+            return std::nullopt;
+        v = v * 10 + digit;
+        ++i;
+    }
+    return neg ? -v : v;
+}
+
+} // namespace detail
+
+// ── Session-open / chunk-ack / commit response parsing ──────────────────
+
+struct SessionOpenResponse {
+    std::string upload_id;
+    std::string session_secret;
+    std::int64_t chunk_max_bytes{0};
+    std::int64_t offset{0};
+    std::int64_t expires_at{0};
+};
+
+/// Parses `{"upload_id","session_secret","chunk_max_bytes","offset","expires_at"}`
+/// (session-open success body). `nullopt` on any missing/malformed field, or
+/// a structurally impossible value (`chunk_max_bytes <= 0`, negative offset)
+/// — never a partially-populated result.
+[[nodiscard]] inline std::optional<SessionOpenResponse>
+parse_session_open_response(std::string_view body) {
+    auto upload_id = detail::extract_string(body, "upload_id");
+    auto secret = detail::extract_string(body, "session_secret");
+    auto chunk_max = detail::extract_int(body, "chunk_max_bytes");
+    auto offset = detail::extract_int(body, "offset");
+    auto expires = detail::extract_int(body, "expires_at");
+    if (!upload_id || upload_id->empty() || !secret || secret->empty() || !chunk_max ||
+        *chunk_max <= 0 || !offset || *offset < 0 || !expires)
+        return std::nullopt;
+    return SessionOpenResponse{*upload_id, *secret, *chunk_max, *offset, *expires};
+}
+
+/// Parses a successful chunk PUT's `{"offset":<new_offset>}` body.
+[[nodiscard]] inline std::optional<std::int64_t> parse_chunk_ack_offset(std::string_view body) {
+    return detail::extract_int(body, "offset");
+}
+
+struct CommitResponse {
+    std::string state;
+    std::int64_t actual_size{0};
+    std::string sha256;
+};
+
+/// Parses `{"state":"committed","actual_size","sha256"}`. `nullopt` unless
+/// `state` is EXACTLY `"committed"` — any other value on a 200 would be a
+/// server-contract violation this header refuses to paper over.
+[[nodiscard]] inline std::optional<CommitResponse> parse_commit_response(std::string_view body) {
+    auto state = detail::extract_string(body, "state");
+    auto size = detail::extract_int(body, "actual_size");
+    auto sha = detail::extract_string(body, "sha256");
+    if (!state || *state != "committed" || !size || !sha || sha->empty())
+        return std::nullopt;
+    return CommitResponse{*state, *size, *sha};
+}
+
+/// Whether a parsed commit response's reported size/hash agree with what
+/// THIS run actually computed and transmitted. A 200 response naming a
+/// different artifact's size or digest is a server-contract violation this
+/// header refuses to paper over — same posture as `parse_commit_response`
+/// rejecting a non-`"committed"` state.
+[[nodiscard]] inline bool commit_matches(const CommitResponse& resp, std::int64_t expected_size,
+                                         std::string_view expected_sha256) noexcept {
+    return resp.actual_size == expected_size && resp.sha256 == expected_sha256;
+}
+
+struct StatusResponse {
+    std::string state; ///< "open" | "committed" | "cancelled" | "expired"
+    std::int64_t offset{0};
+    std::int64_t expires_at{0};
+};
+
+/// Parses `{"state","offset","expires_at"}` (the status GET response).
+/// Used to resolve an outcome-AMBIGUOUS commit failure: the frozen
+/// protocol's status route answers 200 with the CURRENT state even once a
+/// session has gone terminal (`file_retrieval_routes.cpp`'s
+/// `register_status` handles `kOk` and `kSessionTerminal` identically), so
+/// this is the one call that can distinguish "already committed by an
+/// earlier attempt whose response was lost" from "genuinely failed or
+/// cancelled".
+[[nodiscard]] inline std::optional<StatusResponse> parse_status_response(std::string_view body) {
+    auto state = detail::extract_string(body, "state");
+    auto offset = detail::extract_int(body, "offset");
+    auto expires = detail::extract_int(body, "expires_at");
+    if (!state || state->empty() || !offset || *offset < 0 || !expires)
+        return std::nullopt;
+    return StatusResponse{*state, *offset, *expires};
+}
+
+struct ErrorInfo {
+    std::optional<Reason> reason;       ///< nullopt if absent or not one of the ten
+    std::optional<std::int64_t> offset; ///< present only for offset_mismatch
+    std::string message;
+};
+
+/// Parses the frozen error envelope's `error` object fields. Tolerant by
+/// design (never itself an error): an envelope missing `reason`/`offset`
+/// simply leaves those fields `nullopt` — the caller (`decide_next_action`)
+/// already treats a missing reason as "generic, classify by HTTP status
+/// alone".
+[[nodiscard]] inline ErrorInfo parse_error_envelope(std::string_view body) {
+    ErrorInfo info;
+    if (auto r = detail::extract_string(body, "reason"))
+        info.reason = parse_reason(*r);
+    info.offset = detail::extract_int(body, "offset");
+    if (auto m = detail::extract_string(body, "message"))
+        info.message = *m;
+    return info;
+}
+
+} // namespace yuzu::content_dist::upload

--- a/changelog.d/1.6-content-dist-authenticated-upload.changed.md
+++ b/changelog.d/1.6-content-dist-authenticated-upload.changed.md
@@ -5,6 +5,6 @@
   server-authenticated upload session, and streams the file in bounded chunks — honouring the
   server's declared `chunk_max_bytes`, re-syncing on an offset mismatch, retrying transient
   failures with backoff, and cancelling the session on any unrecoverable error — committing with a
-  SHA-256 computed from the exact same file handle the bytes were streamed from. `content_dist` also
-  gains its ABI4 per-OS capability declaration and a command-capability catalogue fragment for its
-  five actions.
+  SHA-256 computed from the exact same file handle the bytes were streamed from, and its capability
+  catalogue entry (`content/definitions/t2_capabilities.yaml`) updated to describe the authenticated
+  mechanism.

--- a/changelog.d/1.6-content-dist-authenticated-upload.changed.md
+++ b/changelog.d/1.6-content-dist-authenticated-upload.changed.md
@@ -1,0 +1,10 @@
+- **`content_dist.upload_file` now speaks the authenticated upload-grant protocol (CC-06 fix, agent
+  side).** The action no longer accepts an operator-supplied `server_url`, never constructs a plain
+  `http://` request, and never asserts its own agent identity on the wire. It instead takes an
+  operator-minted `grant_id`/`grant_secret` (from `POST /api/v1/upload-grants`), opens a
+  server-authenticated upload session, and streams the file in bounded chunks — honouring the
+  server's declared `chunk_max_bytes`, re-syncing on an offset mismatch, retrying transient
+  failures with backoff, and cancelling the session on any unrecoverable error — committing with a
+  SHA-256 computed from the exact same file handle the bytes were streamed from. `content_dist` also
+  gains its ABI4 per-OS capability declaration and a command-capability catalogue fragment for its
+  five actions.

--- a/content/definitions/t2_capabilities.yaml
+++ b/content/definitions/t2_capabilities.yaml
@@ -687,13 +687,18 @@ kind: InstructionDefinition
 metadata:
   id: agent.content_dist.upload_file
   displayName: Upload File to Server
-  version: 1.1.0
+  version: 1.2.0
   description: >
-    Upload a local file from the agent endpoint to the Yuzu server via
-    multipart POST. Computes the SHA-256 hash of the file before upload and
-    sends it alongside the file data for server-side verification. If
-    server_url is not provided, derives it from the agent's configured
-    server web URL. Maximum file size is configurable (default 100 MB).
+    Upload a local file from the agent endpoint to the Yuzu server through
+    the one-time upload-grant + authenticated chunked-receive protocol
+    (PR1.6, CC-06): the operator mints a grant out of band (POST
+    /api/v1/upload-grants) and passes its one-time grant_id/grant_secret
+    here. The agent opens a session against that grant, streams the file in
+    bounded chunks honouring the server's declared chunk size, and commits
+    with a SHA-256 computed from the exact bytes acknowledged. There is no
+    server_url parameter — the destination is derived entirely from the
+    grant and the agent's own configured server transport
+    (agent.server_web_url), and the connection is always TLS.
   tags: [content, upload, transfer, deployment]
 
 spec:
@@ -707,7 +712,7 @@ spec:
 
   parameters:
     type: object
-    required: [path]
+    required: [path, grant_id, grant_secret]
     properties:
       path:
         type: string
@@ -716,19 +721,37 @@ spec:
           The local file path on the endpoint to upload.
         validation:
           maxLength: 4096
-      server_url:
+      grant_id:
         type: string
-        displayName: Server URL
+        displayName: Grant ID
         description: >
-          The Yuzu server base URL to upload to. If not provided, uses the
-          agent's configured server web URL (agent.server_web_url).
+          The one-time upload grant's id, minted operator-side via POST
+          /api/v1/upload-grants. Paired with grant_secret to authenticate
+          the session; both are revealed by the mint response exactly once.
         validation:
-          maxLength: 2048
+          maxLength: 64
+      grant_secret:
+        type: string
+        displayName: Grant Secret
+        description: >
+          The one-time upload grant's secret, minted alongside grant_id.
+          Never logged or echoed back by the server after the mint response.
+        validation:
+          maxLength: 128
+      base_dir:
+        type: string
+        displayName: Base Directory Restriction
+        description: >
+          If set, path must resolve (after symlink canonicalisation) inside
+          this directory, or the upload is refused before anything is read.
+        validation:
+          maxLength: 4096
       max_size_mb:
         type: int32
         displayName: Max Size (MB)
         description: >
-          Maximum allowed file size in megabytes. Default: 100.
+          Maximum allowed file size in megabytes, checked locally before
+          the session opens. Default: 100.
         default: 100
         validation:
           minimum: 1
@@ -740,9 +763,9 @@ spec:
         type: string
       - name: sha256
         type: string
-      - name: bytes_uploaded
+      - name: size
         type: int64
-      - name: filename
+      - name: upload_id
         type: string
 
   readablePayload: "Upload ${path} to server"

--- a/docs/capability-map.md
+++ b/docs/capability-map.md
@@ -539,7 +539,7 @@ Not implemented. Integrity verification of directory trees.
 
 ### 10.13 File Retrieval (Upload to Server) :white_check_mark: `T2`
 
-`upload_file` action in `content_dist` plugin. Agent-side: SHA-256 hash, multipart POST to server. Server-side: `POST /api/v1/file-retrieval` endpoint. File stored in `{data_dir}/file-retrieval/`. `GET/DELETE` endpoints for management.
+`upload_file` action in `content_dist` plugin, via the PR1.6 one-time upload-grant + authenticated chunked-receive protocol (`docs/adr/3004-artifact-blob-storage.md`) — the legacy unauthenticated `POST /api/v1/file-retrieval` endpoint was removed. Operator mints a grant (`POST /api/v1/upload-grants`); the agent redeems it, streams the file in bounded chunks with per-chunk offset CAS, and commits with a SHA-256 computed from the exact bytes acknowledged. File stored in `{data_dir}/upload-blobs/{retention_class}/{grant_id}`. `GET /api/v1/upload-grants` (list) / `DELETE /api/v1/upload-grants/{id}` (revoke) for management.
 
 ### 10.14 Find File by Size and Hash :white_check_mark: `T2`
 

--- a/server/core/src/mcp_server.cpp
+++ b/server/core/src/mcp_server.cpp
@@ -14,6 +14,7 @@
 #include "reserved_definition_id.hpp" // kMcpDefinitionPrefix (#2442 — the ONE reserved-namespace rule)
 #include "rotation_confirm_state.hpp" // classify_confirm_state (#2443 confirm_engine_rotation precondition)
 #include "rotation_sweep_naming.hpp" // kApiTokenConfirmTotalMetric (shared REST/MCP metric symbol)
+#include "sensitive_instruction_params.hpp" // redact_sensitive_instruction_params (#3136 blocker)
 #include "token_rotation_lookup.hpp" // shared REST/MCP human-token rotation successor lookup (P2 #11)
 
 #include "agent_registry.hpp"           // AgentRegistry (discover_plugins tool)
@@ -6971,7 +6972,11 @@ McpServer::HandlerFn McpServer::build_handler(
                     // appears in the live executions view.
                     exec.status = "running";
                     exec.scope_expression = scope;
-                    exec.parameter_values = nlohmann::json(params).dump();
+                    // #3136 blocker: persist a REDACTED copy — the live
+                    // dispatch below still uses the raw `params` map. See
+                    // sensitive_instruction_params.hpp.
+                    exec.parameter_values =
+                        nlohmann::json(redact_sensitive_instruction_params(params)).dump();
                     // dispatched_by — `session` was authenticated at
                     // handler entry (line ~363) and is in scope here.
                     exec.dispatched_by = session->username;

--- a/server/core/src/rest_api_v1.cpp
+++ b/server/core/src/rest_api_v1.cpp
@@ -23,6 +23,7 @@
 #include "openapi_spec_access.hpp" // external-linkage accessor for discover_routes.cpp / mcp_server.cpp
 #include "principal_quota_gate.hpp" // detail::adopt_quota_slot_into_stream (UP-1)
 #include "rest_a4_envelope.hpp"
+#include "sensitive_instruction_params.hpp" // redact_sensitive_instruction_params (#3136 blocker)
 #include "rest_a4_envelope_http.hpp" // detail::a4_error/a4_denial — #1470 error_json migration
 #include "rest_audit.hpp"            // detail::emit_behavioral_audit (Sec-Audit-Failed, #1647)
 #include "rotation_sweep_naming.hpp" // kApiTokenConfirmTotalMetric
@@ -6958,7 +6959,14 @@ void RestApiV1::register_routes(
             exec.definition_id = std::string(src_kind);
             exec.status = "running";
             exec.scope_expression = scope_expr;
-            exec.parameter_values = nlohmann::json(params).dump();
+            // #3136 blocker: persist a REDACTED copy — the live dispatch
+            // below still uses the raw `params` map. See
+            // sensitive_instruction_params.hpp. This is the same
+            // create-before-dispatch shape as workflow_routes.cpp/
+            // mcp_server.cpp's execute_instruction — an additional leak
+            // site beyond those two, found while remediating #3136.
+            exec.parameter_values =
+                nlohmann::json(redact_sensitive_instruction_params(params)).dump();
             exec.dispatched_by = owner;
             std::string exec_id;
             if (auto created = execution_tracker->create_execution(exec); created.has_value())

--- a/server/core/src/schedule_engine.cpp
+++ b/server/core/src/schedule_engine.cpp
@@ -1,6 +1,7 @@
 #include "schedule_engine.hpp"
 #include "migration_runner.hpp"
 #include "schedule_params_parsers.hpp"
+#include "sensitive_instruction_params.hpp" // schedule_params_contain_sensitive_key (#3136 blocker)
 
 #include <spdlog/spdlog.h>
 
@@ -210,6 +211,21 @@ ScheduleEngine::create_schedule(const InstructionSchedule& sched) {
     auto canon_params = validate_and_canonicalize_schedule_params(sched.parameter_values);
     if (!canon_params)
         return std::unexpected(std::string(to_string(canon_params.error())));
+
+    // #3136 blocker: a schedule's parameter_values is the SOLE record
+    // ScheduleRunner::dispatch_tracked reads back to fire every future
+    // occurrence (schedule_runner.cpp) — unlike the one-shot dispatch paths
+    // (workflow_routes.cpp, mcp_server.cpp, rest_api_v1.cpp), there is no
+    // separate raw in-memory value to redact FROM: the persisted blob IS
+    // what gets redispatched. Redacting it here would silently break
+    // re-dispatch instead of merely protecting a history row, so a
+    // grant_secret-bearing schedule is refused outright — a single-
+    // redemption, ~15-minute-TTL credential cannot survive as a repeatable
+    // schedule regardless of this leak. See sensitive_instruction_params.hpp.
+    if (schedule_params_contain_sensitive_key(*canon_params))
+        return std::unexpected(
+            "parameters contain a one-time credential (grant_secret/grant_id) that cannot be "
+            "scheduled — mint a fresh grant and dispatch it directly instead");
 
     std::unique_lock lock(mtx_);
 

--- a/server/core/src/sensitive_instruction_params.hpp
+++ b/server/core/src/sensitive_instruction_params.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+/// @file sensitive_instruction_params.hpp
+/// PR3136 review remediation (blocker): a small, explicit list of instruction
+/// parameter KEYS that must never reach a persisted parameter_values column.
+/// `grant_secret` is content_dist.upload_file's one-time upload-grant
+/// secret — docs/adr/3004-artifact-blob-storage.md's "Credential shape and
+/// verification" section promises it never appears in a log line, an audit
+/// `detail` field, or a second database column beyond the store's own
+/// sha256(secret). `grant_id` is redacted alongside it, defense-in-depth, as
+/// the lookup key for that secret's own store row.
+///
+/// Two consumers, by dispatch shape:
+///   - One-shot dispatch paths (workflow_routes.cpp, mcp_server.cpp,
+///     rest_api_v1.cpp's result-set producer) build a request-scoped params
+///     map, dispatch with it immediately, then persist a COPY for
+///     audit/history only — `redact_sensitive_instruction_params` strips the
+///     persisted copy while the live dispatch still uses the raw map.
+///   - Schedules (schedule_engine.cpp) have no such split: the PERSISTED
+///     blob is the only record `ScheduleRunner::dispatch_tracked` reads back
+///     to fire a FUTURE dispatch, so redacting it would silently break
+///     re-dispatch instead of merely protecting a history row.
+///     `schedule_params_contain_sensitive_key` is used instead to REFUSE
+///     persisting a schedule at all when it carries one of these keys — a
+///     single-redemption, ~15-minute-TTL credential cannot survive as a
+///     repeatable schedule regardless of this leak, so refusal is the
+///     correct fix on both functional and security grounds, not merely the
+///     safer one.
+///
+/// EXTEND this list for the next secret-carrying instruction parameter
+/// (`directory_sync.client_secret` is a known pre-existing case with the
+/// same exposure, tracked separately as systemic — PR3136 review) — never
+/// hand-roll a second per-callsite redaction or rejection.
+
+#include <nlohmann/json.hpp>
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace yuzu::server {
+
+inline constexpr std::string_view kRedactedInstructionParamKeys[] = {"grant_secret", "grant_id"};
+
+[[nodiscard]] inline bool is_redacted_instruction_param_key(std::string_view key) {
+    for (auto redacted : kRedactedInstructionParamKeys)
+        if (key == redacted)
+            return true;
+    return false;
+}
+
+/// Strip every redacted key from a copy of `params`. Call this ONLY at a
+/// PERSISTENCE site (an executions/audit row) — never before building the
+/// in-memory CommandRequest, which still needs the raw value.
+[[nodiscard]] inline std::unordered_map<std::string, std::string>
+redact_sensitive_instruction_params(std::unordered_map<std::string, std::string> params) {
+    for (auto redacted : kRedactedInstructionParamKeys)
+        params.erase(std::string(redacted));
+    return params;
+}
+
+/// True if a canonical (already-validated, object-shaped) schedule
+/// parameters JSON string carries a redacted key. Used to REFUSE schedule
+/// creation outright rather than silently storing a value the schedule can
+/// never safely re-dispatch.
+[[nodiscard]] inline bool schedule_params_contain_sensitive_key(std::string_view canonical_json) {
+    nlohmann::json parsed;
+    try {
+        parsed = nlohmann::json::parse(canonical_json);
+    } catch (const nlohmann::json::exception&) {
+        return false; // malformed input is a separate validator's job to reject
+    }
+    if (!parsed.is_object())
+        return false;
+    for (const auto& [key, value] : parsed.items())
+        if (is_redacted_instruction_param_key(key))
+            return true;
+    return false;
+}
+
+}  // namespace yuzu::server

--- a/server/core/src/workflow_routes.cpp
+++ b/server/core/src/workflow_routes.cpp
@@ -7,6 +7,7 @@
 #include "http_route_sink.hpp"
 #include "principal_quota_gate.hpp" // detail::adopt_quota_slot_into_stream (UP-1)
 #include "scope_engine.hpp"
+#include "sensitive_instruction_params.hpp" // redact_sensitive_instruction_params (#3136 blocker)
 #include "web_utils.hpp"
 
 #include <nlohmann/json.hpp>
@@ -1629,7 +1630,11 @@ void WorkflowRoutes::register_routes(HttpRouteSink& sink, Deps deps) {
             exec.definition_id = def_id;
             exec.status = "running";
             exec.scope_expression = scope_expr;
-            exec.parameter_values = nlohmann::json(params).dump();
+            // #3136 blocker: persist a REDACTED copy — the live dispatch
+            // below still uses the raw `params` map. See
+            // sensitive_instruction_params.hpp.
+            exec.parameter_values =
+                nlohmann::json(redact_sensitive_instruction_params(params)).dump();
             exec.dispatched_by = session->username;
             if (auto created = execution_tracker->create_execution(exec); created.has_value()) {
                 execution_id = *created;

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -254,6 +254,7 @@ agent_test_exe = executable(
     'unit/test_registry_local_dispatcher.cpp', # PR1.7 remediation fix #3: real registry.dll driven
                                                 # end to end via LocalDispatcher (Windows-only; a no-op
                                                 # TU elsewhere via the file's own #ifdef _WIN32 guard)
+    'unit/test_content_dist_upload_parsers.cpp', # PR1.6b: pure upload-protocol planner/classifier (no I/O)
   ),
   include_directories: [
     include_directories('../agents/plugins/vuln_scan/src'),  # cve_rules.hpp
@@ -274,6 +275,7 @@ agent_test_exe = executable(
     include_directories('../agents/plugins/event_logs/src'),    # event_logs_macos.hpp (BR-08)
     include_directories('../agents/plugins/certificates/src'),  # certificates_macos_parsers.hpp (Gate-7 FIX A: pure helpers shared with the plugin)
     include_directories('../agents/plugins/users/src'),         # users_macos_last.hpp (qe-M1 pure parser)
+    include_directories('../agents/plugins/content_dist/src'),  # content_dist_upload_parsers.hpp (PR1.6b pure helpers)
   ],
   # agent_platform_args carries -DYUZU_HAVE_LIBSYSTEMD (Linux + libsystemd found)
   # so Linux real-mechanism Service spark tests can compile-gate on it, exactly

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -505,6 +505,7 @@ if build_server
       'unit/server/test_web_utils.cpp',
       'unit/server/test_mcp_body_cap.cpp',
       'unit/server/test_dispatch_target_shape.cpp',
+      'unit/server/test_sensitive_instruction_params.cpp',
       'unit/server/test_workflow_routes.cpp',
       'unit/server/test_agent_service_impl.cpp',
       'unit/server/test_analytics_event.cpp',

--- a/tests/unit/server/test_schedule_engine.cpp
+++ b/tests/unit/server/test_schedule_engine.cpp
@@ -81,6 +81,52 @@ TEST_CASE("ScheduleEngine: create with bad frequency_type fails", "[schedule_eng
     CHECK(!result.has_value());
 }
 
+// #3136 blocker: a schedule's parameter_values is the sole record
+// ScheduleRunner::dispatch_tracked reads back to re-dispatch on every future
+// occurrence — redacting a persisted grant_secret would silently break that
+// re-dispatch rather than merely protecting a history row, so creation is
+// refused outright instead. See sensitive_instruction_params.hpp.
+TEST_CASE("ScheduleEngine: create is refused when parameters carry a one-time credential",
+         "[schedule_engine]") {
+    TestDb tdb;
+    ScheduleEngine engine(tdb.db);
+    engine.create_tables();
+
+    auto sched = make_schedule("def-001", "interval", "Upload Schedule");
+    sched.interval_minutes = 60;
+    sched.parameter_values = R"({"grant_secret":"deadbeef","path":"/tmp/x"})";
+    auto result = engine.create_schedule(sched);
+    REQUIRE_FALSE(result.has_value());
+    CHECK(result.error().find("one-time credential") != std::string::npos);
+}
+
+TEST_CASE("ScheduleEngine: create is refused when parameters carry a bare grant_id",
+         "[schedule_engine]") {
+    TestDb tdb;
+    ScheduleEngine engine(tdb.db);
+    engine.create_tables();
+
+    auto sched = make_schedule("def-001", "interval", "Upload Schedule");
+    sched.interval_minutes = 60;
+    sched.parameter_values = R"({"grant_id":"abc123"})";
+    auto result = engine.create_schedule(sched);
+    CHECK_FALSE(result.has_value());
+}
+
+TEST_CASE("ScheduleEngine: create succeeds when parameters carry no sensitive key",
+         "[schedule_engine]") {
+    TestDb tdb;
+    ScheduleEngine engine(tdb.db);
+    engine.create_tables();
+
+    auto sched = make_schedule("def-001", "interval", "Ordinary Schedule");
+    sched.interval_minutes = 60;
+    sched.parameter_values = R"({"path":"/tmp/x","max_size_mb":"100"})";
+    auto result = engine.create_schedule(sched);
+    REQUIRE(result.has_value());
+    CHECK(!result->empty());
+}
+
 TEST_CASE("ScheduleEngine: create schedule with all fields", "[schedule_engine]") {
     TestDb tdb;
     ScheduleEngine engine(tdb.db);

--- a/tests/unit/server/test_sensitive_instruction_params.cpp
+++ b/tests/unit/server/test_sensitive_instruction_params.cpp
@@ -1,0 +1,80 @@
+/**
+ * test_sensitive_instruction_params.cpp — the pure redaction/rejection rule
+ * that closes PR3136's review blocker: `content_dist.upload_file`'s one-time
+ * `grant_secret` bearer credential was being persisted in cleartext into
+ * `executions.parameter_values` (workflow_routes.cpp, mcp_server.cpp,
+ * rest_api_v1.cpp's result-set producer) and readable by any principal
+ * holding the broadly-granted `Execution:Read` permission — a direct
+ * violation of docs/adr/3004-artifact-blob-storage.md's promise that the raw
+ * secret "never appears in a log line, an audit detail field, or a second
+ * database column."
+ *
+ * Two distinct fixes, because the two families of caller have different
+ * shapes (see sensitive_instruction_params.hpp's file header for why):
+ * one-shot dispatch paths REDACT the persisted copy while still dispatching
+ * with the raw in-memory map; schedules REFUSE to persist at all, since a
+ * schedule's parameter_values is the sole record re-dispatched on every
+ * future occurrence.
+ */
+
+#include "sensitive_instruction_params.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace yuzu::server;
+
+TEST_CASE("redact_sensitive_instruction_params strips grant_secret and grant_id",
+         "[server][sensitive_params]") {
+    std::unordered_map<std::string, std::string> params{
+        {"grant_secret", "deadbeef"}, {"grant_id", "abc123"}, {"path", "/tmp/file.bin"}};
+    auto redacted = redact_sensitive_instruction_params(params);
+    CHECK(redacted.count("grant_secret") == 0);
+    CHECK(redacted.count("grant_id") == 0);
+    REQUIRE(redacted.count("path") == 1);
+    CHECK(redacted.at("path") == "/tmp/file.bin");
+}
+
+TEST_CASE("redact_sensitive_instruction_params is a no-op when no sensitive key is present",
+         "[server][sensitive_params]") {
+    std::unordered_map<std::string, std::string> params{{"path", "/tmp/file.bin"},
+                                                         {"max_size_mb", "100"}};
+    auto redacted = redact_sensitive_instruction_params(params);
+    CHECK(redacted.size() == 2);
+    CHECK(redacted.at("path") == "/tmp/file.bin");
+    CHECK(redacted.at("max_size_mb") == "100");
+}
+
+TEST_CASE("redact_sensitive_instruction_params on an empty map returns empty",
+         "[server][sensitive_params]") {
+    std::unordered_map<std::string, std::string> params;
+    CHECK(redact_sensitive_instruction_params(params).empty());
+}
+
+TEST_CASE("is_redacted_instruction_param_key recognizes exactly the closed set",
+         "[server][sensitive_params]") {
+    CHECK(is_redacted_instruction_param_key("grant_secret"));
+    CHECK(is_redacted_instruction_param_key("grant_id"));
+    CHECK_FALSE(is_redacted_instruction_param_key("path"));
+    CHECK_FALSE(is_redacted_instruction_param_key("Grant_Secret")); // case-sensitive
+    CHECK_FALSE(is_redacted_instruction_param_key(""));
+}
+
+TEST_CASE("schedule_params_contain_sensitive_key detects grant_secret in a canonical object",
+         "[server][sensitive_params]") {
+    CHECK(schedule_params_contain_sensitive_key(R"({"grant_secret":"deadbeef"})"));
+    CHECK(schedule_params_contain_sensitive_key(R"({"path":"/x","grant_id":"abc"})"));
+}
+
+TEST_CASE("schedule_params_contain_sensitive_key is false for ordinary params",
+         "[server][sensitive_params]") {
+    CHECK_FALSE(schedule_params_contain_sensitive_key(R"({"path":"/x","max_size_mb":"100"})"));
+    CHECK_FALSE(schedule_params_contain_sensitive_key("{}"));
+}
+
+TEST_CASE("schedule_params_contain_sensitive_key fails closed-to-false on malformed/non-object "
+         "input (a separate validator's job to reject)",
+         "[server][sensitive_params]") {
+    CHECK_FALSE(schedule_params_contain_sensitive_key("not json"));
+    CHECK_FALSE(schedule_params_contain_sensitive_key("[1,2,3]"));
+    CHECK_FALSE(schedule_params_contain_sensitive_key(""));
+}

--- a/tests/unit/server/test_workflow_routes.cpp
+++ b/tests/unit/server/test_workflow_routes.cpp
@@ -139,6 +139,11 @@ struct ExecHarness {
     /// into the dispatch stub (the confinement the production dispatch_confined
     /// seam then applies). Mirrors test_mcp_server.cpp's last_dispatch_exec_visible.
     yuzu::server::authz::VisibleSet last_dispatch_exec_visible;
+    /// #3136 blocker regression net: the RAW params map cmd_dispatch actually
+    /// received, so a test can assert it still carries a sensitive value
+    /// (e.g. grant_secret) even though the PERSISTED execution row's
+    /// parameter_values must not.
+    std::unordered_map<std::string, std::string> last_dispatch_params;
     /// PLAN-006: the full DispatchCaller (identity + exec_visible) the execute
     /// handler threaded into the dispatch stub, so a test can assert the
     /// principal half independently of last_dispatch_exec_visible above.
@@ -243,7 +248,7 @@ struct ExecHarness {
         auto cmd_dispatch = [this](const std::string&, const std::string&,
                                    const std::vector<std::string>& agent_ids,
                                    const std::string& scope_expr,
-                                   const std::unordered_map<std::string, std::string>&,
+                                   const std::unordered_map<std::string, std::string>& params,
                                    const std::string& execution_id,
                                    const yuzu::server::DispatchCaller& caller)
             -> std::pair<std::string, int> {
@@ -252,6 +257,7 @@ struct ExecHarness {
             ++dispatch_calls;
             last_dispatch_agent_ids = agent_ids;
             last_dispatch_scope = scope_expr;
+            last_dispatch_params = params;
             // K-R7-02 / PLAN-006: capture the confinement + identity threaded
             // into dispatch.
             last_dispatch_exec_visible = caller.exec_visible;
@@ -994,6 +1000,47 @@ TEST_CASE("#1088 — POST /api/instructions/:id/execute response includes execut
     CHECK(body["command_id"] == "cmd-agentic-abc");
     CHECK(body["agents_reached"] == 3);
     CHECK(body["definition_id"] == "def-AGENTIC");
+}
+
+TEST_CASE("#3136 blocker: grant_secret reaches cmd_dispatch but is redacted from the "
+         "persisted execution row",
+         "[pg][workflow][executions][security]") {
+    // The concrete attack this closes: an execution row created BEFORE
+    // dispatch (create-before-dispatch, UP2-4) used to carry the FULL
+    // caller-supplied params JSON — including a one-time upload-grant
+    // secret — into executions.parameter_values, readable by any principal
+    // holding the broadly-granted Execution:Read permission within the
+    // grant's TTL. See sensitive_instruction_params.hpp.
+    YUZU_REQUIRE_PG_DB_TPL(db, responsestore_tpl);
+    PgPool pool{{.conninfo = db.dsn(), .size = 4}};
+    ExecHarness h(pool);
+    h.make_def("def-UPLOAD", "Upload File");
+    h.dispatch_cmd_override = "cmd-upload-abc";
+    h.dispatch_sent_override = 1;
+
+    auto res = h.sink.Post(
+        "/api/instructions/def-UPLOAD/execute",
+        R"({"params":{"grant_id":"deadbeef","grant_secret":"topsecret","path":"/tmp/x"},)"
+        R"("agent_ids":["agent-1"]})");
+    REQUIRE(res);
+    REQUIRE(res->status == 200);
+
+    // The LIVE dispatch still got the raw secret — otherwise the upload
+    // could never actually authenticate against the server.
+    REQUIRE(h.dispatch_calls == 1);
+    CHECK(h.last_dispatch_params.at("grant_secret") == "topsecret");
+    CHECK(h.last_dispatch_params.at("grant_id") == "deadbeef");
+
+    // The PERSISTED row must not carry either sensitive key.
+    auto body = nlohmann::json::parse(res->body);
+    auto exec = h.tracker->get_execution(body["execution_id"].get<std::string>());
+    REQUIRE(exec.has_value());
+    auto stored = nlohmann::json::parse(exec->parameter_values);
+    CHECK_FALSE(stored.contains("grant_secret"));
+    CHECK_FALSE(stored.contains("grant_id"));
+    // Ordinary, non-sensitive parameters survive untouched.
+    REQUIRE(stored.contains("path"));
+    CHECK(stored["path"] == "/tmp/x");
 }
 
 TEST_CASE("PR2 hardening — query_by_execution includes the partial-index "

--- a/tests/unit/test_content_dist_upload_parsers.cpp
+++ b/tests/unit/test_content_dist_upload_parsers.cpp
@@ -1,0 +1,430 @@
+/**
+ * test_content_dist_upload_parsers.cpp — pure-parser coverage for
+ * `content_dist`'s `upload_file` action (content_dist_upload_parsers.hpp),
+ * the AGENT half of the PR1.6 one-time upload grant + authenticated chunked
+ * receive protocol. Fixture strings only — no sockets, no filesystem, no
+ * process spawns, no sleeps; `backoff_delay_ms` is checked as a pure
+ * function of its input, never actually slept on.
+ *
+ * `plan_resync_rehash` below is the pure decision `do_upload`'s commit-hash
+ * repair (content_dist_plugin.cpp) is built on — a lost chunk-ack response
+ * followed by a forward resync used to leave the acknowledged bytes out of
+ * the commit digest, since the hasher is fed only on the ACK path and a
+ * lost ACK meant that feed never happened. The orchestration itself (the
+ * actual network loop, actual file reads, actual `IncrementalSha256`) is
+ * NOT unit-tested here, deliberately: it lives in the "no sockets, no
+ * filesystem, no process spawns" shell this file's own header comment
+ * names, and TLS is mandatory for every request that shell makes with no
+ * test-CA injection point — exercising it for real belongs on the
+ * integration surface (CLAUDE.md's "inject the boundary" / "prefer the
+ * integration surface" test-efficiency rules), not the unit suite. What is
+ * pinned here is the invariant the fix depends on: which byte range must be
+ * re-hashed, and that a resync which does NOT move past what has already
+ * been hashed triggers no repair at all.
+ */
+
+#include "content_dist_upload_parsers.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace yuzu::content_dist::upload;
+
+// ── Chunk planning ───────────────────────────────────────────────────────
+
+TEST_CASE("plan_next_chunk: a successful multi-chunk plan walks the whole file",
+         "[agent][content_dist][upload]") {
+    // 25 bytes, 10-byte chunks -> 10, 10, 5.
+    auto c1 = plan_next_chunk(0, 25, 10);
+    REQUIRE(c1.has_value());
+    CHECK(c1->start == 0);
+    CHECK(c1->end == 9);
+    CHECK(c1->total == 25);
+
+    auto c2 = plan_next_chunk(10, 25, 10);
+    REQUIRE(c2.has_value());
+    CHECK(c2->start == 10);
+    CHECK(c2->end == 19);
+
+    auto c3 = plan_next_chunk(20, 25, 10);
+    REQUIRE(c3.has_value());
+    CHECK(c3->start == 20);
+    CHECK(c3->end == 24); // last chunk is short, not padded
+
+    // Nothing left once offset reaches file_size.
+    CHECK_FALSE(plan_next_chunk(25, 25, 10).has_value());
+}
+
+TEST_CASE("plan_next_chunk: a chunk never exceeds chunk_max_bytes and never buffers past it",
+         "[agent][content_dist][upload]") {
+    auto c = plan_next_chunk(0, 1'000'000, 8 * 1024 * 1024);
+    REQUIRE(c.has_value());
+    CHECK(c->end - c->start + 1 == 1'000'000); // whole (small) file fits in one chunk
+}
+
+TEST_CASE("plan_next_chunk: rejects structurally invalid input", "[agent][content_dist][upload]") {
+    CHECK_FALSE(plan_next_chunk(-1, 100, 10).has_value());  // negative offset
+    CHECK_FALSE(plan_next_chunk(0, 0, 10).has_value());     // empty file
+    CHECK_FALSE(plan_next_chunk(0, 100, 0).has_value());    // zero chunk cap
+    CHECK_FALSE(plan_next_chunk(150, 100, 10).has_value()); // offset past EOF
+}
+
+TEST_CASE("chunk_count matches how many plan_next_chunk calls a fresh upload needs",
+         "[agent][content_dist][upload]") {
+    CHECK(chunk_count(25, 10) == 3);
+    CHECK(chunk_count(20, 10) == 2);
+    CHECK(chunk_count(1, 10) == 1);
+    CHECK(chunk_count(0, 10) == 0);
+}
+
+// ── Resume-offset reconciliation ────────────────────────────────────────
+
+TEST_CASE("reconcile_resume_offset accepts any offset within [0, file_size]",
+         "[agent][content_dist][upload]") {
+    CHECK(reconcile_resume_offset(0, 100) == 0);
+    CHECK(reconcile_resume_offset(50, 100) == 50);
+    CHECK(reconcile_resume_offset(100, 100) == 100); // exactly EOF is valid (upload complete)
+}
+
+TEST_CASE("reconcile_resume_offset rejects an offset outside the file",
+         "[agent][content_dist][upload]") {
+    CHECK_FALSE(reconcile_resume_offset(-1, 100).has_value());
+    CHECK_FALSE(reconcile_resume_offset(101, 100).has_value());
+}
+
+TEST_CASE("plan_resync_rehash: the lost-ack scenario — a forward resync past what has "
+         "been hashed requires repairing exactly the gap",
+         "[agent][content_dist][upload]") {
+    // The exact defect: chunk 1 covers [0, 40) and the server accepts it,
+    // but this process never sees the 200 response (dropped connection),
+    // so `hasher` is never fed those bytes — hashed_to stays 0. The retry
+    // of chunk 1 then gets offset_mismatch with the server's real recorded
+    // offset, 40 (it already has those bytes). Repairing the digest means
+    // hashing exactly [0, 40) before adopting offset 40.
+    auto range = plan_resync_rehash(/*hashed_to=*/0, /*resynced_offset=*/40);
+    REQUIRE(range.has_value());
+    CHECK(range->start == 0);
+    CHECK(range->end == 40);
+}
+
+TEST_CASE("plan_resync_rehash: a resync that does not move past what is already hashed "
+         "requires no repair",
+         "[agent][content_dist][upload]") {
+    // The ordinary case: hasher already covers everything up to the
+    // current offset, so a resync landing at or behind that point is a
+    // no-op for the digest (it might still affect the send-side offset,
+    // but that is `reconcile_resume_offset`'s concern, not this one's).
+    CHECK_FALSE(plan_resync_rehash(/*hashed_to=*/40, /*resynced_offset=*/40).has_value());
+    CHECK_FALSE(plan_resync_rehash(/*hashed_to=*/40, /*resynced_offset=*/20).has_value());
+    CHECK_FALSE(plan_resync_rehash(/*hashed_to=*/40, /*resynced_offset=*/0).has_value());
+}
+
+TEST_CASE("plan_resync_rehash: a mid-stream loss (chunk 3 of 5 acknowledged silently) "
+         "still yields exactly the missing middle range",
+         "[agent][content_dist][upload]") {
+    // hashed_to sits at the end of chunk 2 (bytes [0,20) already fed to the
+    // hasher on their own successful acks); the lost ack belongs to chunk 3,
+    // [20,30); the resync target is 30. Only that ten-byte gap is missing —
+    // proving the range is anchored to hashed_to, not to 0, so a resume
+    // from a partial hasher state never re-hashes bytes it already has.
+    auto range = plan_resync_rehash(/*hashed_to=*/20, /*resynced_offset=*/30);
+    REQUIRE(range.has_value());
+    CHECK(range->start == 20);
+    CHECK(range->end == 30);
+}
+
+TEST_CASE("validate_chunk_ack accepts only the offset the request itself committed to",
+         "[agent][content_dist][upload]") {
+    // A chunk covering [10, 19] must ack exactly 20 — the agent already
+    // knows this, it isn't new information from the server.
+    CHECK(validate_chunk_ack(20, 20, 100) == 20);
+}
+
+TEST_CASE("validate_chunk_ack rejects a missing, disagreeing, or out-of-range acknowledgement",
+         "[agent][content_dist][upload]") {
+    CHECK_FALSE(validate_chunk_ack(std::nullopt, 20, 100).has_value());  // missing
+    CHECK_FALSE(validate_chunk_ack(19, 20, 100).has_value());            // behind
+    CHECK_FALSE(validate_chunk_ack(21, 20, 100).has_value());            // ahead
+    CHECK_FALSE(validate_chunk_ack(-1, 20, 100).has_value());            // negative
+    CHECK_FALSE(validate_chunk_ack(150, 20, 100).has_value());           // past EOF
+}
+
+// ── The ten frozen reason strings ───────────────────────────────────────
+
+TEST_CASE("parse_reason recognizes every one of the ten frozen strings, and only those",
+         "[agent][content_dist][upload]") {
+    CHECK(parse_reason("grant_unknown") == Reason::kGrantUnknown);
+    CHECK(parse_reason("grant_already_redeemed") == Reason::kGrantAlreadyRedeemed);
+    CHECK(parse_reason("expired") == Reason::kExpired);
+    CHECK(parse_reason("offset_mismatch") == Reason::kOffsetMismatch);
+    CHECK(parse_reason("chunk_too_large") == Reason::kChunkTooLarge);
+    CHECK(parse_reason("size_exceeded") == Reason::kSizeExceeded);
+    CHECK(parse_reason("hash_mismatch") == Reason::kHashMismatch);
+    CHECK(parse_reason("session_unknown") == Reason::kSessionUnknown);
+    CHECK(parse_reason("session_terminal") == Reason::kSessionTerminal);
+    CHECK(parse_reason("tls_required") == Reason::kTlsRequired);
+
+    CHECK_FALSE(parse_reason("").has_value());
+    CHECK_FALSE(parse_reason("not_a_real_reason").has_value());
+    CHECK_FALSE(parse_reason("Grant_Unknown").has_value()); // case-sensitive, matches the wire exactly
+}
+
+TEST_CASE("reason_string(parse_reason(s)) round-trips for every one of the ten reasons",
+         "[agent][content_dist][upload]") {
+    const char* kReasons[] = {
+        "grant_unknown", "grant_already_redeemed", "expired",         "offset_mismatch",
+        "chunk_too_large", "size_exceeded",         "hash_mismatch",  "session_unknown",
+        "session_terminal", "tls_required",
+    };
+    for (auto* s : kReasons) {
+        auto r = parse_reason(s);
+        REQUIRE(r.has_value());
+        CHECK(reason_string(*r) == s);
+    }
+}
+
+TEST_CASE("classify_reason maps every one of the ten frozen reasons to a decision",
+         "[agent][content_dist][upload]") {
+    // Resync: the response carries new authoritative state to adopt.
+    CHECK(classify_reason(Reason::kOffsetMismatch) == UploadDecision::kResync);
+
+    // Abort: every other frozen reason is a terminal, non-retryable outcome.
+    // `chunk_too_large` included — the agent's cap is deterministic from
+    // `chunk_max_bytes` learned at session-open, so a retry resends the
+    // IDENTICAL range and cannot converge on its own (no new cap comes back
+    // in-band); retrying would only burn the attempt budget.
+    CHECK(classify_reason(Reason::kChunkTooLarge) == UploadDecision::kAbort);
+    CHECK(classify_reason(Reason::kGrantUnknown) == UploadDecision::kAbort);
+    CHECK(classify_reason(Reason::kGrantAlreadyRedeemed) == UploadDecision::kAbort);
+    CHECK(classify_reason(Reason::kExpired) == UploadDecision::kAbort);
+    CHECK(classify_reason(Reason::kSizeExceeded) == UploadDecision::kAbort);
+    CHECK(classify_reason(Reason::kHashMismatch) == UploadDecision::kAbort);
+    CHECK(classify_reason(Reason::kSessionUnknown) == UploadDecision::kAbort);
+    CHECK(classify_reason(Reason::kSessionTerminal) == UploadDecision::kAbort);
+    CHECK(classify_reason(Reason::kTlsRequired) == UploadDecision::kAbort);
+}
+
+// ── decide_next_action: the scenarios the spec calls out by name ───────
+
+TEST_CASE("decide_next_action: 409 offset_mismatch re-syncs immediately, no backoff",
+         "[agent][content_dist][upload]") {
+    auto d = decide_next_action(409, Reason::kOffsetMismatch, 1);
+    CHECK(d.action == UploadDecision::kResync);
+    CHECK(d.backoff_ms == 0);
+}
+
+TEST_CASE("decide_next_action: 413 chunk_too_large aborts regardless of attempt number",
+         "[agent][content_dist][upload]") {
+    // No new cap comes back in-band, so a retry would resend the identical
+    // range and can never converge — abort immediately rather than burn
+    // the attempt budget on a guaranteed repeat failure.
+    CHECK(decide_next_action(413, Reason::kChunkTooLarge, 1).action == UploadDecision::kAbort);
+    CHECK(decide_next_action(413, Reason::kChunkTooLarge, kMaxAttempts + 10).action ==
+         UploadDecision::kAbort);
+}
+
+TEST_CASE("decide_next_action: 410 expired aborts, no retry regardless of attempt number",
+         "[agent][content_dist][upload]") {
+    CHECK(decide_next_action(410, Reason::kExpired, 1).action == UploadDecision::kAbort);
+    CHECK(decide_next_action(410, Reason::kExpired, kMaxAttempts + 10).action ==
+         UploadDecision::kAbort);
+}
+
+TEST_CASE("decide_next_action: 422 hash_mismatch aborts", "[agent][content_dist][upload]") {
+    CHECK(decide_next_action(422, Reason::kHashMismatch, 1).action == UploadDecision::kAbort);
+}
+
+TEST_CASE("decide_next_action: 409 grant_already_redeemed aborts", "[agent][content_dist][upload]") {
+    CHECK(decide_next_action(409, Reason::kGrantAlreadyRedeemed, 1).action ==
+         UploadDecision::kAbort);
+}
+
+TEST_CASE("decide_next_action: a retryable 5xx with no reason backs off and grows with attempt",
+         "[agent][content_dist][upload]") {
+    auto d1 = decide_next_action(503, std::nullopt, 1);
+    CHECK(d1.action == UploadDecision::kRetry);
+    CHECK(d1.backoff_ms > 0);
+
+    auto d2 = decide_next_action(503, std::nullopt, 2);
+    CHECK(d2.action == UploadDecision::kRetry);
+    CHECK(d2.backoff_ms > d1.backoff_ms); // exponential, not flat
+
+    // A connection-level failure (no HTTP response at all) is the same
+    // transient case, reported by the shell as status 0.
+    CHECK(decide_next_action(0, std::nullopt, 1).action == UploadDecision::kRetry);
+}
+
+TEST_CASE("decide_next_action: exhausted attempts abort even on an otherwise-retryable status",
+         "[agent][content_dist][upload]") {
+    auto d = decide_next_action(503, std::nullopt, kMaxAttempts);
+    CHECK(d.action == UploadDecision::kAbort);
+    CHECK(d.backoff_ms == 0);
+}
+
+TEST_CASE("decide_next_action: an unreasoned non-5xx status is a structural bug, not transient",
+         "[agent][content_dist][upload]") {
+    // A 400 with no `reason` field (e.g. a locally malformed Content-Range)
+    // is never retried — it will fail identically every time.
+    CHECK(decide_next_action(400, std::nullopt, 1).action == UploadDecision::kAbort);
+}
+
+TEST_CASE("backoff_delay_ms is deterministic, monotonic, and capped",
+         "[agent][content_dist][upload]") {
+    CHECK(backoff_delay_ms(1) == kBackoffBaseMs);
+    CHECK(backoff_delay_ms(2) == kBackoffBaseMs * 2);
+    CHECK(backoff_delay_ms(3) == kBackoffBaseMs * 4);
+    CHECK(backoff_delay_ms(1) == backoff_delay_ms(1)); // pure — same input, same output
+    for (int cap_attempt = 1; cap_attempt <= 20; ++cap_attempt)
+        CHECK(backoff_delay_ms(cap_attempt) <= kBackoffCapMs);
+}
+
+TEST_CASE("attempts_exhausted is a simple threshold on kMaxAttempts",
+         "[agent][content_dist][upload]") {
+    CHECK_FALSE(attempts_exhausted(1));
+    CHECK_FALSE(attempts_exhausted(kMaxAttempts - 1));
+    CHECK(attempts_exhausted(kMaxAttempts));
+    CHECK(attempts_exhausted(kMaxAttempts + 1));
+}
+
+TEST_CASE("is_transient_no_reason: only an unreasoned 5xx or a connection failure qualifies",
+         "[agent][content_dist][upload]") {
+    CHECK(is_transient_no_reason(503, std::nullopt));
+    CHECK(is_transient_no_reason(0, std::nullopt));      // connection-level failure
+    CHECK_FALSE(is_transient_no_reason(400, std::nullopt));
+    CHECK_FALSE(is_transient_no_reason(200, std::nullopt));
+    // A recognized reason is never "no reason", regardless of status.
+    CHECK_FALSE(is_transient_no_reason(503, Reason::kSessionTerminal));
+}
+
+TEST_CASE("commit_matches accepts only a response that agrees with what this run computed",
+         "[agent][content_dist][upload]") {
+    CommitResponse resp{"committed", 25,
+                        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"};
+    CHECK(commit_matches(resp, 25, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
+    CHECK_FALSE(commit_matches(resp, 26, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
+    CHECK_FALSE(commit_matches(resp, 25, "0000000000000000000000000000000000000000000000000000000000000000"));
+}
+
+// ── Response parsing ─────────────────────────────────────────────────────
+
+TEST_CASE("parse_session_open_response parses a well-formed session-open body",
+         "[agent][content_dist][upload]") {
+    auto body = R"({"upload_id":"abc123","session_secret":"deadbeef","chunk_max_bytes":8388608,)"
+               R"("offset":0,"expires_at":1700000900})";
+    auto session = parse_session_open_response(body);
+    REQUIRE(session.has_value());
+    CHECK(session->upload_id == "abc123");
+    CHECK(session->session_secret == "deadbeef");
+    CHECK(session->chunk_max_bytes == 8388608);
+    CHECK(session->offset == 0);
+    CHECK(session->expires_at == 1700000900);
+}
+
+TEST_CASE("parse_session_open_response rejects a malformed or incomplete body",
+         "[agent][content_dist][upload]") {
+    CHECK_FALSE(parse_session_open_response("{}").has_value());
+    CHECK_FALSE(parse_session_open_response(R"({"upload_id":"abc"})").has_value());
+    // chunk_max_bytes <= 0 is structurally impossible, never trusted.
+    CHECK_FALSE(parse_session_open_response(
+                    R"({"upload_id":"a","session_secret":"b","chunk_max_bytes":0,)"
+                    R"("offset":0,"expires_at":1})")
+                    .has_value());
+}
+
+TEST_CASE("parse_chunk_ack_offset parses a successful chunk PUT body",
+         "[agent][content_dist][upload]") {
+    auto offset = parse_chunk_ack_offset(R"({"offset":1048576})");
+    REQUIRE(offset.has_value());
+    CHECK(*offset == 1048576);
+}
+
+TEST_CASE("parse_commit_response parses a well-formed commit body",
+         "[agent][content_dist][upload]") {
+    auto body = R"({"state":"committed","actual_size":25,)"
+               R"("sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"})";
+    auto commit = parse_commit_response(body);
+    REQUIRE(commit.has_value());
+    CHECK(commit->state == "committed");
+    CHECK(commit->actual_size == 25);
+    CHECK(commit->sha256 ==
+         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+}
+
+TEST_CASE("parse_commit_response rejects a non-committed or malformed state",
+         "[agent][content_dist][upload]") {
+    CHECK_FALSE(
+        parse_commit_response(R"({"state":"open","actual_size":25,"sha256":"aa"})").has_value());
+    CHECK_FALSE(parse_commit_response("{}").has_value());
+}
+
+TEST_CASE("parse_status_response parses the status GET body, terminal states included",
+         "[agent][content_dist][upload]") {
+    auto open = parse_status_response(R"({"state":"open","offset":1048576,"expires_at":1700000900})");
+    REQUIRE(open.has_value());
+    CHECK(open->state == "open");
+    CHECK(open->offset == 1048576);
+
+    // register_status answers 200 with the CURRENT state even once the
+    // session has gone terminal — this is what resolves an ambiguous
+    // commit outcome.
+    auto committed = parse_status_response(R"({"state":"committed","offset":25,"expires_at":1700000900})");
+    REQUIRE(committed.has_value());
+    CHECK(committed->state == "committed");
+}
+
+TEST_CASE("parse_status_response rejects a malformed body", "[agent][content_dist][upload]") {
+    CHECK_FALSE(parse_status_response("{}").has_value());
+    CHECK_FALSE(parse_status_response(R"({"state":"","offset":0,"expires_at":1})").has_value());
+}
+
+TEST_CASE("parse_error_envelope extracts reason and message from the frozen envelope",
+         "[agent][content_dist][upload]") {
+    auto body = R"({"error":{"code":401,"message":"grant unknown or invalid credential",)"
+               R"("reason":"grant_unknown"},"meta":{"api_version":"v1"}})";
+    auto info = parse_error_envelope(body);
+    REQUIRE(info.reason.has_value());
+    CHECK(*info.reason == Reason::kGrantUnknown);
+    CHECK(info.message == "grant unknown or invalid credential");
+    CHECK_FALSE(info.offset.has_value());
+}
+
+TEST_CASE("parse_error_envelope extracts the authoritative offset merged into the error object",
+         "[agent][content_dist][upload]") {
+    // file_retrieval_routes.cpp merges the extra `offset` field INTO the
+    // `error` object, never top-level — see send_reason()'s `extra` param.
+    auto body = R"({"error":{"code":409,"message":"offset mismatch","reason":"offset_mismatch",)"
+               R"("offset":4194304},"meta":{"api_version":"v1"}})";
+    auto info = parse_error_envelope(body);
+    REQUIRE(info.reason.has_value());
+    CHECK(*info.reason == Reason::kOffsetMismatch);
+    REQUIRE(info.offset.has_value());
+    CHECK(*info.offset == 4194304);
+}
+
+TEST_CASE("parse_error_envelope on a generic (non-ten-reason) envelope leaves reason unset",
+         "[agent][content_dist][upload]") {
+    // The operator-route / generic-failure envelope shape carries no
+    // `reason` field at all (see file_retrieval_routes.cpp's
+    // generic_error_json) — decide_next_action then classifies by HTTP
+    // status alone.
+    auto body = R"({"error":{"code":503,"message":"upload grant store unavailable"},)"
+               R"("meta":{"api_version":"v1"}})";
+    auto info = parse_error_envelope(body);
+    CHECK_FALSE(info.reason.has_value());
+    CHECK(info.message == "upload grant store unavailable");
+}
+
+// ── Integer field extraction: overflow safety ───────────────────────────
+
+TEST_CASE("a numeric field too large for int64_t is rejected, not silently overflowed",
+         "[agent][content_dist][upload]") {
+    // 19-digit value well past INT64_MAX (~9.22e18) — computing this with
+    // an unchecked `v * 10 + digit` loop is signed-overflow undefined
+    // behavior; the parser must refuse it before that point is reached.
+    auto huge = parse_chunk_ack_offset(R"({"offset":99999999999999999999})");
+    CHECK_FALSE(huge.has_value());
+
+    // A value exactly at the boundary still parses correctly.
+    auto at_max = parse_chunk_ack_offset(R"({"offset":9223372036854775807})");
+    REQUIRE(at_max.has_value());
+    CHECK(*at_max == 9223372036854775807LL);
+}

--- a/tests/unit/test_content_dist_upload_parsers.cpp
+++ b/tests/unit/test_content_dist_upload_parsers.cpp
@@ -29,6 +29,28 @@
 
 using namespace yuzu::content_dist::upload;
 
+// ── Credential grammar (#3136 minor) ─────────────────────────────────────
+
+TEST_CASE("is_valid_credential_parts accepts well-formed 32/64 lowercase hex",
+         "[agent][content_dist][upload]") {
+    const std::string id(32, 'a');
+    const std::string secret(64, 'f');
+    CHECK(is_valid_credential_parts(id, secret));
+}
+
+TEST_CASE("is_valid_credential_parts rejects wrong length, case, or non-hex",
+         "[agent][content_dist][upload]") {
+    const std::string good_id(32, 'a');
+    const std::string good_secret(64, 'f');
+    CHECK_FALSE(is_valid_credential_parts(std::string(31, 'a'), good_secret)); // short id
+    CHECK_FALSE(is_valid_credential_parts(std::string(33, 'a'), good_secret)); // long id
+    CHECK_FALSE(is_valid_credential_parts(good_id, std::string(63, 'f')));    // short secret
+    CHECK_FALSE(is_valid_credential_parts(std::string(32, 'A'), good_secret)); // uppercase
+    CHECK_FALSE(is_valid_credential_parts(std::string(32, 'g'), good_secret)); // non-hex
+    CHECK_FALSE(is_valid_credential_parts("", good_secret));
+    CHECK_FALSE(is_valid_credential_parts(good_id, ""));
+}
+
 // ── Chunk planning ───────────────────────────────────────────────────────
 
 TEST_CASE("plan_next_chunk: a successful multi-chunk plan walks the whole file",
@@ -327,6 +349,14 @@ TEST_CASE("parse_session_open_response rejects a malformed or incomplete body",
     CHECK_FALSE(parse_session_open_response(
                     R"({"upload_id":"a","session_secret":"b","chunk_max_bytes":0,)"
                     R"("offset":0,"expires_at":1})")
+                    .has_value());
+    // #3136 should-fix: a fresh session-open ALWAYS returns offset 0 per the
+    // frozen protocol text (server/core/src/upload_grant_parsers.hpp) — a
+    // non-zero offset here is a server-contract violation this parser must
+    // not trust, not a resume-poll value (that's StatusResponse's job).
+    CHECK_FALSE(parse_session_open_response(
+                    R"({"upload_id":"a","session_secret":"b","chunk_max_bytes":8388608,)"
+                    R"("offset":1,"expires_at":1700000900})")
                     .has_value());
 }
 


### PR DESCRIPTION
<!-- Placeholders to fill before raising:
     PR #TBD-n — PR numbers in the Stack ladder diagram, filled at raise time
-->
## Contents

- [Headline](#headline)
- [Stack](#stack)
- [Description](#description)
- [Impact](#impact)
- [Testing & verification](#testing--verification)
- [Related items](#related-items)

## Headline

The previous rung gave the server an authenticated, integrity-checked upload door.
Agents still need a client that speaks it.

This PR teaches the content-distribution plugin to upload through that door: redeem a
grant, stream the file in chunks, recover cleanly when an acknowledgement is lost —
without corrupting the integrity hash — and commit with the hash check.

It completes the end-to-end replacement of the old unauthenticated upload path: from
this rung on, agent uploads are authenticated and hash-verified from the plugin to the
blob store.

## Stack

```
dev
 └─ feat/1.9a-dispatch-tag-wire          (PR #3131)
     └─ feat/1.9b-capability-registry    (PR #3132)
         └─ feat/1.9c-dispatch-chokepoint   (PR #3133)
             └─ feat/1.5-plugin-config-plane   (PR #3134)
                 └─ feat/1.6a-upload-grants    (PR #3135)
                     └─ feat/1.6b-content-dist-uploader   ◀── THIS PR
                         └─ feat/1.5-1.6-operator-surface
dev
 └─ feat/1.10-abi4-descriptors           (parallel — no stack dependency)
```

**Merge mechanics**

- Base now: `feat/1.6a-upload-grants`. This PR must not be merged before its
  predecessor.
- On the predecessor's merge: this PR is retargeted to `dev`, rebased, and only then
  is auto-merge armed.
- Depends on this PR: `feat/1.5-1.6-operator-surface`.
- Review order: the stack reviews bottom-up; `feat/1.9c-dispatch-chokepoint` is the
  security-review center of gravity.

Rung 6 of an eight-PR split of the verified integration branch
`integr/wave1-completion` @ `48aecb08` (raised whole as #3115, closed unmerged as too
large to review; it remains the integration reference and carries the full granular
history).

- Boundary note, named honestly: this rung touches only the plugin's uploader region;
  its ABI4 descriptor block stays at `dev` content and rides the parallel 1.10 PR. The
  descriptor rows there describe the transport mechanism, which is identical before
  and after this protocol rework — so the two PRs are safe in either merge order.
- Every rung is a byte-exact carve of `48aecb08`; the split converges to that tree —
  see Testing & verification.

## Description

- **Summary** — The content_dist plugin's chunked-upload client (the plugin's
  descriptor block is untouched here — it rides the parallel 1.10 PR); a pure-parser
  header (`content_dist_upload_parsers.hpp`) with its unit suite; capability-map and
  t2-capabilities updates reflecting the authenticated mechanism. Diffstat:
  +1,524/−115 over 7 files.
- **Rationale & drivers** — The server half of the protocol landed in the previous
  rung; this makes an agent actually use it. Protocol parsing and resync decisions
  live in a pure free-function header, so the unit suite feeds fixture strings and
  never spawns a process or opens a socket.
- **Technical overview** —
  - Upload flow: redeem grant → open session → chunked PUTs → commit with SHA-256.
  - Lost-ack resync replays from the server-acknowledged offset, so retransmitted and
    skipped bytes can no longer be silently omitted from the digest — a review-found
    integrity bug fixed on the integration branch, covered by parser-level tests.
  - Capability map and t2 rows updated to describe the authenticated uploader.

## Impact

- **Capabilities** — new: agent-side authenticated, resumable chunked upload in the
  content-distribution plugin; capability map updated to match.
- **Security:** the upload digest is now correct across a lost-ack resync — the hash
  the server verifies covers exactly the bytes received, so resync can no longer
  silently undermine the integrity check.

## Testing & verification

**Verification transfer — the full gate suite ran once, at the final tree of this
stack.**

- This PR is a byte-exact carve of `integr/wave1-completion` @ `48aecb08`, the tree
  where all gates ran and passed:
  - Three-way review — external branch review, `/code-review`, `/adversarial-review`
    (all originally BLOCK; every finding remediated on the branch) — plus the full
    8-gate `/governance` pipeline.
  - `/test` on two hosts: macOS full C++ suite, and the-rig (Windows/MSVC full surface,
    build clean; Postgres-tagged suites 1,910 cases / 60,459 assertions; gateway eunit
    218/218; server/agent/TAR suites in full) — zero failures on every the-rig suite;
    macOS green apart from the documented pre-existing APFS `wal_sidecar_present`
    cases (environmental, Linux CI is the enforcement point).
- The split converges to that exact tree: the union of the stack tip (`02daf462`) and
  `feat/1.10-abi4-descriptors` (`a7239ce6`) is tree-identical to `48aecb08` — verified
  by merge + `git diff` (empty). One deterministic check that no line was lost or
  altered in the carve.

**This rung's own checks**

- Incremental build clean (`ninja -k 0`).
- Targeted suite green — the content_dist upload-parser unit suite (pure functions,
  fixture-fed, no process or network use): 47 cases / 236 assertions.

## Related items

- Roadmap item 1.6 — this rung completes it end to end with its predecessor.
- Integration reference: closed #3115.
- Changelog fragment: `1.6-content-dist-authenticated-upload`.
