### PR TITLE
ci(macos): 2x meson test-timeout headroom for the shared BigMags box

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1428,7 +1428,16 @@ jobs:
           echo "The Yuzu server is Linux-only (ADR-0035); Linux + Windows CI legs run the full [pg] suite."
 
       - name: Test
-        run: python3 scripts/ci/flake-retry.py --builddir build-macos -- --print-errorlogs
+        # --timeout-multiplier 2: BigMags is a shared box (2 runner agents, and
+        # the release+LTO build is co-resident after #3348), so give each test 2x
+        # meson's kill-timeout to absorb CPU/memory contention. Per tests/meson.build's
+        # own guidance, multiply for a slower environment rather than raising
+        # individual test `timeout:` kwargs. This ONLY covers a slow test being
+        # KILLED before it finishes — it does NOT help in-test wall-clock
+        # assertions (CHECK(elapsed < N), CHECK_FALSE(poll_until(...))), which flake
+        # on a loaded box and are fixed per-test (#3357, #2372, and the
+        # elapsed-ceiling issue).
+        run: python3 scripts/ci/flake-retry.py --builddir build-macos -- --print-errorlogs --timeout-multiplier 2
 
       # Same rationale as the linux + windows upload steps: keep test
       # failures diagnosable when meson's `--print-errorlogs` truncation


### PR DESCRIPTION
## What
Adds `--timeout-multiplier 2` to the macOS `meson test` invocation in `ci.yml`, giving each test 2× meson's kill-timeout on the shared **BigMags** box (2 runner agents, and the release+LTO build co-resident after #3348).

## Why
Prompted by #3357. The audit that spun out of it separated two risk classes on the shared box:
- **Tests being KILLED by meson before they finish** under contention → *this* PR (the "increase the timeout, correctly" knob — per `tests/meson.build`'s guidance to multiply for a slower environment rather than raising individual `timeout:` kwargs).
- **In-test wall-clock assertions** (`CHECK(elapsed < N)`, `CHECK_FALSE(poll_until(…))`) → **NOT** helped by this (a bigger window makes negative ones *worse*); fixed per-test in #3357, #2372, and #3364.

## Scope
One line + comment; `flake-retry.py:414` forwards `-- …` args to the primary `meson test` run. No behavior change to Linux/Windows. CI-plumbing → no changelog fragment (changelog.d/README rule 3). Defensive headroom — no macOS test is hitting the meson kill-timeout today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcDGJL7zWF9wuvo8nE6sVL
