### PR TITLE
chore(ci): declare intentional BigMags macOS runner pool

### DIFF
--- a/.github/runner-inventory.json
+++ b/.github/runner-inventory.json
@@ -5,72 +5,144 @@
     {
       "name": "yuzu-wsl2-linux",
       "host": "Shulgi (AMD 5950X, WSL2 Ubuntu 24.04)",
-      "labels": ["self-hosted", "Linux", "X64"],
+      "labels": [
+        "self-hosted",
+        "Linux",
+        "X64"
+      ],
       "role": "Linux CI jobs — ci.yml proto-compat, linux matrix, sanitizer-asan, sanitizer-tsan, coverage. Also CodeQL Linux leg and sanitizer-tests.yml dispatches. INCUMBENT 24.04 toolchain (gcc-13 / clang-19) — remains the live Linux runner until the Big Tam cutover. Cannot build the gcc-15 / clang-21 (26.04) toolchain.",
       "installed": "2026-04-09"
     },
     {
       "name": "yuzu-local-windows",
       "host": "Shulgi (native Windows 11)",
-      "labels": ["self-hosted", "Windows", "X64"],
+      "labels": [
+        "self-hosted",
+        "Windows",
+        "X64"
+      ],
       "role": "Windows MSVC CI jobs — ci.yml windows matrix (release + debug), codeql Windows leg.",
       "installed": "2026-04-14"
     },
     {
       "name": "yuzu-bigtam-linux-0",
       "host": "Big Tam (Threadripper 9970X, native Ubuntu 26.04)",
-      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam-linux"],
+      "labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "yuzu-bigtam-linux"
+      ],
       "role": "Linux CI pool (shared label yuzu-bigtam-linux) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
       "installed": "2026-06-19"
     },
     {
       "name": "yuzu-bigtam-linux-1",
       "host": "Big Tam (Threadripper 9970X, native Ubuntu 26.04)",
-      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam-linux"],
+      "labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "yuzu-bigtam-linux"
+      ],
       "role": "Linux CI pool (shared label yuzu-bigtam-linux) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
       "installed": "2026-06-19"
     },
     {
       "name": "yuzu-bigtam-linux-2",
       "host": "Big Tam (Threadripper 9970X, native Ubuntu 26.04)",
-      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam-linux"],
+      "labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "yuzu-bigtam-linux"
+      ],
       "role": "Linux CI pool (shared label yuzu-bigtam-linux) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
       "installed": "2026-06-19"
     },
     {
       "name": "yuzu-bigtam-linux-3",
       "host": "Big Tam (Threadripper 9970X, native Ubuntu 26.04)",
-      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam-linux"],
+      "labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "yuzu-bigtam-linux"
+      ],
       "role": "Linux CI pool (shared label yuzu-bigtam-linux) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
       "installed": "2026-06-19"
     },
     {
       "name": "yuzu-weetam-windows-0",
       "host": "Wee Tam (Threadripper 9970X, native Windows 11)",
-      "labels": ["self-hosted", "Windows", "X64", "yuzu-weetam-windows"],
+      "labels": [
+        "self-hosted",
+        "Windows",
+        "X64",
+        "yuzu-weetam-windows"
+      ],
       "role": "Windows MSVC CI pool (shared label yuzu-weetam-windows) — ci.yml windows matrix (release + debug), codeql Windows leg. Replaces yuzu-local-windows after the Shulgi cutover.",
       "installed": "2026-06-20"
     },
     {
       "name": "yuzu-weetam-windows-1",
       "host": "Wee Tam (Threadripper 9970X, native Windows 11)",
-      "labels": ["self-hosted", "Windows", "X64", "yuzu-weetam-windows"],
+      "labels": [
+        "self-hosted",
+        "Windows",
+        "X64",
+        "yuzu-weetam-windows"
+      ],
       "role": "Windows MSVC CI pool (shared label yuzu-weetam-windows) — ci.yml windows matrix (release + debug), codeql Windows leg. Replaces yuzu-local-windows after the Shulgi cutover.",
       "installed": "2026-06-20"
     },
     {
       "name": "yuzu-weetam-windows-2",
       "host": "Wee Tam (Threadripper 9970X, native Windows 11)",
-      "labels": ["self-hosted", "Windows", "X64", "yuzu-weetam-windows"],
+      "labels": [
+        "self-hosted",
+        "Windows",
+        "X64",
+        "yuzu-weetam-windows"
+      ],
       "role": "Windows MSVC CI pool (shared label yuzu-weetam-windows) — ci.yml windows matrix (release + debug), codeql Windows leg. Replaces yuzu-local-windows after the Shulgi cutover.",
       "installed": "2026-06-20"
     },
     {
       "name": "yuzu-weetam-windows-3",
       "host": "Wee Tam (Threadripper 9970X, native Windows 11)",
-      "labels": ["self-hosted", "Windows", "X64", "yuzu-weetam-windows"],
+      "labels": [
+        "self-hosted",
+        "Windows",
+        "X64",
+        "yuzu-weetam-windows"
+      ],
       "role": "Windows MSVC CI pool (shared label yuzu-weetam-windows) — ci.yml windows matrix (release + debug), codeql Windows leg. Replaces yuzu-local-windows after the Shulgi cutover.",
       "installed": "2026-06-20"
+    },
+    {
+      "name": "yuzu-bigmags-macos-0",
+      "host": "BigMags (Mac Mini, Apple M4 Pro, 24 GiB, macOS 26)",
+      "labels": [
+        "self-hosted",
+        "macOS",
+        "ARM64",
+        "yuzu-bigmags-macos"
+      ],
+      "role": "macOS ARM64 CI pool (shared label yuzu-bigmags-macos) — ci.yml macos matrix (debug on PR, debug+release on push). Replaces GitHub-hosted macos-15 for the test leg; release.yml notarize build stays hosted until on-box signing is set up.",
+      "installed": "2026-08-17"
+    },
+    {
+      "name": "yuzu-bigmags-macos-1",
+      "host": "BigMags (Mac Mini, Apple M4 Pro, 24 GiB, macOS 26)",
+      "labels": [
+        "self-hosted",
+        "macOS",
+        "ARM64",
+        "yuzu-bigmags-macos"
+      ],
+      "role": "macOS ARM64 CI pool (shared label yuzu-bigmags-macos) — ci.yml macos matrix (debug on PR, debug+release on push). Replaces GitHub-hosted macos-15 for the test leg; release.yml notarize build stays hosted until on-box signing is set up.",
+      "installed": "2026-08-17"
     }
   ]
 }

--- a/.github/runner-inventory.json
+++ b/.github/runner-inventory.json
@@ -5,142 +5,84 @@
     {
       "name": "yuzu-wsl2-linux",
       "host": "Shulgi (AMD 5950X, WSL2 Ubuntu 24.04)",
-      "labels": [
-        "self-hosted",
-        "Linux",
-        "X64"
-      ],
+      "labels": ["self-hosted", "Linux", "X64"],
       "role": "Linux CI jobs — ci.yml proto-compat, linux matrix, sanitizer-asan, sanitizer-tsan, coverage. Also CodeQL Linux leg and sanitizer-tests.yml dispatches. INCUMBENT 24.04 toolchain (gcc-13 / clang-19) — remains the live Linux runner until the Big Tam cutover. Cannot build the gcc-15 / clang-21 (26.04) toolchain.",
       "installed": "2026-04-09"
     },
     {
       "name": "yuzu-local-windows",
       "host": "Shulgi (native Windows 11)",
-      "labels": [
-        "self-hosted",
-        "Windows",
-        "X64"
-      ],
+      "labels": ["self-hosted", "Windows", "X64"],
       "role": "Windows MSVC CI jobs — ci.yml windows matrix (release + debug), codeql Windows leg.",
       "installed": "2026-04-14"
     },
     {
       "name": "yuzu-bigtam-linux-0",
       "host": "Big Tam (Threadripper 9970X, native Ubuntu 26.04)",
-      "labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "yuzu-bigtam-linux"
-      ],
+      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam-linux"],
       "role": "Linux CI pool (shared label yuzu-bigtam-linux) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
       "installed": "2026-06-19"
     },
     {
       "name": "yuzu-bigtam-linux-1",
       "host": "Big Tam (Threadripper 9970X, native Ubuntu 26.04)",
-      "labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "yuzu-bigtam-linux"
-      ],
+      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam-linux"],
       "role": "Linux CI pool (shared label yuzu-bigtam-linux) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
       "installed": "2026-06-19"
     },
     {
       "name": "yuzu-bigtam-linux-2",
       "host": "Big Tam (Threadripper 9970X, native Ubuntu 26.04)",
-      "labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "yuzu-bigtam-linux"
-      ],
+      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam-linux"],
       "role": "Linux CI pool (shared label yuzu-bigtam-linux) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
       "installed": "2026-06-19"
     },
     {
       "name": "yuzu-bigtam-linux-3",
       "host": "Big Tam (Threadripper 9970X, native Ubuntu 26.04)",
-      "labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "yuzu-bigtam-linux"
-      ],
+      "labels": ["self-hosted", "Linux", "X64", "yuzu-bigtam-linux"],
       "role": "Linux CI pool (shared label yuzu-bigtam-linux) — ci.yml proto-compat + linux matrix. Sanitizers, coverage, and the CodeQL Linux leg migrate here after the yuzu-shulgi pin cutover.",
       "installed": "2026-06-19"
     },
     {
       "name": "yuzu-weetam-windows-0",
       "host": "Wee Tam (Threadripper 9970X, native Windows 11)",
-      "labels": [
-        "self-hosted",
-        "Windows",
-        "X64",
-        "yuzu-weetam-windows"
-      ],
+      "labels": ["self-hosted", "Windows", "X64", "yuzu-weetam-windows"],
       "role": "Windows MSVC CI pool (shared label yuzu-weetam-windows) — ci.yml windows matrix (release + debug), codeql Windows leg. Replaces yuzu-local-windows after the Shulgi cutover.",
       "installed": "2026-06-20"
     },
     {
       "name": "yuzu-weetam-windows-1",
       "host": "Wee Tam (Threadripper 9970X, native Windows 11)",
-      "labels": [
-        "self-hosted",
-        "Windows",
-        "X64",
-        "yuzu-weetam-windows"
-      ],
+      "labels": ["self-hosted", "Windows", "X64", "yuzu-weetam-windows"],
       "role": "Windows MSVC CI pool (shared label yuzu-weetam-windows) — ci.yml windows matrix (release + debug), codeql Windows leg. Replaces yuzu-local-windows after the Shulgi cutover.",
       "installed": "2026-06-20"
     },
     {
       "name": "yuzu-weetam-windows-2",
       "host": "Wee Tam (Threadripper 9970X, native Windows 11)",
-      "labels": [
-        "self-hosted",
-        "Windows",
-        "X64",
-        "yuzu-weetam-windows"
-      ],
+      "labels": ["self-hosted", "Windows", "X64", "yuzu-weetam-windows"],
       "role": "Windows MSVC CI pool (shared label yuzu-weetam-windows) — ci.yml windows matrix (release + debug), codeql Windows leg. Replaces yuzu-local-windows after the Shulgi cutover.",
       "installed": "2026-06-20"
     },
     {
       "name": "yuzu-weetam-windows-3",
       "host": "Wee Tam (Threadripper 9970X, native Windows 11)",
-      "labels": [
-        "self-hosted",
-        "Windows",
-        "X64",
-        "yuzu-weetam-windows"
-      ],
+      "labels": ["self-hosted", "Windows", "X64", "yuzu-weetam-windows"],
       "role": "Windows MSVC CI pool (shared label yuzu-weetam-windows) — ci.yml windows matrix (release + debug), codeql Windows leg. Replaces yuzu-local-windows after the Shulgi cutover.",
       "installed": "2026-06-20"
     },
     {
       "name": "yuzu-bigmags-macos-0",
       "host": "BigMags (Mac Mini, Apple M4 Pro, 24 GiB, macOS 26)",
-      "labels": [
-        "self-hosted",
-        "macOS",
-        "ARM64",
-        "yuzu-bigmags-macos"
-      ],
+      "labels": ["self-hosted", "macOS", "ARM64", "yuzu-bigmags-macos"],
       "role": "macOS ARM64 CI pool (shared label yuzu-bigmags-macos) — ci.yml macos matrix (debug on PR, debug+release on push). Replaces GitHub-hosted macos-15 for the test leg; release.yml notarize build stays hosted until on-box signing is set up.",
       "installed": "2026-08-17"
     },
     {
       "name": "yuzu-bigmags-macos-1",
       "host": "BigMags (Mac Mini, Apple M4 Pro, 24 GiB, macOS 26)",
-      "labels": [
-        "self-hosted",
-        "macOS",
-        "ARM64",
-        "yuzu-bigmags-macos"
-      ],
+      "labels": ["self-hosted", "macOS", "ARM64", "yuzu-bigmags-macos"],
       "role": "macOS ARM64 CI pool (shared label yuzu-bigmags-macos) — ci.yml macos matrix (debug on PR, debug+release on push). Replaces GitHub-hosted macos-15 for the test leg; release.yml notarize build stays hosted until on-box signing is set up.",
       "installed": "2026-08-17"
     }


### PR DESCRIPTION
## What

Adds the two intentional BigMags self-hosted macOS runners to `.github/runner-inventory.json` on `main`:

- `yuzu-bigmags-macos-0`
- `yuzu-bigmags-macos-1`

Both are registered and online with labels `[self-hosted, macOS, ARM64, yuzu-bigmags-macos]`.

## Why this targets `main`

PR #3217 already introduced the full BigMags CI cutover and inventory declaration on `dev`, but the runner-inventory sentinel executes from `main`. `main` therefore treats the intentional runners as unknown and appends to #2301 every 30 minutes. A full `dev` → `main` promotion is currently much broader, so this is the single-file stable-branch inventory hotfix.

## Validation

- Exact names and labels taken from sentinel run `32460027228`.
- Matches the inventory entries already merged to `dev` by #3217.
- No workflow routing or runner registration changes.

After merge, the next sentinel tick should report no BigMags inventory drift; close #2301 once a green run confirms it.