### PR TITLE
fix(tls): rename Config::allow_one_way_tls to insecure_skip_client_verify (#543)

### DIFF
--- a/server/core/include/yuzu/server/server.hpp
+++ b/server/core/include/yuzu/server/server.hpp
@@ -36,7 +36,7 @@ struct Config {
     std::filesystem::path tls_server_cert; // PEM server certificate
     std::filesystem::path tls_server_key;  // PEM server private key
     std::filesystem::path tls_ca_cert;     // For mTLS agent verification
-    bool allow_one_way_tls{false};         // Permit TLS without client cert verification
+    bool insecure_skip_client_verify{false}; // Permit TLS without client cert verification
 
     // PKI default certs (PR2). With no operator cert flags and without
     // --no-default-certs, the server generates a per-install CA + server-side

--- a/server/core/src/main.cpp
+++ b/server/core/src/main.cpp
@@ -395,16 +395,16 @@ int main(int argc, char* argv[]) {
         ->envname("YUZU_CERT_GROUP");
     app.add_option("--ca-cert", cfg.tls_ca_cert, "PEM CA cert (for mTLS agent verification)")
         ->envname("YUZU_CA_CERT");
-    bool deprecated_allow_one_way_tls_flag = false;
+    bool deprecated_tls_flag_used = false;
     app.add_flag("--insecure-skip-client-verify",
                  "Allow TLS without --ca-cert (disables mTLS client verification). "
                  "Requires YUZU_ALLOW_INSECURE_TLS=1.")
-        ->each([&cfg](const std::string&) { cfg.allow_one_way_tls = true; });
+        ->each([&cfg](const std::string&) { cfg.insecure_skip_client_verify = true; });
     app.add_flag("--allow-one-way-tls", "[DEPRECATED] Renamed to --insecure-skip-client-verify; "
                                         "still accepted for backward compatibility.")
-        ->each([&cfg, &deprecated_allow_one_way_tls_flag](const std::string&) {
-            cfg.allow_one_way_tls = true;
-            deprecated_allow_one_way_tls_flag = true;
+        ->each([&cfg, &deprecated_tls_flag_used](const std::string&) {
+            cfg.insecure_skip_client_verify = true;
+            deprecated_tls_flag_used = true;
         });
     app.add_option("--management-cert", cfg.mgmt_tls_server_cert,
                    "PEM management server certificate override");
@@ -1183,11 +1183,11 @@ int main(int argc, char* argv[]) {
     // an explicit environment variable, so that no single misconfiguration
     // (typo, copy-pasted command, leaked CLI history) can silently downgrade
     // the agent listener from mTLS to one-way TLS.
-    if (deprecated_allow_one_way_tls_flag) {
+    if (deprecated_tls_flag_used) {
         spdlog::warn("--allow-one-way-tls is deprecated; use --insecure-skip-client-verify "
                      "instead (this flag will be removed in a future release).");
     }
-    if (cfg.allow_one_way_tls && cfg.tls_enabled) {
+    if (cfg.insecure_skip_client_verify && cfg.tls_enabled) {
         if (!yuzu::server::security::insecure_tls_env_authorized()) {
             spdlog::error("--insecure-skip-client-verify requires YUZU_ALLOW_INSECURE_TLS=1 "
                           "in the environment as a second confirmation. Refusing to start.");

--- a/server/core/src/server.cpp
+++ b/server/core/src/server.cpp
@@ -5808,7 +5808,7 @@ public:
         std::shared_ptr<grpc::ServerCredentials> mgmt_creds = grpc::InsecureServerCredentials();
         if (cfg_.tls_enabled) {
             auto tls = build_tls_credentials(cfg_.tls_server_cert, cfg_.tls_server_key,
-                                             cfg_.tls_ca_cert, cfg_.allow_one_way_tls,
+                                             cfg_.tls_ca_cert, cfg_.insecure_skip_client_verify,
                                              /*require_client_cert=*/!cfg_.using_default_agent_certs,
                                              "agent listener");
             if (tls) {
@@ -5830,7 +5830,7 @@ public:
                 // unauthenticated peer on the management plane.
                 auto mgmt_tls = build_tls_credentials(
                     cfg_.mgmt_tls_server_cert, cfg_.mgmt_tls_server_key, cfg_.mgmt_tls_ca_cert,
-                    cfg_.allow_one_way_tls, /*require_client_cert=*/true, "management listener");
+                    cfg_.insecure_skip_client_verify, /*require_client_cert=*/true, "management listener");
                 if (!mgmt_tls) {
                     spdlog::error("Management TLS credentials are invalid; refusing to start");
                     startup_failed_ = true;
@@ -5850,7 +5850,7 @@ public:
                 // so the gateway-upstream listener still connects.
                 auto mgmt_tls = build_tls_credentials(
                     cfg_.tls_server_cert, cfg_.tls_server_key, cfg_.tls_ca_cert,
-                    cfg_.allow_one_way_tls, /*require_client_cert=*/true, "management listener");
+                    cfg_.insecure_skip_client_verify, /*require_client_cert=*/true, "management listener");
                 if (!mgmt_tls) {
                     spdlog::error("Management TLS credentials (strict, default certs) are invalid; "
                                   "refusing to start");
@@ -6580,7 +6580,7 @@ public:
         // so SOC 2 CC7.2 evidence is collected for the duration the server runs
         // in a degraded posture (otherwise spdlog-only output would not survive
         // log rotation or land in audit.db).
-        const bool insecure_skip_verify_active = cfg_.tls_enabled && cfg_.allow_one_way_tls;
+        const bool insecure_skip_verify_active = cfg_.tls_enabled && cfg_.insecure_skip_client_verify;
         const bool no_tls_active = !cfg_.tls_enabled;
         const bool default_certs_active = cfg_.using_default_certs;
         if (insecure_skip_verify_active || no_tls_active || default_certs_active) {
@@ -7903,7 +7903,7 @@ private:
     [[nodiscard]] std::shared_ptr<grpc::ServerCredentials>
     build_tls_credentials(const std::filesystem::path& cert_path,
                           const std::filesystem::path& key_path,
-                          const std::filesystem::path& ca_path, bool allow_one_way_tls,
+                          const std::filesystem::path& ca_path, bool insecure_skip_client_verify,
                           bool require_client_cert, std::string_view listener_name) const {
         if (cert_path.empty() || key_path.empty()) {
             spdlog::error("{} TLS requires certificate and key", listener_name);
@@ -7943,7 +7943,7 @@ private:
                 require_client_cert ? GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY
                                     : GRPC_SSL_REQUEST_CLIENT_CERTIFICATE_AND_VERIFY;
         } else {
-            if (!allow_one_way_tls) {
+            if (!insecure_skip_client_verify) {
                 spdlog::error("{} TLS requires --ca-cert (or enable "
                               "--insecure-skip-client-verify with YUZU_ALLOW_INSECURE_TLS=1)",
                               listener_name);

--- a/server/core/src/settings_routes.cpp
+++ b/server/core/src/settings_routes.cpp
@@ -416,8 +416,8 @@ std::string SettingsRoutes::render_tls_fragment() {
 
     // Insecure-skip-client-verify (one-way TLS) — color red when enabled to flag the
     // weakened posture in the operator dashboard, not just the warm-orange "warning" hue.
-    std::string owt_color = cfg_->allow_one_way_tls ? "#f85149" : "#8b949e";
-    std::string owt_text = cfg_->allow_one_way_tls
+    std::string owt_color = cfg_->insecure_skip_client_verify ? "#f85149" : "#8b949e";
+    std::string owt_text = cfg_->insecure_skip_client_verify
                                ? "Client cert verification DISABLED (--insecure-skip-client-verify)"
                                : "Disabled (mTLS enforced)";
     html += "<div class=\"form-row\" style=\"margin-top:0.75rem\">"


### PR DESCRIPTION
## Headline

The internal config field backing TLS client-verification skipping was still named `allow_one_way_tls`, even though the CLI flag it powers was renamed to `--insecure-skip-client-verify` a while back to make the security posture explicit. This PR finishes that rename on the internal side so the source code matches what operators already see on the command line.

## Description

- **Summary** — Renames `Config::allow_one_way_tls` to `Config::insecure_skip_client_verify` across all 12 internal call sites in `server.hpp`, `server.cpp`, `main.cpp`, and `settings_routes.cpp`. The separate local variable tracking whether the deprecated `--allow-one-way-tls` CLI alias was used is renamed independently (`deprecated_tls_flag_used`), since it tracks a different fact.
- **Rationale & drivers** — Closes #543. Pure naming debt: the CLI surface and dashboard label already say "insecure skip client verify"; the internal identifier lagged behind.
- **Technical overview** — Mechanical identifier substitution only. No behaviour, control flow, or default value changes. The deprecated `--allow-one-way-tls` CLI alias remains wired and unchanged.

## Testing & verification

- `git grep` confirms zero remaining occurrences of the old identifier and exactly 12 of the new one across the four owned files.
- Full local build + `meson test --suite server`: clean compile, 33387/33393 assertions passed (6 pre-existing, unrelated macOS/APFS `wal_sidecar_present` failures in shard B — not caused by this change).
- `/governance` gate: 0 CRITICAL/HIGH findings.

## Related items

Closes #543.
