### PR TITLE
fix(ci): drop stale GRANDFATHERED entries for network_config and msi_packages (#3405)

### DIFF
--- a/scripts/ci/check-plugin-spawn-lexical.sh
+++ b/scripts/ci/check-plugin-spawn-lexical.sh
@@ -482,8 +482,6 @@ GRANDFATHERED = {
     "agents/plugins/firewall/src/firewall_plugin.cpp",
     "agents/plugins/installed_apps/src/installed_apps_plugin.cpp",
     "agents/plugins/license_scan/src/licensing_linux.cpp",
-    "agents/plugins/msi_packages/src/msi_packages_plugin.cpp",
-    "agents/plugins/network_config/src/network_config_plugin.cpp",
     "agents/plugins/sccm/src/sccm_plugin.cpp",
     "agents/plugins/script_exec/src/script_exec_plugin.cpp",
     "agents/plugins/software_actions/src/software_actions_plugin.cpp",


### PR DESCRIPTION
## Headline

Two plugins on the CI spawn-safety gate's grandfather list finished migrating away from raw process-spawn calls a while ago, but the temporary exemption entries were never removed. This PR drops them, so the gate would actually catch a regression if either plugin reintroduced a raw spawn.

## Description

- **Summary** — Removes the `network_config_plugin.cpp` and `msi_packages_plugin.cpp` entries from `GRANDFATHERED` in `scripts/ci/check-plugin-spawn-lexical.sh`.
- **Rationale & drivers** — Closes #3405. Both plugins migrated every spawn leg to `run_bounded_subprocess`; the grandfather entries currently grandfather nothing and would silently mask a regression.
- **Technical overview** — Re-verified at HEAD that neither plugin file has a raw `popen`/`system`/`fork`/`CreateProcess` call outside a comment (the gate strips comments before scanning). Deletion only — no other change to the script.

## Testing & verification

- `bash scripts/ci/check-plugin-spawn-lexical.sh --selftest` — exits 0.
- `bash scripts/ci/check-plugin-spawn-lexical.sh --base <merge-base>` — exits 0.
- `/governance` gate: 0 CRITICAL/HIGH findings.

## Related items

Closes #3405.
