### PR TITLE
fix(server): promote -Wswitch to an error for the server core library (#3109)

### DIFF
--- a/server/core/meson.build
+++ b/server/core/meson.build
@@ -243,7 +243,10 @@ if _yaml_probe.returncode() != 0
     'PyYAML is required to embed shipped InstructionDefinitions but is '
     + 'not importable from ' + embed_python.full_path() + '. '
     + 'Install with `pip install pyyaml` (Linux/macOS) or '
-    + '`pacman -S python-yaml` (MSYS2). See CLAUDE.md "Instruction Engine".'
+    + '`pacman -S python-yaml` (MSYS2). If you have just installed PyYAML, '
+    + 're-run with `meson setup --wipe <builddir>` -- meson caches '
+    + 'run_command results in introspection state, so --reconfigure will '
+    + 'not re-probe. See CLAUDE.md "Instruction Engine".'
   )
 endif
 

--- a/server/core/meson.build
+++ b/server/core/meson.build
@@ -24,6 +24,13 @@ if host_machine.system() == 'windows'
   endif
 endif
 
+# #3109: file_retrieval_routes.cpp's admit_to_write_lock() switches over the
+# 5-value SessionAuthOutcome with no `default:`, relying on the compiler to
+# fail the build if the enum ever grows without that switch being updated.
+# Promote -Wswitch (MSVC: C4062, the exact analogue) to an error so that
+# guarantee is actually enforced rather than merely warned about.
+switch_werror_args = cxx.get_id() == 'msvc' ? ['/we4062'] : ['-Werror=switch']
+
 https_cpp_args = []
 https_deps = []
 if not is_disabler(openssl_dep) and openssl_dep.found()
@@ -563,7 +570,7 @@ yuzu_server_core_lib = static_library(
     'src/security_headers.cpp',
   )],
   include_directories: ['include', '../../common/include'],
-  cpp_args: https_cpp_args + ['-DCPPHTTPLIB_LISTEN_BACKLOG=128'] + (cxx.get_id() == 'msvc' ? ['/bigobj'] : []),
+  cpp_args: https_cpp_args + ['-DCPPHTTPLIB_LISTEN_BACKLOG=128'] + (cxx.get_id() == 'msvc' ? ['/bigobj'] : []) + switch_werror_args,
   dependencies: [yuzu_sdk_dep, yuzu_proto_dep, spdlog_dep, httplib_dep,
                  sqlite3_dep, nlohmann_json_dep, re2_dep, qrcodegen_dep,
                  libpq_dep, yuzu_key_provider_dep] + auth_crypto_deps + https_deps


### PR DESCRIPTION
## Headline

The server core library relies on the compiler catching a non-exhaustive `switch` over `SessionAuthOutcome` in one security-sensitive fail-closed path, but nothing enforced that guarantee — `-Wswitch` only warned, never failed the build. This PR promotes it to an error for that one library target.

## Description

- **Summary** — Adds a `switch_werror_args` variable to `server/core/meson.build` (`-Werror=switch` on GCC/Clang, `/we4062` on MSVC) and appends it to `yuzu_server_core_lib`'s `cpp_args`.
- **Rationale & drivers** — Closes #3109. `file_retrieval_routes.cpp`'s `admit_to_write_lock()` deliberately switches over all 5 `SessionAuthOutcome` values with no `default:`, so the fail-closed guarantee depends entirely on the compiler catching a future enum addition. That guarantee was unenforced until now.
- **Technical overview** — Scoped to `yuzu_server_core_lib` only — root `meson.build` and its project-wide `werror=false` are untouched, as is `yuzu_key_provider_lib`/`qrcodegen_lib`/the two `executable()` targets. `-Wswitch-enum` is deliberately NOT enabled (would force an unrelated repo-wide refactor across ~128 switch statements).

## Testing & verification

- Verified the flag actually fires: temporarily removed one enumerator's case from `admit_to_write_lock()`'s switch and confirmed the build fails with `error: enumeration value 'kUnavailable' not handled in switch [-Werror,-Wswitch]`; reverted before commit.
- Full local build + `meson test --suite server` with the flag active: clean compile (zero pre-existing `-Wswitch` violations surfaced), 33387/33393 assertions passed (6 pre-existing, unrelated macOS/APFS `wal_sidecar_present` failures in shard B).
- `/governance` gate: 0 CRITICAL/HIGH findings.

## Related items

Closes #3109.
