### PR TITLE
docs(adr-0049): align shutdown claims with code comments and drop the stop_drain overclaim (#3384)

### DIFF
--- a/docs/adr/0049-analytics-event-store-postgres-migration.md
+++ b/docs/adr/0049-analytics-event-store-postgres-migration.md
@@ -275,8 +275,9 @@ A second, separate divergence from the sibling PG-backed stores, found and close
   tests, which call `stop_drain()` then read `pending_count()` to observe final state — the
   intended, established usage, not a test bug. Root cause was never actually reachable for these
   two methods: their sole production callers are `web_server_->Get(...)` HTTP handlers, and
-  `server.cpp`'s `web_thread_` join (with its own bounded wait/`_Exit` escalation) completes well
-  before `pg_pool_.reset()` runs — no in-flight handler can still be here when the pool is freed.
+  `server.cpp`'s `web_thread_` join (with its own bounded wait/`_Exit` escalation) completes
+  strictly before `pg_pool_.reset()` runs — every httplib worker thread, including any in-flight
+  analytics handler, is already joined by then. That's a join ordering, not a timing margin.
   The gate was defense-in-depth for a caller that doesn't exist on these two paths; removed. This
   first surfaced on CI's initial real `[pg]` execution (these tests skip locally without
   `YUZU_TEST_ENABLE_PG`) — verified by hand against a real local Postgres before re-pushing.

--- a/server/core/src/analytics_event_store.cpp
+++ b/server/core/src/analytics_event_store.cpp
@@ -291,11 +291,16 @@ void AnalyticsEventStore::start_drain() {
 }
 
 void AnalyticsEventStore::stop_drain() {
-    // Set first, before anything else below: this is what makes it safe
-    // for server.cpp's stop() to free pg_pool_ (which this object borrows
-    // by reference) without waiting on or joining the untracked
-    // forward_gateway_pending() detached thread — emit() checks this before
-    // ever touching pool_.
+    // Set first, before anything else below, so emit() sees it as early as
+    // possible: this is a latch, not a rundown/quiesce guard, on the same
+    // terms as emit()'s comment above (which is the full statement) —
+    // refusing NEW entrants doesn't block a caller that already read it as
+    // false an instant earlier, so this alone does not make it provably
+    // safe for server.cpp's stop() to free pg_pool_ without waiting on or
+    // joining the untracked forward_gateway_pending() detached thread. What
+    // makes that acceptable in practice is the same multi-second span
+    // before pg_pool_.reset() described in emit()'s comment, not this
+    // store alone.
     shutting_down_.store(true, std::memory_order_release);
 #ifdef __cpp_lib_jthread
     if (drain_thread_.joinable()) {


### PR DESCRIPTION
## Headline

An ADR's claim about the analytics event store's shutdown ordering was slightly weaker than what the code actually guarantees, while a code comment nearby made a claim slightly stronger than what's actually safe. This PR corrects both in opposite directions so they agree with the honest, already-reviewed framing that exists elsewhere in the same file.

## Description

- **Summary** — Strengthens ADR-0049's `web_thread_` join claim to match `analytics_event_store.cpp`'s `query_recent()` comment verbatim (a real happens-before join, not just a timing margin). Weakens the `stop_drain()` comment's absolute-safety claim about the detached `forward_gateway_pending()` thread to match `emit()`'s already-honest framing: the `shutting_down_` latch refuses new entrants but doesn't make the drain window provably zero.
- **Rationale & drivers** — Closes #3384. The two passages in `analytics_event_store.cpp` (lines ~117-127 and ~293-298) previously contradicted each other on the same underlying question.
- **Technical overview** — One sentence changed in the ADR; comment-only change in `analytics_event_store.cpp` (no executable line touched — `shutting_down_.store(...)`, memory order, and control flow are all unchanged). `server.cpp`'s own separate wording of the same join is deliberately left as-is; the two code copies are not meant to be identical.

## Testing & verification

- `git diff server/core/src/analytics_event_store.cpp` confirmed comment-only (every changed line begins with `//`).
- Full local build + `meson test --suite server`: clean compile, 33387/33393 assertions passed (6 pre-existing, unrelated macOS/APFS `wal_sidecar_present` failures in shard B).
- `/governance` gate: 0 CRITICAL/HIGH findings.

## Related items

Closes #3384.
