### PR TITLE
test(policy-store): migrate substring assertions to Catch2 ContainsSubstring (#755)

### DIFF
--- a/tests/unit/server/test_policy_store.cpp
+++ b/tests/unit/server/test_policy_store.cpp
@@ -9,10 +9,12 @@
 #include "store_errors.hpp"
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include <string>
 
 using namespace yuzu::server;
+using Catch::Matchers::ContainsSubstring;
 
 // ---- YAML helpers ----------------------------------------------------------
 
@@ -196,13 +198,13 @@ TEST_CASE("PolicyStore: create fragment with wrong kind", "[policy_store][fragme
 
     auto result = store.create_fragment("kind: Policy\nname: oops\n");
     REQUIRE(!result.has_value());
-    CHECK(result.error().find("kind must be 'PolicyFragment'") != std::string::npos);
+    CHECK_THAT(result.error(), ContainsSubstring("kind must be 'PolicyFragment'"));
     // Issue #621: error must include a worked example so operators sending
     // partial YAML (or sending `kind` as a request param) get unstuck without
     // having to find the docs separately. The prefix above stays stable so
     // existing scripts that grep on it keep working.
-    CHECK(result.error().find("apiVersion: yuzu.io/v1alpha1") != std::string::npos);
-    CHECK(result.error().find("docs/user-manual/policy-engine.md") != std::string::npos);
+    CHECK_THAT(result.error(), ContainsSubstring("apiVersion: yuzu.io/v1alpha1"));
+    CHECK_THAT(result.error(), ContainsSubstring("docs/user-manual/policy-engine.md"));
 }
 
 TEST_CASE("PolicyStore: create fragment with missing kind", "[policy_store][fragment]") {
@@ -210,12 +212,12 @@ TEST_CASE("PolicyStore: create fragment with missing kind", "[policy_store][frag
 
     auto result = store.create_fragment("name: no-kind\ndescription: missing kind field\n");
     REQUIRE(!result.has_value());
-    CHECK(result.error().find("kind must be 'PolicyFragment'") != std::string::npos);
-    CHECK(result.error().find("apiVersion: yuzu.io/v1alpha1") != std::string::npos);
+    CHECK_THAT(result.error(), ContainsSubstring("kind must be 'PolicyFragment'"));
+    CHECK_THAT(result.error(), ContainsSubstring("apiVersion: yuzu.io/v1alpha1"));
     // Governance Gate 7 (consistency S2 / QA SHOULD): docs link must be
     // pinned on this branch too — not just the wrong-kind branch — so the
     // operator-facing UX is symmetric across both `kind`-failure modes.
-    CHECK(result.error().find("docs/user-manual/policy-engine.md") != std::string::npos);
+    CHECK_THAT(result.error(), ContainsSubstring("docs/user-manual/policy-engine.md"));
 }
 
 TEST_CASE("PolicyStore: fragment with check only (no fix, no postCheck)",
@@ -361,7 +363,7 @@ scope:
 )";
     auto result = store.create_policy(yaml);
     REQUIRE_FALSE(result.has_value());
-    CHECK(result.error().find("fromResultSet") != std::string::npos);
+    CHECK_THAT(result.error(), ContainsSubstring("fromResultSet"));
 }
 
 TEST_CASE("PolicyStore: scalar scope.fromResultSet is also rejected (#1221 MEDIUM-1)",
@@ -385,7 +387,7 @@ scope: from_result_set:rs_abc
 )";
     auto result = store.create_policy(yaml);
     REQUIRE_FALSE(result.has_value());
-    CHECK(result.error().find("fromResultSet") != std::string::npos);
+    CHECK_THAT(result.error(), ContainsSubstring("fromResultSet"));
 
     // The same ref composed into a larger scalar expression is likewise rejected.
     std::string yaml2 = R"(
@@ -398,7 +400,7 @@ scope: ostype == "windows" AND from_result_set:rs_abc
 )";
     auto result2 = store.create_policy(yaml2);
     REQUIRE_FALSE(result2.has_value());
-    CHECK(result2.error().find("fromResultSet") != std::string::npos);
+    CHECK_THAT(result2.error(), ContainsSubstring("fromResultSet"));
 }
 
 TEST_CASE("PolicyStore: inline flow-mapping scope is rejected (UP-6)",
@@ -417,7 +419,7 @@ scope: {selector: {platform: windows}}
 )";
     auto result = store.create_policy(yaml);
     REQUIRE_FALSE(result.has_value());
-    CHECK(result.error().find("inline flow-mapping") != std::string::npos);
+    CHECK_THAT(result.error(), ContainsSubstring("inline flow-mapping"));
 }
 
 TEST_CASE("PolicyStore: query policies with filters", "[policy_store][policy]") {
@@ -547,11 +549,11 @@ TEST_CASE("PolicyStore: create policy with wrong kind", "[policy_store][policy]"
 
     auto r = store.create_policy("kind: PolicyFragment\nname: wrong\n");
     REQUIRE(!r.has_value());
-    CHECK(r.error().find("kind must be 'Policy'") != std::string::npos);
+    CHECK_THAT(r.error(), ContainsSubstring("kind must be 'Policy'"));
     // Issue #621: same UX expectation as create_fragment — operators must
     // see a worked example in the error body, not just the prefix.
-    CHECK(r.error().find("apiVersion: yuzu.io/v1alpha1") != std::string::npos);
-    CHECK(r.error().find("docs/user-manual/policy-engine.md") != std::string::npos);
+    CHECK_THAT(r.error(), ContainsSubstring("apiVersion: yuzu.io/v1alpha1"));
+    CHECK_THAT(r.error(), ContainsSubstring("docs/user-manual/policy-engine.md"));
 }
 
 TEST_CASE("PolicyStore: create policy with missing kind", "[policy_store][policy]") {
@@ -563,9 +565,9 @@ TEST_CASE("PolicyStore: create policy with missing kind", "[policy_store][policy
     // worked-example body from create_policy alone slip through CI.
     auto r = store.create_policy("name: no-kind\ndescription: missing kind field\n");
     REQUIRE(!r.has_value());
-    CHECK(r.error().find("kind must be 'Policy'") != std::string::npos);
-    CHECK(r.error().find("apiVersion: yuzu.io/v1alpha1") != std::string::npos);
-    CHECK(r.error().find("docs/user-manual/policy-engine.md") != std::string::npos);
+    CHECK_THAT(r.error(), ContainsSubstring("kind must be 'Policy'"));
+    CHECK_THAT(r.error(), ContainsSubstring("apiVersion: yuzu.io/v1alpha1"));
+    CHECK_THAT(r.error(), ContainsSubstring("docs/user-manual/policy-engine.md"));
 }
 
 TEST_CASE("PolicyStore: create policy with missing fragment", "[policy_store][policy]") {
@@ -574,7 +576,7 @@ TEST_CASE("PolicyStore: create policy with missing fragment", "[policy_store][po
     auto yaml = make_policy_yaml("nonexistent-fragment-id");
     auto r = store.create_policy(yaml);
     REQUIRE(!r.has_value());
-    CHECK(r.error().find("not found") != std::string::npos);
+    CHECK_THAT(r.error(), ContainsSubstring("not found"));
 }
 
 TEST_CASE("PolicyStore: create policy without fragment field", "[policy_store][policy]") {
@@ -588,7 +590,7 @@ description: missing fragment field
 )";
     auto r = store.create_policy(yaml);
     REQUIRE(!r.has_value());
-    CHECK(r.error().find("fragment") != std::string::npos);
+    CHECK_THAT(r.error(), ContainsSubstring("fragment"));
 }
 
 // ============================================================================
@@ -638,7 +640,7 @@ TEST_CASE("PolicyStore: update agent status with invalid status", "[policy_store
 
     auto r = store.update_agent_status("pol-1", "agent-1", "garbage");
     REQUIRE(!r.has_value());
-    CHECK(r.error().find("invalid status") != std::string::npos);
+    CHECK_THAT(r.error(), ContainsSubstring("invalid status"));
 }
 
 TEST_CASE("PolicyStore: update agent status with empty IDs", "[policy_store][compliance]") {
@@ -805,7 +807,7 @@ TEST_CASE("PolicyStore: invalidate empty policy ID", "[policy_store][invalidatio
 
     auto r = store.invalidate_policy("");
     REQUIRE(!r.has_value());
-    CHECK(r.error().find("required") != std::string::npos);
+    CHECK_THAT(r.error(), ContainsSubstring("required"));
 }
 
 TEST_CASE("PolicyStore: invalidate all policies", "[policy_store][invalidation]") {


### PR DESCRIPTION
## Headline

Twenty substring assertions in the policy-store test suite were checking `.find(...) != std::string::npos`, which prints nothing but "CHECK failed" when it trips. This PR migrates them to Catch2's `ContainsSubstring` matcher, so a failure prints both the actual and expected strings.

## Description

- **Summary** — Converts all 20 `CHECK(<expr>.find("<needle>") != std::string::npos)` assertions in `tests/unit/server/test_policy_store.cpp` to `CHECK_THAT(<expr>, ContainsSubstring("<needle>"))`. Adds the matching `#include` and `using` declaration, following the same pattern already used in `test_static_js_bundle.cpp`.
- **Rationale & drivers** — Closes #755. Every subject expression and needle string literal is preserved byte-for-byte, including the four `kind must be '...'` needles a sibling PR (#753's `kind_mismatch_error` helper) depends on staying unchanged.
- **Technical overview** — Pure Catch2 macro substitution. No production code touched, no TEST_CASE/SECTION renamed or reordered.

## Testing & verification

- `grep -c 'npos'` → 0; `grep -c 'CHECK_THAT'` → 20; both `#include`/`using` lines present exactly once.
- Full local build + `meson test --suite server`: clean compile, 33387/33393 assertions passed (6 pre-existing, unrelated macOS/APFS `wal_sidecar_present` failures in shard B).
- `/governance` gate: 11 agents (Gate 2/3/4/6), unanimous PASS, zero findings.

## Related items

Closes #755.
