### PR TITLE
refactor(stores): unify kind-mismatch error wording behind a shared helper (#753)

### DIFF
--- a/changelog.d/753-kind-mismatch-error-helper.changed.md
+++ b/changelog.d/753-kind-mismatch-error-helper.changed.md
@@ -1,0 +1,1 @@
+- Rejecting a YAML document whose `kind:` does not match the store it was submitted to now returns the same sentence whichever store rejected it, and a document with no `kind:` at all now says so in the same terms instead of a terser one-off message. Policy fragments, policies, workflows, and product-pack documents previously each phrased the same failure differently.

--- a/server/core/src/policy_store.cpp
+++ b/server/core/src/policy_store.cpp
@@ -220,11 +220,8 @@ PolicyStore::create_fragment(const std::string& yaml_source) {
     // worked example.
     auto kind = extract_yaml_value(yaml_source, "kind");
     if (kind != "PolicyFragment")
-        return std::unexpected(
-            "kind must be 'PolicyFragment', got '" + kind +
-            "'. yaml_source must be a complete YAML document including "
-            "'apiVersion: yuzu.io/v1alpha1' and 'kind: PolicyFragment'. "
-            "Example:\n"
+        return std::unexpected(kind_mismatch_error(
+            "PolicyFragment", kind,
             "  apiVersion: yuzu.io/v1alpha1\n"
             "  kind: PolicyFragment\n"
             "  metadata:\n"
@@ -233,8 +230,8 @@ PolicyStore::create_fragment(const std::string& yaml_source) {
             "    check:\n"
             "      plugin: <plugin>\n"
             "      action: <action>\n"
-            "      compliance: <CEL expression>\n"
-            "See docs/user-manual/policy-engine.md.");
+            "      compliance: <CEL expression>\n",
+            "docs/user-manual/policy-engine.md"));
 
     // Extract metadata
     auto id_val = extract_yaml_value(yaml_source, "id");
@@ -619,11 +616,8 @@ PolicyStore::create_policy(const std::string& yaml_source) {
     // verbose example — same UX issue (#621), different kind.
     auto kind = extract_yaml_value(yaml_source, "kind");
     if (kind != "Policy")
-        return std::unexpected(
-            "kind must be 'Policy', got '" + kind +
-            "'. yaml_source must be a complete YAML document including "
-            "'apiVersion: yuzu.io/v1alpha1' and 'kind: Policy'. "
-            "Example:\n"
+        return std::unexpected(kind_mismatch_error(
+            "Policy", kind,
             "  apiVersion: yuzu.io/v1alpha1\n"
             "  kind: Policy\n"
             "  metadata:\n"
@@ -633,8 +627,8 @@ PolicyStore::create_policy(const std::string& yaml_source) {
             "    scope: <scope-expression>\n"
             "    triggers:\n"
             "      - type: interval\n"
-            "        interval: 3600\n"
-            "See docs/user-manual/policy-engine.md.");
+            "        interval: 3600\n",
+            "docs/user-manual/policy-engine.md"));
 
     // Extract metadata
     auto id_val = extract_yaml_value(yaml_source, "id");

--- a/server/core/src/product_pack_store.cpp
+++ b/server/core/src/product_pack_store.cpp
@@ -1,5 +1,6 @@
 #include "product_pack_store.hpp"
 #include "migration_runner.hpp"
+#include "store_errors.hpp"
 
 #include <nlohmann/json.hpp>
 #include <spdlog/spdlog.h>
@@ -481,7 +482,7 @@ std::expected<std::string, std::string> ProductPackStore::install(const std::str
                 documents[i].find("plugin:") != std::string::npos) {
                 kind = "InstructionDefinition";
             } else {
-                errors.push_back("document " + std::to_string(i) + " has no kind");
+                errors.push_back("document " + std::to_string(i) + ": " + kind_missing_error());
                 continue;
             }
         }

--- a/server/core/src/store_errors.hpp
+++ b/server/core/src/store_errors.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <string_view>
 
 namespace yuzu::server {
@@ -33,6 +34,53 @@ inline std::string_view strip_conflict_prefix(std::string_view msg) {
 
 inline bool is_conflict_error(std::string_view msg) {
     return msg.rfind(kConflictPrefix, 0) == 0;
+}
+
+// Shared kind-validation wording (#753) so operators see one message
+// regardless of which store rejected their YAML. These are 400s, not
+// 409s — do NOT route them through kConflictPrefix.
+//
+// kind_mismatch_error() covers "kind" present but wrong; kind_missing_error()
+// covers "kind" absent entirely — a missing kind is not a mismatch, so it
+// gets its own honest verb rather than being force-fitted into the
+// mismatch string.
+//
+// Byte-exact outputs (verify any change against these before committing):
+//   kind_mismatch_error("X", "Y") ==
+//     "kind must be 'X', got 'Y'. yaml_source must be a complete YAML "
+//     "document including 'apiVersion: yuzu.io/v1alpha1' and 'kind: X'."
+//   kind_mismatch_error("X", "Y", example) appends " Example:\n" + example
+//   kind_mismatch_error("X", "Y", example, docs_ref) further appends
+//     "See " + docs_ref + "."
+//   kind_missing_error() ==
+//     "kind is required. yaml_source must be a complete YAML document "
+//     "including 'apiVersion: yuzu.io/v1alpha1' and a 'kind:' field."
+inline std::string kind_mismatch_error(std::string_view expected, std::string_view actual,
+                                        std::string_view example = {},
+                                        std::string_view docs_ref = {}) {
+    std::string msg = "kind must be '";
+    msg += expected;
+    msg += "', got '";
+    msg += actual;
+    msg += "'. yaml_source must be a complete YAML document including "
+           "'apiVersion: yuzu.io/v1alpha1' and 'kind: ";
+    msg += expected;
+    msg += "'.";
+    if (!example.empty()) {
+        msg += " Example:\n";
+        msg += example;
+    }
+    if (!docs_ref.empty()) {
+        msg += "See ";
+        msg += docs_ref;
+        msg += ".";
+    }
+    return msg;
+}
+
+inline std::string kind_missing_error() {
+    return "kind is required. yaml_source must be a complete YAML document "
+           "including 'apiVersion: yuzu.io/v1alpha1' and a 'kind:' field.";
 }
 
 } // namespace yuzu::server

--- a/server/core/src/workflow_engine.cpp
+++ b/server/core/src/workflow_engine.cpp
@@ -1,5 +1,6 @@
 #include "workflow_engine.hpp"
 #include "migration_runner.hpp"
+#include "store_errors.hpp"
 
 #include <nlohmann/json.hpp>
 #include <spdlog/spdlog.h>
@@ -296,7 +297,7 @@ std::expected<std::string, std::string> WorkflowEngine::create_workflow(
     // Validate kind
     auto kind = extract_yaml_value(yaml_source, "kind");
     if (!kind.empty() && kind != "Workflow") {
-        return std::unexpected("expected kind: Workflow, got: " + kind);
+        return std::unexpected(kind_mismatch_error("Workflow", kind));
     }
 
     auto name = extract_yaml_value(yaml_source, "displayName");

--- a/tests/unit/server/test_store_errors.cpp
+++ b/tests/unit/server/test_store_errors.cpp
@@ -81,3 +81,54 @@ TEST_CASE("strip_conflict_prefix handles boundary inputs without underflow",
     // is_conflict_error matches the prefix even if the body contains NULs.
     CHECK(is_conflict_error(nul_after_prefix));
 }
+
+// #753: kind_mismatch_error()/kind_missing_error() unify the kind-validation
+// wording across PolicyStore, WorkflowEngine and ProductPackStore. These
+// pin the exact byte output so a refactor of either helper can't silently
+// drift what operators see.
+TEST_CASE("kind_mismatch_error produces the exact two-argument message",
+          "[store_errors]") {
+    CHECK(kind_mismatch_error("Workflow", "Policy") ==
+          "kind must be 'Workflow', got 'Policy'. yaml_source must be a "
+          "complete YAML document including 'apiVersion: yuzu.io/v1alpha1' "
+          "and 'kind: Workflow'.");
+}
+
+TEST_CASE("kind_missing_error produces the exact message", "[store_errors]") {
+    CHECK(kind_missing_error() ==
+          "kind is required. yaml_source must be a complete YAML document "
+          "including 'apiVersion: yuzu.io/v1alpha1' and a 'kind:' field.");
+}
+
+TEST_CASE("kind_mismatch_error wording agrees across stores modulo the "
+          "substituted kind",
+          "[store_errors]") {
+    // Cross-store wording agreement asserted mechanically: swap the
+    // expected kind for the substring that would differ, and the three
+    // results must then be byte-identical.
+    auto fragment_msg = kind_mismatch_error("PolicyFragment", "X");
+    auto policy_msg = kind_mismatch_error("Policy", "X");
+    auto workflow_msg = kind_mismatch_error("Workflow", "X");
+
+    auto normalize = [](std::string s, std::string_view kind) {
+        std::string placeholder = "<KIND>";
+        std::string::size_type pos = 0;
+        while ((pos = s.find(kind, pos)) != std::string::npos) {
+            s.replace(pos, kind.size(), placeholder);
+            pos += placeholder.size();
+        }
+        return s;
+    };
+
+    auto fragment_norm = normalize(fragment_msg, "PolicyFragment");
+    auto policy_norm = normalize(policy_msg, "Policy");
+    auto workflow_norm = normalize(workflow_msg, "Workflow");
+
+    CHECK(fragment_norm == policy_norm);
+    CHECK(policy_norm == workflow_norm);
+
+    // Sanity: the un-normalized messages actually differ (otherwise the
+    // check above would be vacuous).
+    CHECK(fragment_msg != policy_msg);
+    CHECK(policy_msg != workflow_msg);
+}


### PR DESCRIPTION
## Headline

Rejecting a YAML document with the wrong `kind:` returned differently-worded error strings depending on which store rejected it — PolicyStore, workflow engine, and product-pack store each phrased the same failure differently. This PR unifies them behind a shared helper, so operators see one consistent sentence regardless of which store caught the problem.

## Description

- **Summary** — Adds `kind_mismatch_error()` and `kind_missing_error()` to `server/core/src/store_errors.hpp` and converts all four kind-validation sites (two in `policy_store.cpp`, one each in `workflow_engine.cpp` and `product_pack_store.cpp`) onto them.
- **Rationale & drivers** — Closes #753. PolicyStore's existing output is reproduced byte-for-byte, including its two distinct worked examples — it's the sentence that unifies, not the example.
- **Technical overview** — `product_pack_store.cpp`'s "no kind" case uses `kind_missing_error()` rather than being force-fit into a mismatch string, since a missing kind is a different fact from a mismatched one. Does not touch `test_policy_store.cpp` (a sibling PR's file) — the contract is fixed to reproduce that file's existing needles exactly, so no change there was needed.

## Testing & verification

- New `[store_errors]`-tagged test case asserts the exact full output of both helpers as string-literal equalities, plus a mechanical check that the three kind-mismatch strings differ only in the substituted kind.
- Full local build + `meson test --suite server`: clean compile, 33393/33399 assertions passed (6 pre-existing, unrelated macOS/APFS `wal_sidecar_present` failures in shard B), including `test_policy_store` and the new `test_store_errors` cases.
- `/governance` gate: 0 CRITICAL/HIGH findings.

## Related items

Closes #753.
