### PR TITLE
Fix #3615: wrap std::stoll/stoul in try/catch on unprotected REST route handlers

### DIFF
--- a/server/core/src/notification_routes.cpp
+++ b/server/core/src/notification_routes.cpp
@@ -62,11 +62,20 @@ void NotificationRoutes::register_routes(httplib::Server& svr, AuthFn auth_fn, P
                          R"({"error":{"code":503,"message":"service unavailable"},"meta":{"api_version":"v1"}})",
                          "application/json");
                      return;
-                 }
-                 auto id = std::stoll(req.matches[1].str());
-                 notification_store->mark_read(id);
-                 res.set_content(R"({"status":"ok"})", "application/json");
-             });
+                  }
+                  int64_t id;
+                  try {
+                      id = std::stoll(req.matches[1].str());
+                  } catch (const std::out_of_range&) {
+                      res.status = 404;
+                      res.set_content(
+                          R"({"error":{"code":404,"message":"notification not found"},"meta":{"api_version":"v1"}})",
+                          "application/json");
+                      return;
+                  }
+                  notification_store->mark_read(id);
+                  res.set_content(R"({"status":"ok"})", "application/json");
+              });
 
     // POST /api/notifications/:id/dismiss — dismiss notification
     svr.Post(R"(/api/notifications/(\d+)/dismiss)",
@@ -81,7 +90,16 @@ void NotificationRoutes::register_routes(httplib::Server& svr, AuthFn auth_fn, P
                          "application/json");
                      return;
                  }
-                 auto id = std::stoll(req.matches[1].str());
+                 int64_t id;
+                 try {
+                     id = std::stoll(req.matches[1].str());
+                 } catch (const std::out_of_range&) {
+                     res.status = 404;
+                     res.set_content(
+                         R"({"error":{"code":404,"message":"notification not found"},"meta":{"api_version":"v1"}})",
+                         "application/json");
+                     return;
+                 }
                  notification_store->dismiss(id);
                  audit_fn(req, "notification.dismiss", "success", "notification",
                           std::to_string(id), "");

--- a/server/core/src/settings_routes.cpp
+++ b/server/core/src/settings_routes.cpp
@@ -4179,7 +4179,16 @@ void SettingsRoutes::register_routes(
               [this](const httplib::Request& req, httplib::Response& res) {
                   if (!admin_fn_(req, res))
                       return;
-                  auto idx = static_cast<size_t>(std::stoul(req.matches[1].str()));
+                  size_t idx;
+                  try {
+                      idx = static_cast<size_t>(std::stoul(req.matches[1].str()));
+                  } catch (const std::out_of_range&) {
+                      res.status = 404;
+                      res.set_content(
+                          R"({"error":{"code":404,"message":"auto-approve rule not found"},"meta":{"api_version":"v1"}})",
+                          "application/json");
+                      return;
+                  }
                   auto rules = auto_approve_->list_rules();
                   if (idx < rules.size()) {
                       auto_approve_->set_enabled(idx, !rules[idx].enabled);
@@ -4191,7 +4200,16 @@ void SettingsRoutes::register_routes(
                 [this](const httplib::Request& req, httplib::Response& res) {
                     if (!admin_fn_(req, res))
                         return;
-                    auto idx = static_cast<size_t>(std::stoul(req.matches[1].str()));
+                    size_t idx;
+                    try {
+                        idx = static_cast<size_t>(std::stoul(req.matches[1].str()));
+                    } catch (const std::out_of_range&) {
+                        res.status = 404;
+                        res.set_content(
+                            R"({"error":{"code":404,"message":"auto-approve rule not found"},"meta":{"api_version":"v1"}})",
+                            "application/json");
+                        return;
+                    }
                     auto_approve_->remove_rule(idx);
                     spdlog::info("Auto-approve rule {} removed", idx);
                     res.set_content(render_auto_approve_fragment(), "text/html; charset=utf-8");

--- a/server/core/src/webhook_routes.cpp
+++ b/server/core/src/webhook_routes.cpp
@@ -92,7 +92,16 @@ void WebhookRoutes::register_routes(httplib::Server& svr, AuthFn auth_fn, PermFn
                            "application/json");
                        return;
                    }
-                   auto id = std::stoll(req.matches[1].str());
+                   int64_t id;
+                   try {
+                       id = std::stoll(req.matches[1].str());
+                   } catch (const std::out_of_range&) {
+                       res.status = 404;
+                       res.set_content(
+                           R"({"error":{"code":404,"message":"webhook not found"},"meta":{"api_version":"v1"}})",
+                           "application/json");
+                       return;
+                   }
                    if (webhook_store->delete_webhook(id)) {
                        audit_fn(req, "webhook.delete", "success", "webhook",
                                 std::to_string(id), "");
@@ -117,7 +126,16 @@ void WebhookRoutes::register_routes(httplib::Server& svr, AuthFn auth_fn, PermFn
                         "application/json");
                     return;
                 }
-                auto webhook_id = std::stoll(req.matches[1].str());
+                int64_t webhook_id;
+                try {
+                    webhook_id = std::stoll(req.matches[1].str());
+                } catch (const std::out_of_range&) {
+                    res.status = 404;
+                    res.set_content(
+                        R"({"error":{"code":404,"message":"webhook not found"},"meta":{"api_version":"v1"}})",
+                        "application/json");
+                    return;
+                }
                 int limit = 50;
                 auto limit_str = req.get_param_value("limit");
                 if (!limit_str.empty()) {


### PR DESCRIPTION
## Fixes #3615

### Problem

Six REST route handlers parse numeric path params via \std::stoll\/\std::stoul\ with no try/catch. Oversized ids (>19 digits for int64) throw \std::out_of_range\, which httplib catches and turns into HTTP 500 with an empty body — breaking the A4 JSON error envelope invariant.

### Fix

Added \	ry/catch (const std::out_of_range&)\ on all 6 unprotected call sites, returning 404 with the standard A4 error JSON on overflow. This matches the existing correct pattern in \offload_routes.cpp::parse_id_segment()\.

**Files changed:**
| File | Routes |
|------|--------|
| \webhook_routes.cpp\ | \DELETE /api/webhooks/:id\, \GET /api/webhooks/:id/deliveries\ |
| \
otification_routes.cpp\ | \POST /api/notifications/:id/read\, \POST /api/notifications/:id/dismiss\ |
| \settings_routes.cpp\ | \POST /api/settings/auto-approve/:id/toggle\, \DELETE /api/settings/auto-approve/:id\ |

**Verified:** All 3 modified files compile without new warnings under the project's C++23 settings.