### PR TITLE
fix: reformat fragile append-lists to one-item-per-line for merge safety

### DIFF
--- a/docs/agent-spawn-sink-manifest.md
+++ b/docs/agent-spawn-sink-manifest.md
@@ -198,11 +198,19 @@ Plugin-granularity seed from the ADR-3002 review inventory (dev @ 2026-07-23,
 private helpers). Site-level transcription is #2380's first work item —
 these rows are pointers, not evidence.
 
-**Raw `popen`/`system` helpers:**
-device_identity, ioc, network_diag, os_info, processes,
-vuln_scan, windows_updates.
-(`vuln_scan` carries code slated for retirement per ADR-0028/ADR-0018 —
-sequence that cleanup against migrating it, tracked in #2380.)
+**Raw `popen`/`system` helpers** (one plugin per line, alphabetized — this
+list has been repeatedly corrupted into duplicate/stale entries by the
+automated dev-merge-into-open-PR-branches bot's line-based 3-way merge when
+two PRs independently touched the same wrapped line; keep it one-per-line so
+two independent edits land as two independent inserted lines instead):
+- device_identity
+- ioc
+- network_diag
+- os_info
+- processes
+- vuln_scan (carries code slated for retirement per ADR-0028/ADR-0018 —
+  sequence that cleanup against migrating it, tracked in #2380)
+- windows_updates
 
 **Migrated off raw spawn (Wave 4, PR4.2):** `event_logs` (Windows
 PowerShell `Get-WinEvent` via raw `_popen` promoted to rung-1 wevtapi

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -523,14 +523,41 @@ agent_test_exe = executable(
   # link_depends, a fresh build could leave the test executable built before
   # the fixture exists (build-ci B3's lesson: a fixture with no consumer in
   # the meson graph can silently stop building unnoticed).
-  link_depends: [reserved_name_fixture_plugin, invalid_name_fixture_plugin, abi3_fixture_plugin,
-                users_plugin_lib, os_info_plugin_lib, processes_plugin_lib,
-                network_diag_plugin_lib, ioc_plugin_lib,
-                hardware_plugin_lib, device_identity_plugin_lib, netstat_plugin_lib,
-                windows_updates_plugin_lib, sccm_plugin_lib, event_logs_plugin_lib,
-                installed_apps_plugin_lib, msi_packages_plugin_lib, network_config_plugin_lib,
-                wifi_plugin_lib, content_dist_plugin_lib, script_exec_plugin_lib,
-                software_actions_plugin_lib, license_scan_plugin_lib, echo_argv_fixture],
+  # One identifier per line, alphabetized: this array has been repeatedly
+  # corrupted (a stray extra closing bracket followed by more list items,
+  # breaking meson configure on every platform) by the automated dev-merge-
+  # into-open-PR-branches bot's line-based 3-way merge -- two different PRs
+  # each appending one plugin identifier to the same shared wrapped line look
+  # like non-conflicting inserts to a line-based merge, but the combined
+  # result is invalid. One-per-line makes two independent appends land as
+  # two independent inserted lines, which merges cleanly. Do not repack this
+  # onto fewer lines -- see the identical, already-safe shape in
+  # scripts/ci/check-plugin-spawn-lexical.sh's GRANDFATHERED set.
+  link_depends: [
+                abi3_fixture_plugin,
+                content_dist_plugin_lib,
+                device_identity_plugin_lib,
+                echo_argv_fixture,
+                event_logs_plugin_lib,
+                hardware_plugin_lib,
+                installed_apps_plugin_lib,
+                invalid_name_fixture_plugin,
+                ioc_plugin_lib,
+                license_scan_plugin_lib,
+                msi_packages_plugin_lib,
+                netstat_plugin_lib,
+                network_config_plugin_lib,
+                network_diag_plugin_lib,
+                os_info_plugin_lib,
+                processes_plugin_lib,
+                reserved_name_fixture_plugin,
+                sccm_plugin_lib,
+                script_exec_plugin_lib,
+                software_actions_plugin_lib,
+                users_plugin_lib,
+                wifi_plugin_lib,
+                windows_updates_plugin_lib,
+                ],
 )
 # Two agent tests are [tsan-heavy]: concurrency STRESS checkpoints that spin four to five
 # threads on real SQLite I/O with no throttle. Their wall time is contention-dominated - it


### PR DESCRIPTION
## Contents

- [Headline](#headline)
- [Description](#description)
- [Impact](#impact)
- [Testing & verification](#testing--verification)
- [Related items](#related-items)

## Headline

CI has been repeatedly failing across several open PRs (Linux, Windows, and macOS all at once) with a build configuration error, not a code bug. The cause was a fragile file format: a couple of plugin lists in the build config and docs were written as long, wrapped lines with several plugin names packed together. Whenever two different PRs each added their own plugin name to the same line around the same time, the automatic merge tooling combined them incorrectly, producing invalid content that broke every platform's build simultaneously.

This PR reformats those two lists to one plugin per line — the same safe format already used elsewhere in the repo. That makes it structurally impossible for two independent additions to collide, so this class of CI failure won't recur.

## Description

- **Summary** — Reformatted `tests/meson.build`'s `link_depends` array and `docs/agent-spawn-sink-manifest.md`'s "Raw popen/system helpers" list to one item per line, alphabetized. No content change — same plugin sets, purely a merge-safety reformat.
- **Rationale & drivers** — This exact corruption pattern broke CI on PRs #3578, #3580 (twice), #3680, #3750, and #3580 again over the course of one day, and at one point landed on `dev` itself (confirmed via `git show origin/dev:...`), meaning every other open PR's next auto-merge from dev was primed to re-trigger it. Root-caused during live remediation of #3580's CI failure.
- **Technical overview** — The automated dev-merge-into-open-PR-branches bot does a plain line-based git 3-way merge. When two PRs each append one plugin identifier to a shared wrapped line, git sees two non-conflicting single-line edits and merges them "cleanly" — but the result is invalid: a stray extra closing bracket followed by more list items in the `.build` file (hard Meson configure-time syntax error), or duplicated/stale plugin names in the doc. One-item-per-line means two independent appends land as two independent inserted lines, which a line-based merge handles correctly by construction — matching the shape `GRANDFATHERED` already uses safely in `scripts/ci/check-plugin-spawn-lexical.sh` (edited by just as many PRs, never hit by this bug). An Explore sweep of the rest of the repo found no other list with this same risk profile.

## Impact

- **Reliability:** Eliminates a recurring, multi-PR-blocking CI failure class by construction rather than by repeated manual patching.

## Testing & verification

- `meson setup --reconfigure` succeeds (the array is still syntactically valid after reordering).
- `meson compile` builds clean.
- `./build-macos/tests/yuzu_agent_tests` smoke run across several of the listed plugins (wifi, software_actions, license_scan, content_dist, script_exec) — 931 assertions / 216 test cases, all green — confirms reordering `link_depends` has no functional effect.

## Related items

Closes #3791.
