### PR TITLE
fix(deps): close remaining npm Dependabot advisories + puppeteer sandbox bug

### DIFF
--- a/changelog.d/20260902-npm-lockfile-advisories-2.security.md
+++ b/changelog.d/20260902-npm-lockfile-advisories-2.security.md
@@ -1,0 +1,4 @@
+- **Closed the last 2 open npm advisories in the docs-site lockfile.** `npm audit
+  fix` resolved nanoid's infinite-loop-on-zero-size bug (GHSA-2v37-7h3g-55p8) and
+  js-yaml's quadratic-CPU `!!omap` resolution (CVE-2026-59870 / GHSA-5p4m-2wfm-xmqj)
+  within already-declared ranges — no `overrides`, `package.json` unchanged.

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -28,7 +28,7 @@ tier — not the tracking mechanism — decides the remediation posture:
   server, agent, or gateway: vcpkg deps, Docker base images, rebar3 deps,
   and the vendored JS assets embedded into the server binary. Security
   advisories here follow the vulnerability-management commitments in
-  `docs/enterprise-readiness-soc2-first-customer.md` (Workstream F).
+  `docs/enterprise-readiness-soc2-first-customer.md` (Workstream C).
 - **Tier 2 — repo tooling.** Build/test/docs/demo tooling that never
   ships in a product artifact: the three npm directories and the pip CI
   tooling. Advisories are tracked, surfaced, and auto-patched through the

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -134,6 +134,17 @@ that harness. The docs site pins its toolchain floor in
 `site/package.json` `engines` (mirrors Astro's own floor — currently
 Node ≥ 22.12.0, npm ≥ 9.6.5; the docs-site job runs Node 22).
 
+**Standing convention — puppeteer launch args.** Every script in
+`tests/puppeteer/` passes `--no-sandbox` in its `puppeteer.launch` args (all
+seven do, as of the fix that closed this gap). On hosts where user-namespace/
+AppArmor restrictions block Chromium's own sandbox, its absence is an
+outright launch failure — not a puppeteer-version problem — which is exactly
+what blocked the manual pre-approval smoke this doc mandates above for
+puppeteer majors: four of the seven scripts silently diverged from the other
+three and none of them could launch a browser at all until the flag was
+added back. A new script in this directory must carry the flag from
+creation.
+
 **Standing convention — new npm directories.** A directory gaining a
 `package.json` ships, in the same PR: a committed `package-lock.json`,
 an entry in the `npm` block's `directories:` list in

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -79,9 +79,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -97,9 +94,6 @@
       "integrity": "sha512-f0heT9ZZEseSu5bHCeb80eL2DH07ArE6U9xi1WT/PEusNjzPmEr3GJsjG1tRLo5VYUUYX7h3ScaqGmGrMOVGmw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -117,9 +111,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -135,9 +126,6 @@
       "integrity": "sha512-/Kebk8sO6HnLeSd691JkaAPfN7CqR9/KEXmWvyNPkaKNGmj8rTZ/lf2uXtnPu92Lan84UrKdIKVPy1fSo2encQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -366,9 +354,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -381,9 +366,6 @@
       "integrity": "sha512-yWdgG1g17Nh2QyGVlFUxGRa3FEFwiMcpZEyMNWkbM3deC94cmVc+/i9OuyFpdKuWo3GkgoCtYVOoxk1uCnCZIA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -398,9 +380,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -413,9 +392,6 @@
       "integrity": "sha512-EHpVAx2bqW3GINHTKkljtxVfQmVDGWIuwOYOP5YghTj+0PkBa2o8oKPRtQ9Kbsr1Fye8jtUcDjhwj2jMNugZKg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3082,9 +3058,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",
@@ -3095,7 +3071,6 @@
           "url": "https://github.com/sponsors/nodeca"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -4230,9 +4205,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/tests/puppeteer/dashboard-help-test.mjs
+++ b/tests/puppeteer/dashboard-help-test.mjs
@@ -7,7 +7,7 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
 async function main() {
   const browser = await puppeteer.launch({
     headless: true,
-    args: ['--window-size=1400,900'],
+    args: ['--window-size=1400,900', '--no-sandbox'],
     defaultViewport: { width: 1400, height: 900 },
   });
   const page = await browser.newPage();

--- a/tests/puppeteer/dashboard-plugin-suite.mjs
+++ b/tests/puppeteer/dashboard-plugin-suite.mjs
@@ -236,7 +236,7 @@ async function main() {
 
   const browser = await puppeteer.launch({
     headless: false,
-    args: ['--window-size=1400,900'],
+    args: ['--window-size=1400,900', '--no-sandbox'],
     defaultViewport: { width: 1400, height: 900 },
   });
 

--- a/tests/puppeteer/dashboard-sse-bug.mjs
+++ b/tests/puppeteer/dashboard-sse-bug.mjs
@@ -28,7 +28,7 @@ async function main() {
 
   const browser = await puppeteer.launch({
     headless: false,
-    args: ['--window-size=1400,900'],
+    args: ['--window-size=1400,900', '--no-sandbox'],
     defaultViewport: { width: 1400, height: 900 },
   });
 

--- a/tests/puppeteer/dashboard-sse-debug.mjs
+++ b/tests/puppeteer/dashboard-sse-debug.mjs
@@ -20,7 +20,7 @@ async function main() {
 
   const browser = await puppeteer.launch({
     headless: false,
-    args: ['--window-size=1400,900'],
+    args: ['--window-size=1400,900', '--no-sandbox'],
     defaultViewport: { width: 1400, height: 900 },
   });
 


### PR DESCRIPTION
## Summary

- Closes the last 2 open npm security advisories on `dev`'s dependency tree: `nanoid` (infinite-loop DoS, GHSA-2v37-7h3g-55p8) and `js-yaml` (quadratic-CPU DoS, CVE-2026-59870/GHSA-5p4m-2wfm-xmqj) in `site/`, resolved via `npm audit fix` within already-declared ranges — no `overrides`, `package.json` unchanged. `dev`'s own weekly Dependabot cadence had already independently patched everything else (astro, postcss, svgo, sharp, and the entire `tests/puppeteer/`/`deploy/docker/cedar-vale/app/` trees) by the time this was investigated.
- Fixes an unrelated, pre-existing bug found during verification: 4 of 7 Puppeteer UAT scripts (`dashboard-help-test.mjs`, `dashboard-plugin-suite.mjs`, `dashboard-sse-bug.mjs`, `dashboard-sse-debug.mjs`) were missing the `--no-sandbox` Chromium launch flag that the other 3 sibling scripts already carried, causing an outright browser-launch failure on this class of host ("No usable sandbox!"). Reproduced red, fixed, reproduced green.
- Adds a changelog fragment and a new standing convention in `docs/dependency-updates.md` (every script in `tests/puppeteer/` must carry `--no-sandbox` from creation) so the same gap can't silently recur, plus a one-line fix to a pre-existing stale cross-reference (Workstream F → C) in the same doc.

Zero C++, zero product server/agent/gateway code — entirely Tier 2 "repo tooling" (docs site + local dev/UAT test scripts) per `docs/dependency-updates.md`'s own tiering, which explicitly carries no product SLA.

## Test plan

- [x] `npm audit --package-lock-only` in `site/`: 0 vulnerabilities
- [x] `npm run build` in `site/`: succeeds (40 pages + pagefind index)
- [x] Reproduced the puppeteer sandbox launch failure with the pre-fix config, confirmed launch + page interaction succeed with the fix, using the exact config `dashboard-help-test.mjs` uses
- [x] Full 8-agent `/governance` run (security-guardian, docs-writer, happy-path, unhappy-path, consistency-auditor, compliance-officer, sre, enterprise-readiness) — zero BLOCKING findings; every SHOULD/NICE raised was fixed and re-verified
- [x] Branch confirmed 0 commits behind `origin/dev` immediately before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)