### PR TITLE
docs(rest): fix header docstring to state response X-Correlation-Id

### DIFF
--- a/server/core/src/rest_a4_envelope_http.hpp
+++ b/server/core/src/rest_a4_envelope_http.hpp
@@ -5,7 +5,7 @@
 /// The httplib-coupled half of the unified A4 error/denial envelope. The pure
 /// JSON-string builders live in `rest_a4_envelope.hpp` (no httplib include, so
 /// they are testable in isolation via TestRouteSink). This header adds the thin
-/// `httplib::Response&`-taking wrapper that (1) mints or reuses the request's
+/// `httplib::Response&`-taking wrapper that (1) mints or reuses the response's
 /// `X-Correlation-Id` header so the header and the body's `correlation_id`
 /// always agree, then (2) returns the A4 body string. Kept out of the pure
 /// header so nothing that only needs the shape contract pulls in httplib.


### PR DESCRIPTION
Fixes wording in file header comment (lines 8-9) of rest_a4_envelope_http.hpp to accurately reflect that ensure_correlation_id operates on the response header rather than the request header.

## Summary

<!-- Brief description of what this PR does and why -->

## Type of Change

- [ ] Feature (new functionality)
- [ ] Bug fix
- [ ] Refactor (no functional change)
- [x] Documentation
- [ ] CI / Build

## Testing

<!-- What testing was done? -->

## Checklist

- [ ] Changelog fragment added: `changelog.d/<PR#>-<slug>.<section>.md` — do **not** edit `CHANGELOG.md` (see [`changelog.d/README.md`](../changelog.d/README.md); skip only if the change has no operator-visible effect)
- [ ] Builds on Linux (GCC and Clang)
- [ ] Builds on Windows (MSVC)
- [ ] Tests pass (`ctest --preset linux-debug`)
- [ ] No new clang-tidy warnings
- [ ] No new compiler warnings
- [x] I have signed the [Contributor License Agreement](../CLA.md) (either via the CLA workflow comment on this PR, or by appending my name to the Signatories section of `CLA.md`)
